### PR TITLE
Add native packed CPU inference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
             --git https://github.com/huggingface/kernels `
             --rev d43de01d0b43285d8e5061ca4380c2bd1c40ae3b `
             --locked `
+            --debug `
             --root "$env:RUNNER_TEMP\kernel-builder" `
             hf-kernel-builder
 
@@ -98,6 +99,12 @@ jobs:
         shell: pwsh
         working-directory: native-kernels/orbitquant-packed-matmul
         run: |
+          Get-CimInstance Win32_Processor | `
+            Select-Object Name, NumberOfCores, NumberOfLogicalProcessors | `
+            Format-List
+          cmake --version
+          $env:CMAKE_GENERATOR = "Visual Studio 17 2022"
+          $env:CMAKE_GENERATOR_PLATFORM = "x64"
           $env:CMAKE_ARGS = "-DGPU_LANG=CPU"
           $env:MAX_JOBS = "2"
           $python = "$env:GITHUB_WORKSPACE\.venv\Scripts\python.exe"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
 
   windows-native-cpu:
     name: Windows native CPU
-    runs-on: windows-2025
+    runs-on: windows-2022
     steps:
       - name: Check out repository
         uses: actions/checkout@v7.0.0
@@ -77,7 +77,7 @@ jobs:
         uses: actions/cache/restore@v6.1.0
         with:
           path: ${{ runner.temp }}\kernel-builder
-          key: kernel-builder-windows-d43de01d0b43285d8e5061ca4380c2bd1c40ae3b
+          key: kernel-builder-windows-vs2022-d43de01d0b43285d8e5061ca4380c2bd1c40ae3b
 
       - name: Install pinned kernel-builder
         if: steps.kernel-builder-cache.outputs.cache-hit != 'true'
@@ -96,7 +96,7 @@ jobs:
         uses: actions/cache/save@v6.1.0
         with:
           path: ${{ runner.temp }}\kernel-builder
-          key: kernel-builder-windows-d43de01d0b43285d8e5061ca4380c2bd1c40ae3b
+          key: kernel-builder-windows-vs2022-d43de01d0b43285d8e5061ca4380c2bd1c40ae3b
 
       - name: Generate native build project
         shell: pwsh
@@ -118,35 +118,10 @@ jobs:
             Select-Object Name, NumberOfCores, NumberOfLogicalProcessors | `
             Format-List
           cmake --version
-          $vswhere = `
-            "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          $vsRoot = & $vswhere `
-            -latest `
-            -products * `
-            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
-            -property installationPath
-          if (-not $vsRoot) {
-            throw "MSVC x86_64 tools were not found"
-          }
-          $vsDevCmd = Join-Path $vsRoot "Common7\Tools\VsDevCmd.bat"
-          $envDump = cmd.exe /d /s /c `
-            "call `"$vsDevCmd`" -arch=x64 -host_arch=x64 >nul && set"
-          if ($LASTEXITCODE -ne 0) {
-            throw "failed to initialize the MSVC x86_64 environment"
-          }
-          foreach ($line in $envDump) {
-            $parts = $line -split "=", 2
-            if ($parts.Length -eq 2) {
-              Set-Item -Path "Env:$($parts[0])" -Value $parts[1]
-            }
-          }
-          cl.exe 2>&1 | Select-Object -First 3
-          $nmake = (Get-Command nmake.exe).Source
-          $nmake
-          $env:CMAKE_GENERATOR = "NMake Makefiles"
-          $env:CMAKE_MAKE_PROGRAM = $nmake.Replace("\", "/")
+          $env:CMAKE_GENERATOR = "Visual Studio 17 2022"
+          $env:CMAKE_GENERATOR_PLATFORM = "x64"
           $env:CMAKE_ARGS = "-DGPU_LANG=CPU"
-          $env:MAX_JOBS = "1"
+          $env:MAX_JOBS = "2"
           $python = "$env:GITHUB_WORKSPACE\.venv\Scripts\python.exe"
           & $python setup.py bdist_wheel --py-limited-api=cp39
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,8 +120,7 @@ jobs:
           cmake --version
           $env:CMAKE_GENERATOR = "Visual Studio 17 2022"
           $env:CMAKE_GENERATOR_PLATFORM = "x64"
-          $env:CMAKE_GENERATOR_TOOLSET = "host=x86"
-          $env:CMAKE_ARGS = "-DGPU_LANG=CPU"
+          $env:CMAKE_ARGS = "-DGPU_LANG=CPU -T host=x86"
           $env:MAX_JOBS = "2"
           $python = "$env:GITHUB_WORKSPACE\.venv\Scripts\python.exe"
           & $python setup.py bdist_wheel --py-limited-api=cp39

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,8 +141,10 @@ jobs:
             }
           }
           cl.exe 2>&1 | Select-Object -First 3
-          Get-Command nmake.exe | Select-Object -ExpandProperty Source
+          $nmake = (Get-Command nmake.exe).Source
+          $nmake
           $env:CMAKE_GENERATOR = "NMake Makefiles"
+          $env:CMAKE_MAKE_PROGRAM = $nmake.Replace("\", "/")
           $env:CMAKE_ARGS = "-DGPU_LANG=CPU"
           $env:MAX_JOBS = "1"
           $python = "$env:GITHUB_WORKSPACE\.venv\Scripts\python.exe"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,9 +118,22 @@ jobs:
             Select-Object Name, NumberOfCores, NumberOfLogicalProcessors | `
             Format-List
           cmake --version
+          $vswhere = `
+            "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsRoot = & $vswhere `
+            -latest `
+            -products * `
+            -requires Microsoft.Component.MSBuild `
+            -property installationPath
+          $msbuild = Join-Path $vsRoot "MSBuild\Current\Bin\MSBuild.exe"
+          if (-not (Test-Path $msbuild)) {
+            throw "32-bit host MSBuild was not found"
+          }
+          & $msbuild -version
           $env:CMAKE_GENERATOR = "Visual Studio 17 2022"
           $env:CMAKE_GENERATOR_PLATFORM = "x64"
-          $env:CMAKE_ARGS = "-DGPU_LANG=CPU -T host=x86"
+          $env:CMAKE_MAKE_PROGRAM = $msbuild.Replace("\", "/")
+          $env:CMAKE_ARGS = "-DGPU_LANG=CPU"
           $env:MAX_JOBS = "2"
           $python = "$env:GITHUB_WORKSPACE\.venv\Scripts\python.exe"
           & $python setup.py bdist_wheel --py-limited-api=cp39

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,7 @@ jobs:
           cmake --version
           $env:CMAKE_GENERATOR = "Visual Studio 17 2022"
           $env:CMAKE_GENERATOR_PLATFORM = "x64"
+          $env:CMAKE_GENERATOR_TOOLSET = "host=x86"
           $env:CMAKE_ARGS = "-DGPU_LANG=CPU"
           $env:MAX_JOBS = "2"
           $python = "$env:GITHUB_WORKSPACE\.venv\Scripts\python.exe"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,3 +203,121 @@ jobs:
         with:
           name: orbitquant-packed-matmul-windows-cpu
           path: native-kernels/orbitquant-packed-matmul/dist/*.whl
+
+  manylinux-native-cpu:
+    name: manylinux x86_64 native CPU
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.0
+
+      - name: Install test dependencies
+        run: uv sync --extra dev
+
+      - name: Restore pinned kernel-builder
+        id: manylinux-kernel-builder-cache
+        uses: actions/cache/restore@v6.1.0
+        with:
+          path: ${{ runner.temp }}/kernel-builder
+          key: kernel-builder-linux-d43de01d0b43285d8e5061ca4380c2bd1c40ae3b
+
+      - name: Install pinned kernel-builder
+        if: steps.manylinux-kernel-builder-cache.outputs.cache-hit != 'true'
+        run: |
+          cargo install \
+            --git https://github.com/huggingface/kernels \
+            --rev d43de01d0b43285d8e5061ca4380c2bd1c40ae3b \
+            --locked \
+            --debug \
+            --root "$RUNNER_TEMP/kernel-builder" \
+            hf-kernel-builder
+
+      - name: Save pinned kernel-builder
+        if: steps.manylinux-kernel-builder-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6.1.0
+        with:
+          path: ${{ runner.temp }}/kernel-builder
+          key: kernel-builder-linux-d43de01d0b43285d8e5061ca4380c2bd1c40ae3b
+
+      - name: Generate native build project
+        shell: bash
+        run: |
+          kernel_root="native-kernels/orbitquant-packed-matmul"
+          builder="$RUNNER_TEMP/kernel-builder/bin/kernel-builder"
+          "$builder" check-config "$kernel_root"
+          "$builder" create-pyproject --unique-id manylinux_ci -f "$kernel_root"
+          uv run python \
+            "$kernel_root/scripts/prepare_wheel_project.py" \
+            "$kernel_root" \
+            --version 0.1.0
+
+      - name: Build manylinux 2.28 ABI3 wheel
+        env:
+          CIBW_ARCHS_LINUX: x86_64
+          CIBW_BUILD: cp312-manylinux_x86_64
+          CIBW_ENVIRONMENT_LINUX: >-
+            CMAKE_ARGS=-DGPU_LANG=CPU
+            MAX_JOBS=2
+            ORBITQUANT_BUILD_TEMP=/tmp/oq-native-build
+            PIP_INDEX_URL=https://download.pytorch.org/whl/cpu
+            PIP_EXTRA_INDEX_URL=https://pypi.org/simple
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: >-
+            auditwheel repair
+            --exclude libc10.so
+            --exclude libtorch_cpu.so
+            --exclude libtorch.so
+            -w {dest_dir} {wheel}
+          CIBW_TEST_COMMAND: >-
+            python -m pytest {package}/tests/test_packed_matmul.py
+            -m kernels_ci -ra
+          CIBW_TEST_REQUIRES: numpy pytest torch==2.12.1
+        run: |
+          uv run --with cibuildwheel==4.1.0 \
+            python -m cibuildwheel \
+            native-kernels/orbitquant-packed-matmul \
+            --output-dir wheelhouse
+
+      - name: Verify wheel tag, metadata, and size
+        shell: bash
+        run: |
+          wheel=$(find wheelhouse -maxdepth 1 -name '*.whl' -print -quit)
+          test -n "$wheel"
+          case "$(basename "$wheel")" in
+            *-cp39-abi3-manylinux_2_28_x86_64.whl) ;;
+            *) echo "unexpected native CPU wheel: $wheel" >&2; exit 1 ;;
+          esac
+          test "$(stat -c %s "$wheel")" -lt 1048576
+          uv run python -c "import pathlib, zipfile; p=next(pathlib.Path('wheelhouse').glob('*.whl')); z=zipfile.ZipFile(p); names=z.namelist(); m=z.read(next(n for n in names if n.endswith('.dist-info/METADATA'))).decode(); assert 'Requires-Dist: torch>=2.11' in m; assert any(n.endswith('/_ops.py') for n in names); assert not any('/libtorch' in n or '/libc10' in n for n in names); print(p.name); print(m)"
+
+      - name: Clean-install integration tests
+        shell: bash
+        run: |
+          smoke="$RUNNER_TEMP/orbitquant-manylinux-smoke"
+          uv venv "$smoke" --python 3.12
+          python="$smoke/bin/python"
+          uv pip install \
+            --python "$python" \
+            --index https://download.pytorch.org/whl/cpu \
+            --index-strategy unsafe-best-match \
+            torch==2.12.1 pytest
+          uv pip install --python "$python" wheelhouse/*.whl --no-deps
+          "$python" -m pytest \
+            tests/test_native_packed_matmul.py \
+            tests/test_adaln_rtn.py \
+            tests/test_paper_reference_oracle.py \
+            -ra
+
+      - name: Upload manylinux native CPU wheel
+        uses: actions/upload-artifact@v6.0.0
+        with:
+          name: orbitquant-packed-matmul-manylinux-cpu
+          path: wheelhouse/*.whl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,7 @@ jobs:
           $env:CMAKE_GENERATOR = "Ninja Multi-Config"
           $env:CMAKE_MAKE_PROGRAM = $ninja.Replace("\", "/")
           $env:CMAKE_ARGS = "-DGPU_LANG=CPU"
+          $env:ORBITQUANT_BUILD_TEMP = "$env:RUNNER_TEMP\oq-native-build"
           $env:MAX_JOBS = "2"
           $python = "$env:GITHUB_WORKSPACE\.venv\Scripts\python.exe"
           & $python setup.py bdist_wheel --py-limited-api=cp39

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,15 @@ jobs:
           uv sync --extra dev
           uv pip install --python .venv\Scripts\python.exe cmake ninja setuptools wheel
 
+      - name: Cache pinned kernel-builder
+        id: kernel-builder-cache
+        uses: actions/cache@v6.1.0
+        with:
+          path: ${{ runner.temp }}\kernel-builder
+          key: kernel-builder-windows-d43de01d0b43285d8e5061ca4380c2bd1c40ae3b
+
       - name: Install pinned kernel-builder
+        if: steps.kernel-builder-cache.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
           cargo install `
@@ -103,7 +111,7 @@ jobs:
             Select-Object Name, NumberOfCores, NumberOfLogicalProcessors | `
             Format-List
           cmake --version
-          $env:CMAKE_GENERATOR = "Visual Studio 17 2022"
+          $env:CMAKE_GENERATOR = "Visual Studio 18 2026"
           $env:CMAKE_GENERATOR_PLATFORM = "x64"
           $env:CMAKE_ARGS = "-DGPU_LANG=CPU"
           $env:MAX_JOBS = "2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,9 +72,9 @@ jobs:
           uv sync --extra dev
           uv pip install --python .venv\Scripts\python.exe cmake ninja setuptools wheel
 
-      - name: Cache pinned kernel-builder
+      - name: Restore pinned kernel-builder
         id: kernel-builder-cache
-        uses: actions/cache@v6.1.0
+        uses: actions/cache/restore@v6.1.0
         with:
           path: ${{ runner.temp }}\kernel-builder
           key: kernel-builder-windows-d43de01d0b43285d8e5061ca4380c2bd1c40ae3b
@@ -90,6 +90,13 @@ jobs:
             --debug `
             --root "$env:RUNNER_TEMP\kernel-builder" `
             hf-kernel-builder
+
+      - name: Save pinned kernel-builder
+        if: steps.kernel-builder-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6.1.0
+        with:
+          path: ${{ runner.temp }}\kernel-builder
+          key: kernel-builder-windows-d43de01d0b43285d8e5061ca4380c2bd1c40ae3b
 
       - name: Generate native build project
         shell: pwsh
@@ -134,6 +141,7 @@ jobs:
             }
           }
           cl.exe 2>&1 | Select-Object -First 3
+          ninja --version
           $env:CMAKE_GENERATOR = "Ninja"
           $env:CMAKE_ARGS = "-DGPU_LANG=CPU"
           $env:MAX_JOBS = "2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         shell: pwsh
         run: |
           uv sync --extra dev
-          uv pip install --python .venv\Scripts\python.exe cmake ninja setuptools wheel
+          uv pip install --python .venv\Scripts\python.exe cmake setuptools wheel
 
       - name: Restore pinned kernel-builder
         id: kernel-builder-cache
@@ -141,10 +141,10 @@ jobs:
             }
           }
           cl.exe 2>&1 | Select-Object -First 3
-          ninja --version
-          $env:CMAKE_GENERATOR = "Ninja"
+          Get-Command nmake.exe | Select-Object -ExpandProperty Source
+          $env:CMAKE_GENERATOR = "NMake Makefiles"
           $env:CMAKE_ARGS = "-DGPU_LANG=CPU"
-          $env:MAX_JOBS = "2"
+          $env:MAX_JOBS = "1"
           $python = "$env:GITHUB_WORKSPACE\.venv\Scripts\python.exe"
           & $python setup.py bdist_wheel --py-limited-api=cp39
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,105 @@ jobs:
           source "$tmpdir/.venv/bin/activate"
           "$tmpdir/.venv/bin/python" -c "import orbitquant; print(orbitquant.__version__)"
           orbitquant --version
+
+  windows-native-cpu:
+    name: Windows native CPU
+    runs-on: windows-2025
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.0
+
+      - name: Install Python dependencies
+        shell: pwsh
+        run: |
+          uv sync --extra dev
+          uv pip install --python .venv\Scripts\python.exe cmake ninja setuptools wheel
+
+      - name: Install pinned kernel-builder
+        shell: pwsh
+        run: |
+          cargo install `
+            --git https://github.com/huggingface/kernels `
+            --rev d43de01d0b43285d8e5061ca4380c2bd1c40ae3b `
+            --locked `
+            --root "$env:RUNNER_TEMP\kernel-builder" `
+            hf-kernel-builder
+
+      - name: Generate native build project
+        shell: pwsh
+        run: |
+          $kernelRoot = "native-kernels\orbitquant-packed-matmul"
+          $builder = "$env:RUNNER_TEMP\kernel-builder\bin\kernel-builder.exe"
+          & $builder check-config $kernelRoot
+          & $builder create-pyproject --unique-id windows_ci -f $kernelRoot
+          & .venv\Scripts\python.exe `
+            "$kernelRoot\scripts\prepare_wheel_project.py" `
+            $kernelRoot `
+            --version 0.1.0
+
+      - name: Build ABI3 CPU wheel with MSVC
+        shell: pwsh
+        working-directory: native-kernels/orbitquant-packed-matmul
+        run: |
+          $env:CMAKE_ARGS = "-DGPU_LANG=CPU"
+          $env:MAX_JOBS = "2"
+          $python = "$env:GITHUB_WORKSPACE\.venv\Scripts\python.exe"
+          & $python setup.py bdist_wheel --py-limited-api=cp39
+
+      - name: Verify wheel tag and metadata
+        shell: pwsh
+        working-directory: native-kernels/orbitquant-packed-matmul
+        run: |
+          $wheel = Get-ChildItem dist\*.whl | Select-Object -First 1
+          if ($null -eq $wheel) {
+            throw "native CPU wheel was not produced"
+          }
+          if ($wheel.Name -notmatch "-cp39-abi3-win_amd64\.whl$") {
+            throw "unexpected native CPU wheel tag: $($wheel.Name)"
+          }
+          $python = "$env:GITHUB_WORKSPACE\.venv\Scripts\python.exe"
+          & $python -c "import pathlib, zipfile; p=next(pathlib.Path('dist').glob('*.whl')); z=zipfile.ZipFile(p); m=z.read(next(n for n in z.namelist() if n.endswith('.dist-info/METADATA'))).decode(); assert 'Requires-Dist: torch>=2.11' in m; print(p.name); print(m)"
+
+      - name: Smoke install and native package tests
+        shell: pwsh
+        run: |
+          $smoke = "$env:RUNNER_TEMP\orbitquant-native-smoke"
+          uv venv $smoke --python 3.12
+          $python = "$smoke\Scripts\python.exe"
+          uv pip install --python $python torch==2.12.1 pytest
+          $wheel = Get-ChildItem `
+            native-kernels\orbitquant-packed-matmul\dist\*.whl | `
+            Select-Object -First 1
+          uv pip install --python $python $wheel.FullName --no-deps
+          & $python -m pytest `
+            native-kernels\orbitquant-packed-matmul\tests\test_packed_matmul.py `
+            -m kernels_ci `
+            -ra
+
+      - name: OrbitQuant native integration tests
+        shell: pwsh
+        run: |
+          $python = ".venv\Scripts\python.exe"
+          $wheel = Get-ChildItem `
+            native-kernels\orbitquant-packed-matmul\dist\*.whl | `
+            Select-Object -First 1
+          uv pip install --python $python $wheel.FullName --no-deps
+          & $python -m pytest `
+            tests\test_native_packed_matmul.py `
+            tests\test_adaln_rtn.py `
+            tests\test_paper_reference_oracle.py `
+            -ra
+
+      - name: Upload Windows native CPU wheel
+        uses: actions/upload-artifact@v6.0.0
+        with:
+          name: orbitquant-packed-matmul-windows-cpu
+          path: native-kernels/orbitquant-packed-matmul/dist/*.whl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,8 +111,30 @@ jobs:
             Select-Object Name, NumberOfCores, NumberOfLogicalProcessors | `
             Format-List
           cmake --version
-          $env:CMAKE_GENERATOR = "Visual Studio 18 2026"
-          $env:CMAKE_GENERATOR_PLATFORM = "x64"
+          $vswhere = `
+            "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsRoot = & $vswhere `
+            -latest `
+            -products * `
+            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+            -property installationPath
+          if (-not $vsRoot) {
+            throw "MSVC x86_64 tools were not found"
+          }
+          $vsDevCmd = Join-Path $vsRoot "Common7\Tools\VsDevCmd.bat"
+          $envDump = cmd.exe /d /s /c `
+            "call `"$vsDevCmd`" -arch=x64 -host_arch=x64 >nul && set"
+          if ($LASTEXITCODE -ne 0) {
+            throw "failed to initialize the MSVC x86_64 environment"
+          }
+          foreach ($line in $envDump) {
+            $parts = $line -split "=", 2
+            if ($parts.Length -eq 2) {
+              Set-Item -Path "Env:$($parts[0])" -Value $parts[1]
+            }
+          }
+          cl.exe 2>&1 | Select-Object -First 3
+          $env:CMAKE_GENERATOR = "Ninja"
           $env:CMAKE_ARGS = "-DGPU_LANG=CPU"
           $env:MAX_JOBS = "2"
           $python = "$env:GITHUB_WORKSPACE\.venv\Scripts\python.exe"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         shell: pwsh
         run: |
           uv sync --extra dev
-          uv pip install --python .venv\Scripts\python.exe cmake setuptools wheel
+          uv pip install --python .venv\Scripts\python.exe cmake ninja setuptools wheel
 
       - name: Restore pinned kernel-builder
         id: kernel-builder-cache
@@ -123,16 +123,31 @@ jobs:
           $vsRoot = & $vswhere `
             -latest `
             -products * `
-            -requires Microsoft.Component.MSBuild `
+            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
             -property installationPath
-          $msbuild = Join-Path $vsRoot "MSBuild\Current\Bin\MSBuild.exe"
-          if (-not (Test-Path $msbuild)) {
-            throw "32-bit host MSBuild was not found"
+          if (-not $vsRoot) {
+            throw "MSVC x86_64 tools were not found"
           }
-          & $msbuild -version
-          $env:CMAKE_GENERATOR = "Visual Studio 17 2022"
-          $env:CMAKE_GENERATOR_PLATFORM = "x64"
-          $env:CMAKE_MAKE_PROGRAM = $msbuild.Replace("\", "/")
+          $vsDevCmd = Join-Path $vsRoot "Common7\Tools\VsDevCmd.bat"
+          $envDump = cmd.exe /d /s /c `
+            "call `"$vsDevCmd`" -arch=x64 -host_arch=x64 >nul && set"
+          if ($LASTEXITCODE -ne 0) {
+            throw "failed to initialize the MSVC x86_64 environment"
+          }
+          foreach ($line in $envDump) {
+            $parts = $line -split "=", 2
+            if ($parts.Length -eq 2) {
+              Set-Item -Path "Env:$($parts[0])" -Value $parts[1]
+            }
+          }
+          cl.exe 2>&1 | Select-Object -First 3
+          $ninja = "$env:GITHUB_WORKSPACE\.venv\Scripts\ninja.exe"
+          if (-not (Test-Path $ninja)) {
+            throw "the Python Ninja executable was not installed"
+          }
+          & $ninja --version
+          $env:CMAKE_GENERATOR = "Ninja Multi-Config"
+          $env:CMAKE_MAKE_PROGRAM = $ninja.Replace("\", "/")
           $env:CMAKE_ARGS = "-DGPU_LANG=CPU"
           $env:MAX_JOBS = "2"
           $python = "$env:GITHUB_WORKSPACE\.venv\Scripts\python.exe"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The implementation is clean-room and Apache-2.0 licensed.
 - Model-specific policies for paper-sensitive AdaLN and output-layer handling.
 - Compact `safetensors` artifacts and Hugging Face `save_pretrained()` /
   `from_pretrained()` integration.
-- Packed-weight CUDA, Triton, and Metal inference paths that avoid a full
+- Packed-weight CPU, CUDA, Triton, and Metal inference paths that avoid a full
   dequantized weight matrix.
 
 Embeddings, timestep modules, task heads, and common final projections are

--- a/README.md
+++ b/README.md
@@ -218,11 +218,12 @@ pipe = load_quantized_pipeline_from_artifact(
 | --- | --- |
 | CUDA | Native activation kernel plus packed W4A4 tensor-core path; native or Triton packed fallback |
 | MPS | Native packed Metal package |
-| CPU | PyTorch reference path |
+| CPU | Native exact activation, packed low-bit matmul, and packed INT4 AdaLN when the CPU package is importable; PyTorch reference fallback otherwise |
 
 CUDA and MPS do not silently materialize a full BF16/FP16 weight matrix in
 `auto_fused`. If no packed backend is available, the error includes the missing
-backend and installation guidance.
+backend and installation guidance. CPU retains a compatibility fallback when
+the optional native package is absent.
 
 Use the explicit reference path for compatibility or numerical debugging:
 
@@ -257,8 +258,9 @@ inference by setting the allocator before Python starts:
 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True python generate.py
 ```
 
-The variant must match the Torch minor version, CUDA or Metal backend, C++ ABI,
-architecture, and operating system. See
+CUDA and Metal variants must match the Torch/backend tuple. The CPU variant
+targets the LibTorch Stable ABI 2.11, but remains specific to its operating
+system, C++ runtime, and architecture. See
 [`docs/kernel-audit.md`](docs/kernel-audit.md) for tested shapes, benchmark
 methodology, and local package verification.
 

--- a/docs/kernel-audit.md
+++ b/docs/kernel-audit.md
@@ -35,7 +35,7 @@ Other explicit modes are `native_packed_matmul`, `triton_packed_matmul`,
 | --- | --- | --- |
 | CUDA | Optimized packed inference | Native RPBH/quantization, chunked packed-weight decode plus CUTLASS INT8 matmul, direct packed CUDA MMA fallback, and generic Triton packed fallback |
 | MPS/Metal | Optimized packed inference | Native Metal packed matmul and Metal activation quantization stages |
-| CPU | Hardware-verified native source build; platform wheels pending | Runtime ISA dispatch across scalar, AVX2/FMA, AVX-512/BF16, and ARM64 NEON; exact packed activation, packed low-bit matmul, and packed INT4 group-64 AdaLN |
+| CPU | Hardware-verified source builds; Windows x86_64 ABI3 wheel verified in CI but not yet published | Runtime ISA dispatch across scalar, AVX2/FMA, AVX-512/BF16, and ARM64 NEON; exact packed activation, packed low-bit matmul, and packed INT4 group-64 AdaLN |
 | Vulkan | Unverified | No runtime backend |
 | ROCm | Unsupported | No release backend |
 | XPU | Unsupported | No release backend |
@@ -127,6 +127,19 @@ maximum error `1.526e-5`. Packed weights and row norms occupied 1,179,648 bytes
 versus 4,718,592 bytes for BF16 weights, and the native layer retained no
 dequantized-weight cache.
 
+A clean ABI3 wheel rebuild was also profiled on an AMD EPYC 9654 (Zen 4) with
+GCC 13.3 and Torch 2.12.1+cpu. Its hosted cpuset exposed logical CPUs `36,132`,
+the two SMT threads of one physical core. At 32 rows and dimension 1536, exact
+W4A4 packed matmul measured 1.4928 ms hot median and 1.5151 ms p95. Explicit
+dequantization plus `F.linear` measured 6.6373 ms median, so the packed path was
+4.51x faster while using 1,182,784 bytes instead of 4,718,592 bytes for the
+weight-side representation. A resident BF16 `F.linear` was faster at 0.7823 ms
+but retained the complete dense weight. Relative RMSE was `6.546e-6` and maximum
+error was `0.03125`. Disassembly contained the selected AVX-512/BF16 `vpermw`
+and `vdpbf16ps` instructions. The Ubuntu 24.04 development wheel required
+`manylinux_2_38`; it is local evidence, not a distributable Linux release
+artifact.
+
 AdaLN uses an exact signed INT4 group-64 lookup with BF16 scales and
 activations. The realistic modulation shape below is 3072 input channels and
 18432 output channels. Timings are 21 post-warmup calls with
@@ -149,8 +162,17 @@ spatial-token row counts.
 The same x86_64 stable-ABI 2.11 binary built against Torch 2.13 loaded and ran
 under Torch 2.12.1. This verifies the current LibTorch Stable ABI boundary for
 those two runtimes; it does not make the wheel independent of the platform
-GLIBC, C++ runtime, or CPU ISA. Linux and Windows wheel policy remains pending,
-and Windows CPU execution is not yet verified.
+GLIBC, C++ runtime, or CPU ISA. A separate Windows Server 2022 build on an AMD
+EPYC 7763 used Python 3.12.10, Torch 2.12.1, CMake 3.31.6, Ninja Multi-Config,
+and MSVC 19.44. It produced a 147,326-byte
+`orbitquant_packed_matmul-0.1.0-cp39-abi3-win_amd64.whl` with
+`Requires-Dist: torch>=2.11`. A clean environment passed 73 native-package
+tests with 33 accelerator-only skips; OrbitQuant integration and the independent
+paper oracle passed another 33 tests with two CUDA/Triton skips. The suite
+forced both scalar and AVX2 dispatch on the x86_64 runner. This verifies the
+Windows x86_64 build, installation, packed forward, and artifact contract; the
+wheel is not published yet, and Windows Server 2025/Visual Studio 2026 remains
+unverified. A release-compatible Linux wheel also remains pending.
 
 The ARM64 native CPU path was separately built on an Apple M2 Max. At 32 rows
 and dimension 1536, the full native W4A4 layer measured about 1.20 ms versus

--- a/docs/kernel-audit.md
+++ b/docs/kernel-audit.md
@@ -4,9 +4,11 @@ OrbitQuant uses packed low-bit weights directly in optimized runtime modes. The
 reference path materializes a floating-point weight matrix and is available only
 when explicitly selected.
 
-The runtime contract below reflects OrbitQuant 0.3.1. Benchmark tables retain
-the exact software and hardware of each recorded run rather than implying that
-those versions are current installation requirements.
+The runtime contract below reflects the current source tree. Benchmark tables
+retain the exact software and hardware of each recorded run rather than
+implying that those versions are current installation requirements. Binary
+platform support is only marked verified where build, install, and forward
+evidence exists.
 
 ## Runtime Contract
 
@@ -16,10 +18,11 @@ those versions are current installation requirements.
 | --- | --- | --- |
 | CUDA | Native activation kernel plus packed W4A4 tensor-core path; native or Triton packed fallback | A matching native package for the fastest path; Triton for the CUTLASS epilogue and generic packed fallback |
 | MPS | Native packed matmul | An importable local Metal package |
-| CPU | Reference matmul | PyTorch |
+| CPU | Native exact activation, packed low-bit matmul, and packed INT4 AdaLN when the CPU variant is importable; reference fallback otherwise | A matching native CPU package for packed execution |
 
 CUDA and MPS raise an actionable error when no packed backend is available.
-They do not silently fall back to full weight dequantization. Use
+They do not silently fall back to full weight dequantization. CPU keeps a
+compatibility fallback when the optional native package is absent. Use
 `runtime_mode="dequant_bf16"` explicitly for compatibility, debugging, or
 numerical comparison.
 
@@ -32,7 +35,8 @@ Other explicit modes are `native_packed_matmul`, `triton_packed_matmul`,
 | --- | --- | --- |
 | CUDA | Optimized packed inference | Native RPBH/quantization, chunked packed-weight decode plus CUTLASS INT8 matmul, direct packed CUDA MMA fallback, and generic Triton packed fallback |
 | MPS/Metal | Optimized packed inference | Native Metal packed matmul and Metal activation quantization stages |
-| CPU | Reference | PyTorch activation quantization, weight dequantization, and linear matmul |
+| CPU | Hardware-verified native source build; platform wheels pending | Runtime ISA dispatch across scalar, AVX2/FMA, AVX-512/BF16, and ARM64 NEON; exact packed activation, packed low-bit matmul, and packed INT4 group-64 AdaLN |
+| Vulkan | Unverified | No runtime backend |
 | ROCm | Unsupported | No release backend |
 | XPU | Unsupported | No release backend |
 
@@ -103,6 +107,57 @@ The variant must match the active Torch, CUDA or Metal, platform, and C++ ABI
 tuple. OrbitQuant rejects incompatible packages instead of loading them.
 
 ## Verified Devices And Shapes
+
+The native CPU package was built and executed on an AMD EPYC 4564P (Zen 4)
+with GCC 13.3 and Torch 2.13.0+cpu. The hosted cpuset exposed logical CPUs
+`13,29`, which are the two SMT threads of one physical core. These results are
+single-physical-core ISA and latency evidence, not a multi-core scaling claim.
+Runtime dispatch exercised scalar, AVX2/FMA, and AVX-512 paths against the same
+independent BF16 reference. The AVX-512 group-64 path uses `vpermw` for INT4
+lookup and `vdpbf16ps` accumulation; annotated disassembly confirmed that the
+hot rows=4 and rows=8 loops retain accumulators in ZMM registers without a full
+weight decode buffer or stack-spilled accumulator tile.
+
+For an exact W4A4 projection with 32 activation rows and dimension 1536, the
+native activation stage measured 0.1484 ms median, packed matmul measured
+1.0528 ms, and the full native layer measured 1.2081 ms. Explicit
+`dequant_bf16` measured 1.5836 ms and source BF16 `F.linear` measured 0.5479 ms.
+The packed and explicit-reference outputs had relative RMSE `1.203e-7` and
+maximum error `1.526e-5`. Packed weights and row norms occupied 1,179,648 bytes
+versus 4,718,592 bytes for BF16 weights, and the native layer retained no
+dequantized-weight cache.
+
+AdaLN uses an exact signed INT4 group-64 lookup with BF16 scales and
+activations. The realistic modulation shape below is 3072 input channels and
+18432 output channels. Timings are 21 post-warmup calls with
+`ORBITQUANT_CPU_THREADS=1`; `auto_fused` selected the AVX-512/BF16 path.
+
+| Rows | Packed median | Packed p95 | Resident BF16 median | Packed vs resident BF16 | Relative RMSE | Max error |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 2.4828 ms | 2.7575 ms | 6.9140 ms | 2.78x | 1.01e-6 | 0.001953 |
+| 4 | 3.0471 ms | 3.0726 ms | 6.3742 ms | 2.09x | 2.50e-5 | 0.0625 |
+| 32 | 24.4159 ms | 24.4693 ms | 15.9194 ms | 0.65x | 2.32e-5 | 0.125 |
+
+The packed AdaLN weight is 28,311,552 bytes and its BF16 scales are 1,769,472
+bytes, compared with 113,246,208 bytes for the BF16 weight. A native-only
+process increased resident memory by 1.4 MB on its first call and by another
+4.3 MB across 500 calls; it did not allocate the 113 MB dense weight. The
+rows=32 result documents the crossover where oneDNN's resident BF16 GEMM is
+faster; AdaLN conditioning normally uses batch-sized row counts rather than
+spatial-token row counts.
+
+The same x86_64 stable-ABI 2.11 binary built against Torch 2.13 loaded and ran
+under Torch 2.12.1. This verifies the current LibTorch Stable ABI boundary for
+those two runtimes; it does not make the wheel independent of the platform
+GLIBC, C++ runtime, or CPU ISA. Linux and Windows wheel policy remains pending,
+and Windows CPU execution is not yet verified.
+
+The ARM64 native CPU path was separately built on an Apple M2 Max. At 32 rows
+and dimension 1536, the full native W4A4 layer measured about 1.20 ms versus
+1.84 ms for explicit BF16 dequantization; the packed matmul itself was about
+0.81 ms versus 0.79 ms for a resident dense matmul. Scalar and NEON paths were
+both exercised against the independent reference. These CPU measurements are
+separate from the preferred Metal GPU path on Apple Silicon.
 
 CUDA native-package verification passed on an NVIDIA RTX PRO 4500 Blackwell
 with Torch 2.13.0+cu130 using the

--- a/native-kernels/orbitquant-packed-matmul/benchmarks/benchmark.py
+++ b/native-kernels/orbitquant-packed-matmul/benchmarks/benchmark.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import platform
+import statistics
 import time
 
 import torch
@@ -28,18 +31,29 @@ def _synchronize(device: str) -> None:
         torch.mps.synchronize()
 
 
-def _time_call(device: str, iters: int, fn) -> float:
+def _time_call(device: str, fn) -> float:
     _synchronize(device)
-    start = time.perf_counter()
+    start = time.perf_counter_ns()
+    fn()
+    _synchronize(device)
+    return (time.perf_counter_ns() - start) / 1_000_000_000
+
+
+def _time_distribution(device: str, iters: int, fn) -> dict[str, float]:
+    samples = []
     for _ in range(iters):
-        fn()
-    _synchronize(device)
-    return (time.perf_counter() - start) / iters
+        samples.append(_time_call(device, fn))
+    samples.sort()
+    return {
+        "mean": statistics.fmean(samples),
+        "median": statistics.median(samples),
+        "p95": samples[min(len(samples) - 1, int(len(samples) * 0.95))],
+    }
 
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--device", choices=["cuda", "mps"], default="cuda")
+    parser.add_argument("--device", choices=["cpu", "cuda", "mps"], default="cuda")
     parser.add_argument("--bits", type=int, default=4)
     parser.add_argument("--rows", type=int, default=4096)
     parser.add_argument("--in-features", type=int, default=3072)
@@ -47,8 +61,17 @@ def main() -> None:
     parser.add_argument("--iters", type=int, default=20)
     parser.add_argument("--warmup", type=int, default=3)
     parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--threads", type=int, default=0)
     parser.add_argument("--with-bias", action="store_true")
     args = parser.parse_args()
+
+    if args.threads < 0:
+        parser.error("--threads must be non-negative")
+    if args.iters <= 0 or args.warmup < 0:
+        parser.error("--iters must be positive and --warmup must be non-negative")
+    if args.device == "cpu" and args.threads > 0:
+        os.environ["ORBITQUANT_CPU_THREADS"] = str(args.threads)
+        torch.set_num_threads(args.threads)
 
     torch.manual_seed(args.seed)
     dtype = torch.float16 if args.device == "mps" else torch.bfloat16
@@ -98,30 +121,48 @@ def main() -> None:
     def dequantize_then_linear_call() -> torch.Tensor:
         return torch.nn.functional.linear(x, materialize_reference_weight(), bias)
 
+    packed_first_call_seconds = _time_call(args.device, packed_call)
+    predequantized_first_call_seconds = _time_call(args.device, predequantized_linear_call)
+    dequantize_then_first_call_seconds = _time_call(args.device, dequantize_then_linear_call)
+
     for _ in range(args.warmup):
         packed_call()
         predequantized_linear_call()
         dequantize_then_linear_call()
-    packed_seconds = _time_call(args.device, args.iters, packed_call)
-    predequantized_linear_seconds = _time_call(
+    packed_distribution = _time_distribution(args.device, args.iters, packed_call)
+    predequantized_distribution = _time_distribution(
         args.device,
         args.iters,
         predequantized_linear_call,
     )
-    dequantize_then_linear_seconds = _time_call(
+    dequantize_then_distribution = _time_distribution(
         args.device,
         args.iters,
         dequantize_then_linear_call,
     )
+    packed_seconds = packed_distribution["mean"]
+    predequantized_linear_seconds = predequantized_distribution["mean"]
+    dequantize_then_linear_seconds = dequantize_then_distribution["mean"]
 
     packed_output = packed_call()
     reference_output = predequantized_linear_call()
     _synchronize(args.device)
-    max_abs_error = (packed_output.float() - reference_output.float()).abs().max().item()
+    error = packed_output.float() - reference_output.float()
+    max_abs_error = error.abs().max().item()
+    rmse = error.square().mean().sqrt().item()
+    reference_rms = reference_output.float().square().mean().sqrt().item()
+    relative_rmse = rmse / max(reference_rms, 1e-12)
 
     payload = {
         "device": args.device,
-        "device_name": torch.cuda.get_device_name(0) if args.device == "cuda" else "mps",
+        "device_name": (
+            torch.cuda.get_device_name(0)
+            if args.device == "cuda"
+            else "mps"
+            if args.device == "mps"
+            else f"{platform.processor() or platform.machine()} "
+            f"({torch.backends.cpu.get_cpu_capability()})"
+        ),
         "dtype": str(dtype).replace("torch.", ""),
         "bits": args.bits,
         "rows": args.rows,
@@ -129,10 +170,25 @@ def main() -> None:
         "out_features": args.out_features,
         "iters": args.iters,
         "warmup": args.warmup,
+        "threads": (
+            os.environ.get("ORBITQUANT_CPU_THREADS", "runtime default")
+            if args.device == "cpu"
+            else None
+        ),
+        "torch_threads": torch.get_num_threads() if args.device == "cpu" else None,
         "with_bias": args.with_bias,
         "packed_seconds_per_iter": packed_seconds,
+        "packed_first_call_seconds": packed_first_call_seconds,
+        "packed_hot_median_seconds": packed_distribution["median"],
+        "packed_hot_p95_seconds": packed_distribution["p95"],
         "predequantized_f_linear_seconds_per_iter": predequantized_linear_seconds,
+        "predequantized_first_call_seconds": predequantized_first_call_seconds,
+        "predequantized_hot_median_seconds": predequantized_distribution["median"],
+        "predequantized_hot_p95_seconds": predequantized_distribution["p95"],
         "dequantize_then_f_linear_seconds_per_iter": dequantize_then_linear_seconds,
+        "dequantize_then_first_call_seconds": dequantize_then_first_call_seconds,
+        "dequantize_then_hot_median_seconds": dequantize_then_distribution["median"],
+        "dequantize_then_hot_p95_seconds": dequantize_then_distribution["p95"],
         "packed_weight_indices_bytes": packed_weight_indices_bytes,
         "row_norms_bytes": row_norms_bytes,
         "centroid_bytes": centroid_bytes,
@@ -155,6 +211,8 @@ def main() -> None:
         if packed_seconds > 0
         else None,
         "max_abs_error": max_abs_error,
+        "rmse": rmse,
+        "relative_rmse": relative_rmse,
         "reference": (
             "predequantized PyTorch F.linear over a materialized dequantized "
             "weight matrix"

--- a/native-kernels/orbitquant-packed-matmul/build.toml
+++ b/native-kernels/orbitquant-packed-matmul/build.toml
@@ -3,7 +3,7 @@ name = "orbitquant-packed-matmul"
 version = 1
 edition = 5
 license = "Apache-2.0"
-backends = ["cuda", "metal"]
+backends = ["cpu", "cuda", "metal"]
 upstream = "https://github.com/iamwavecut/OrbitQuant"
 source = "https://huggingface.co/WaveCut/orbitquant-packed-matmul"
 
@@ -14,6 +14,37 @@ repo-id = "WaveCut/orbitquant-packed-matmul"
 src = [
   "torch-ext/torch_binding.cpp",
   "torch-ext/torch_binding.h",
+]
+
+[torch.stable-abi]
+cpu = "2.11"
+
+[kernel.packed_matmul_cpu]
+backend = "cpu"
+depends = ["torch"]
+include = ["orbitquant_packed_matmul_cpu"]
+src = [
+  "orbitquant_packed_matmul_cpu/cpu_isa.cpp",
+  "orbitquant_packed_matmul_cpu/cpu_kernel_args.h",
+  "orbitquant_packed_matmul_cpu/cpu_threads.cpp",
+  "orbitquant_packed_matmul_cpu/cpu_threads.h",
+  "orbitquant_packed_matmul_cpu/packed_adaln_cpu.cpp",
+  "orbitquant_packed_matmul_cpu/packed_matmul_cpu.cpp",
+  "orbitquant_packed_matmul_cpu/packed_matmul_cpu.h",
+  "orbitquant_packed_matmul_cpu/packed_matmul_scalar.cpp",
+  "orbitquant_packed_matmul_cpu/packed_matmul_neon.cpp",
+  "orbitquant_packed_matmul_cpu/packed_matmul_x86_avx512.cpp",
+  "orbitquant_packed_matmul_cpu/quantize_activations_cpu.cpp",
+]
+
+[kernel.packed_matmul_cpu_x86_avx2]
+backend = "cpu"
+depends = ["torch"]
+include = ["orbitquant_packed_matmul_cpu"]
+cxx-flags = ["$<$<CXX_COMPILER_ID:MSVC>:/arch:AVX2>"]
+src = [
+  "orbitquant_packed_matmul_cpu/cpu_msvc_avx2.cpp",
+  "orbitquant_packed_matmul_cpu/packed_matmul_x86.cpp",
 ]
 
 [kernel.packed_matmul_cuda]

--- a/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/cpu_isa.cpp
+++ b/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/cpu_isa.cpp
@@ -1,0 +1,42 @@
+#include "packed_matmul_cpu.h"
+
+#if defined(__x86_64__) || defined(_M_X64)
+#if defined(_MSC_VER)
+#include <intrin.h>
+#pragma intrinsic(_xgetbv)
+#endif
+#endif
+
+namespace orbitquant::cpu {
+namespace {
+
+bool runtime_has_avx2_fma_f16c() {
+#if defined(_MSC_VER) && defined(_M_X64)
+  int registers[4]{};
+  __cpuid(registers, 1);
+  const bool osxsave = (registers[2] & (1 << 27)) != 0;
+  const bool avx = (registers[2] & (1 << 28)) != 0;
+  const bool fma = (registers[2] & (1 << 12)) != 0;
+  const bool f16c = (registers[2] & (1 << 29)) != 0;
+  if (!osxsave || !avx || !fma || !f16c || (_xgetbv(0) & 0x6) != 0x6) {
+    return false;
+  }
+  __cpuidex(registers, 7, 0);
+  return (registers[1] & (1 << 5)) != 0;
+#elif defined(__x86_64__)
+  __builtin_cpu_init();
+  return __builtin_cpu_supports("avx2") && __builtin_cpu_supports("fma") &&
+      __builtin_cpu_supports("f16c");
+#else
+  return false;
+#endif
+}
+
+}  // namespace
+
+bool packed_matmul_x86_avx2_available() {
+  static const bool available = runtime_has_avx2_fma_f16c();
+  return available;
+}
+
+}  // namespace orbitquant::cpu

--- a/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/cpu_kernel_args.h
+++ b/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/cpu_kernel_args.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "packed_matmul_cpu.h"
+
+#include <cstdint>
+
+namespace orbitquant::cpu {
+
+enum class ActivationIsa : std::uint8_t {
+  Portable,
+  Neon,
+  Avx2,
+  Avx512,
+};
+
+struct ActivationArgs {
+  void *out;
+  void const *x;
+  std::int64_t const *permutation;
+  std::int8_t const *signs;
+  float const *centroids;
+  float const *boundaries;
+  ScalarKind scalar_kind;
+  ActivationIsa isa;
+  std::int64_t rows;
+  std::int64_t dim;
+  std::int64_t boundary_count;
+  std::int64_t block_size;
+  float eps;
+  float inv_sqrt_block;
+};
+
+void activation_fwht_msvc_avx2(float *values, std::int64_t block_size);
+
+float activation_squared_norm_msvc_avx2(
+    void const *data,
+    ScalarKind scalar_kind,
+    std::int64_t offset,
+    std::int64_t dim);
+
+void activation_quantize_lookup_msvc_avx2(
+    ActivationArgs const &args,
+    float const *scratch,
+    std::int64_t output_offset,
+    float norm);
+
+struct AdalnArgs {
+  void *out;
+  void const *x;
+  std::uint8_t const *packed_weight;
+  float const *scales;
+  float const *bias;
+  bool has_bias;
+  std::int64_t rows;
+  std::int64_t out_features;
+  std::int64_t in_features;
+  std::int64_t group_size;
+  std::int64_t num_groups;
+  std::int64_t padded_in_features;
+};
+
+using AdalnRangeFn = void (*)(
+    AdalnArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end);
+
+void packed_adaln_msvc_avx2_range(
+    AdalnArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end);
+
+}  // namespace orbitquant::cpu

--- a/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/cpu_msvc_avx2.cpp
+++ b/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/cpu_msvc_avx2.cpp
@@ -1,0 +1,431 @@
+#include "cpu_kernel_args.h"
+
+#if defined(_MSC_VER) && defined(_M_X64)
+#include <immintrin.h>
+
+#include <torch/headeronly/util/BFloat16.h>
+#include <torch/headeronly/util/Half.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <type_traits>
+
+namespace orbitquant::cpu {
+namespace {
+
+template <typename scalar_t>
+inline float load_scalar(void const *data, std::int64_t offset) {
+  return static_cast<float>(static_cast<scalar_t const *>(data)[offset]);
+}
+
+template <>
+inline float load_scalar<float>(void const *data, std::int64_t offset) {
+  return static_cast<float const *>(data)[offset];
+}
+
+template <typename scalar_t>
+inline void store_scalar(void *data, std::int64_t offset, float value) {
+  static_cast<scalar_t *>(data)[offset] = scalar_t(value);
+}
+
+template <>
+inline void store_scalar<float>(void *data, std::int64_t offset, float value) {
+  static_cast<float *>(data)[offset] = value;
+}
+
+template <typename scalar_t>
+float squared_norm_avx2(
+    void const *data,
+    std::int64_t offset,
+    std::int64_t dim) {
+  __m256 accumulator = _mm256_setzero_ps();
+  std::int64_t index = 0;
+  for (; index + 8 <= dim; index += 8) {
+    __m256 values;
+    if constexpr (std::is_same_v<scalar_t, float>) {
+      values = _mm256_loadu_ps(
+          static_cast<float const *>(data) + offset + index);
+    } else if constexpr (std::is_same_v<scalar_t, c10::Half>) {
+      const auto *source =
+          static_cast<std::uint16_t const *>(data) + offset + index;
+      values = _mm256_cvtph_ps(
+          _mm_loadu_si128(reinterpret_cast<__m128i const *>(source)));
+    } else {
+      const auto *source =
+          static_cast<std::uint16_t const *>(data) + offset + index;
+      const __m128i packed =
+          _mm_loadu_si128(reinterpret_cast<__m128i const *>(source));
+      values = _mm256_castsi256_ps(
+          _mm256_slli_epi32(_mm256_cvtepu16_epi32(packed), 16));
+    }
+    accumulator = _mm256_fmadd_ps(values, values, accumulator);
+  }
+  const __m128 halves = _mm_add_ps(
+      _mm256_castps256_ps128(accumulator),
+      _mm256_extractf128_ps(accumulator, 1));
+  const __m128 pairs = _mm_hadd_ps(halves, halves);
+  float result = _mm_cvtss_f32(_mm_hadd_ps(pairs, pairs));
+  for (; index < dim; ++index) {
+    const float value = load_scalar<scalar_t>(data, offset + index);
+    result += value * value;
+  }
+  return result;
+}
+
+inline std::int64_t nearest_centroid(
+    float value,
+    float const *boundaries,
+    std::int64_t boundary_count) {
+  std::int64_t low = 0;
+  std::int64_t high = boundary_count;
+  while (low < high) {
+    const std::int64_t middle = low + (high - low) / 2;
+    if (value <= boundaries[middle]) {
+      high = middle;
+    } else {
+      low = middle + 1;
+    }
+  }
+  return low;
+}
+
+inline __m128i float8_to_bfloat8(__m256 values) {
+  const __m256i bits = _mm256_castps_si256(values);
+  const __m256i absolute_bits =
+      _mm256_and_si256(bits, _mm256_set1_epi32(0x7fffffff));
+  const __m256i nan_mask =
+      _mm256_cmpgt_epi32(absolute_bits, _mm256_set1_epi32(0x7f800000));
+  const __m256i rounding = _mm256_add_epi32(
+      _mm256_set1_epi32(0x7fff),
+      _mm256_and_si256(_mm256_srli_epi32(bits, 16), _mm256_set1_epi32(1)));
+  const __m256i upper = _mm256_srli_epi32(
+      _mm256_add_epi32(bits, rounding),
+      16);
+  __m128i packed = _mm_packus_epi32(
+      _mm256_castsi256_si128(upper),
+      _mm256_extracti128_si256(upper, 1));
+  const __m128i packed_nan_mask = _mm_packs_epi32(
+      _mm256_castsi256_si128(nan_mask),
+      _mm256_extracti128_si256(nan_mask, 1));
+  return _mm_blendv_epi8(
+      packed,
+      _mm_set1_epi16(0x7fc0),
+      packed_nan_mask);
+}
+
+template <typename scalar_t>
+void quantize_lookup_avx2(
+    ActivationArgs const &args,
+    float const *scratch,
+    std::int64_t output_offset,
+    float norm) {
+  const __m256 inverse_sqrt_block = _mm256_set1_ps(args.inv_sqrt_block);
+  const __m256 output_norm = _mm256_set1_ps(norm);
+  const __m256i ones = _mm256_set1_epi32(1);
+  std::int64_t index = 0;
+  for (; index + 8 <= args.dim; index += 8) {
+    const __m256 direction = _mm256_mul_ps(
+        _mm256_loadu_ps(scratch + index), inverse_sqrt_block);
+    __m256i centroid_indices = _mm256_setzero_si256();
+    for (std::int64_t boundary = 0; boundary < args.boundary_count; ++boundary) {
+      const __m256 comparison = _mm256_cmp_ps(
+          direction,
+          _mm256_set1_ps(args.boundaries[boundary]),
+          _CMP_NLE_UQ);
+      centroid_indices = _mm256_add_epi32(
+          centroid_indices,
+          _mm256_and_si256(_mm256_castps_si256(comparison), ones));
+    }
+    const __m256 output = _mm256_mul_ps(
+        _mm256_i32gather_ps(args.centroids, centroid_indices, 4),
+        output_norm);
+    if constexpr (std::is_same_v<scalar_t, float>) {
+      _mm256_storeu_ps(
+          static_cast<float *>(args.out) + output_offset + index,
+          output);
+    } else if constexpr (std::is_same_v<scalar_t, c10::Half>) {
+      _mm_storeu_si128(
+          reinterpret_cast<__m128i *>(
+              static_cast<std::uint16_t *>(args.out) + output_offset + index),
+          _mm256_cvtps_ph(output, _MM_FROUND_TO_NEAREST_INT));
+    } else {
+      _mm_storeu_si128(
+          reinterpret_cast<__m128i *>(
+              static_cast<std::uint16_t *>(args.out) + output_offset + index),
+          float8_to_bfloat8(output));
+    }
+  }
+  for (; index < args.dim; ++index) {
+    const float direction = scratch[index] * args.inv_sqrt_block;
+    const std::int64_t centroid_index = nearest_centroid(
+        direction, args.boundaries, args.boundary_count);
+    store_scalar<scalar_t>(
+        args.out,
+        output_offset + index,
+        args.centroids[centroid_index] * norm);
+  }
+}
+
+inline float load_bfloat(void const *data, std::int64_t offset) {
+  return static_cast<float>(
+      static_cast<c10::BFloat16 const *>(data)[offset]);
+}
+
+inline void store_bfloat(void *data, std::int64_t offset, float value) {
+  static_cast<c10::BFloat16 *>(data)[offset] = c10::BFloat16(value);
+}
+
+inline std::uint8_t unpack_adaln_index(
+    std::uint8_t const *packed,
+    std::int64_t flat_index) {
+  const std::uint8_t byte = packed[flat_index / 2];
+  return (flat_index & 1) == 0 ? byte & 15u : (byte >> 4) & 15u;
+}
+
+inline float dequantized_adaln_value(std::uint8_t index, float scale) {
+  return static_cast<float>(
+      c10::BFloat16((static_cast<int>(index) - 8) * scale));
+}
+
+inline void fill_group_lut(float *lut, float scale) {
+  for (int index = 0; index < 16; ++index) {
+    lut[index] = dequantized_adaln_value(
+        static_cast<std::uint8_t>(index), scale);
+  }
+}
+
+void packed_adaln_scalar_range(
+    AdalnArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  for (std::int64_t out_col = out_start; out_col < out_end; ++out_col) {
+    for (std::int64_t row = 0; row < args.rows; ++row) {
+      float accumulator = 0.0f;
+      const std::int64_t input_offset = row * args.in_features;
+      for (std::int64_t k = 0; k < args.in_features; ++k) {
+        const std::int64_t weight_offset =
+            out_col * args.padded_in_features + k;
+        const std::uint8_t index =
+            unpack_adaln_index(args.packed_weight, weight_offset);
+        const float scale =
+            args.scales[out_col * args.num_groups + k / args.group_size];
+        accumulator += load_bfloat(args.x, input_offset + k) *
+            dequantized_adaln_value(index, scale);
+      }
+      if (args.has_bias) {
+        accumulator += args.bias[out_col];
+      }
+      store_bfloat(
+          args.out,
+          row * args.out_features + out_col,
+          accumulator);
+    }
+  }
+}
+
+inline __m256 load_bfloat8(void const *data, std::int64_t offset) {
+  const auto *source =
+      static_cast<std::uint16_t const *>(data) + offset;
+  const __m128i packed =
+      _mm_loadu_si128(reinterpret_cast<__m128i const *>(source));
+  return _mm256_castsi256_ps(
+      _mm256_slli_epi32(_mm256_cvtepu16_epi32(packed), 16));
+}
+
+inline float horizontal_sum(__m256 value) {
+  const __m128 halves = _mm_add_ps(
+      _mm256_castps256_ps128(value),
+      _mm256_extractf128_ps(value, 1));
+  const __m128 pairs = _mm_hadd_ps(halves, halves);
+  return _mm_cvtss_f32(_mm_hadd_ps(pairs, pairs));
+}
+
+template <int row_tile>
+inline void packed_adaln_avx2_rows(
+    AdalnArgs const &args,
+    std::uint8_t const *packed_row,
+    float const *scale_row,
+    std::int64_t out_col,
+    std::int64_t row_start) {
+  __m256 accumulators[row_tile];
+  float tails[row_tile]{};
+  for (int row = 0; row < row_tile; ++row) {
+    accumulators[row] = _mm256_setzero_ps();
+  }
+  const __m128i nibble_mask = _mm_set1_epi8(15);
+  const __m256i low_table_limit = _mm256_set1_epi32(7);
+
+  for (std::int64_t group = 0; group < args.num_groups; ++group) {
+    float lut[16];
+    fill_group_lut(lut, scale_row[group]);
+    const __m256 lut_low = _mm256_loadu_ps(lut);
+    const __m256 lut_high = _mm256_loadu_ps(lut + 8);
+    const std::int64_t group_start = group * args.group_size;
+    const std::int64_t group_end = std::min(
+        args.in_features,
+        group_start + args.group_size);
+    std::int64_t k = group_start;
+    for (; k + 8 <= group_end; k += 8) {
+      std::int32_t packed;
+      std::memcpy(&packed, packed_row + k / 2, sizeof(packed));
+      const __m128i bytes = _mm_cvtsi32_si128(packed);
+      const __m128i low = _mm_and_si128(bytes, nibble_mask);
+      const __m128i high = _mm_and_si128(
+          _mm_srli_epi16(bytes, 4), nibble_mask);
+      const __m256i indices =
+          _mm256_cvtepu8_epi32(_mm_unpacklo_epi8(low, high));
+      const __m256 weight = _mm256_blendv_ps(
+          _mm256_permutevar8x32_ps(lut_low, indices),
+          _mm256_permutevar8x32_ps(lut_high, indices),
+          _mm256_castsi256_ps(
+              _mm256_cmpgt_epi32(indices, low_table_limit)));
+      for (int row = 0; row < row_tile; ++row) {
+        const std::int64_t input_offset =
+            (row_start + row) * args.in_features + k;
+        accumulators[row] = _mm256_fmadd_ps(
+            load_bfloat8(args.x, input_offset),
+            weight,
+            accumulators[row]);
+      }
+    }
+    for (; k < group_end; ++k) {
+      const float weight = lut[unpack_adaln_index(packed_row, k)];
+      for (int row = 0; row < row_tile; ++row) {
+        tails[row] += load_bfloat(
+            args.x,
+            (row_start + row) * args.in_features + k) * weight;
+      }
+    }
+  }
+
+  for (int row = 0; row < row_tile; ++row) {
+    float accumulator = horizontal_sum(accumulators[row]) + tails[row];
+    if (args.has_bias) {
+      accumulator += args.bias[out_col];
+    }
+    store_bfloat(
+        args.out,
+        (row_start + row) * args.out_features + out_col,
+        accumulator);
+  }
+}
+
+template <
+    void (*rows8)(AdalnArgs const &, std::uint8_t const *, float const *, std::int64_t, std::int64_t),
+    void (*rows4)(AdalnArgs const &, std::uint8_t const *, float const *, std::int64_t, std::int64_t),
+    void (*rows3)(AdalnArgs const &, std::uint8_t const *, float const *, std::int64_t, std::int64_t),
+    void (*rows2)(AdalnArgs const &, std::uint8_t const *, float const *, std::int64_t, std::int64_t),
+    void (*rows1)(AdalnArgs const &, std::uint8_t const *, float const *, std::int64_t, std::int64_t)>
+void packed_adaln_tiled_range(
+    AdalnArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  const std::int64_t packed_row_bytes = args.padded_in_features / 2;
+  for (std::int64_t out_col = out_start; out_col < out_end; ++out_col) {
+    const auto *packed_row =
+        args.packed_weight + out_col * packed_row_bytes;
+    const auto *scale_row =
+        args.scales + out_col * args.num_groups;
+    std::int64_t row = 0;
+    for (; row + 8 <= args.rows; row += 8) {
+      rows8(args, packed_row, scale_row, out_col, row);
+    }
+    if (row + 4 <= args.rows) {
+      rows4(args, packed_row, scale_row, out_col, row);
+      row += 4;
+    }
+    switch (args.rows - row) {
+      case 3:
+        rows3(args, packed_row, scale_row, out_col, row);
+        break;
+      case 2:
+        rows2(args, packed_row, scale_row, out_col, row);
+        break;
+      case 1:
+        rows1(args, packed_row, scale_row, out_col, row);
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+}  // namespace
+
+void activation_fwht_msvc_avx2(float *values, std::int64_t block_size) {
+  for (std::int64_t half = 1; half < block_size; half *= 2) {
+    for (std::int64_t base = 0; base < block_size; base += 2 * half) {
+      std::int64_t offset = 0;
+      for (; offset + 8 <= half; offset += 8) {
+        const __m256 left = _mm256_loadu_ps(values + base + offset);
+        const __m256 right =
+            _mm256_loadu_ps(values + base + half + offset);
+        _mm256_storeu_ps(values + base + offset, _mm256_add_ps(left, right));
+        _mm256_storeu_ps(
+            values + base + half + offset,
+            _mm256_sub_ps(left, right));
+      }
+      for (; offset < half; ++offset) {
+        const float left = values[base + offset];
+        const float right = values[base + half + offset];
+        values[base + offset] = left + right;
+        values[base + half + offset] = left - right;
+      }
+    }
+  }
+}
+
+float activation_squared_norm_msvc_avx2(
+    void const *data,
+    ScalarKind scalar_kind,
+    std::int64_t offset,
+    std::int64_t dim) {
+  switch (scalar_kind) {
+    case ScalarKind::Float32:
+      return squared_norm_avx2<float>(data, offset, dim);
+    case ScalarKind::Float16:
+      return squared_norm_avx2<c10::Half>(data, offset, dim);
+    case ScalarKind::BFloat16:
+      return squared_norm_avx2<c10::BFloat16>(data, offset, dim);
+  }
+  return 0.0f;
+}
+
+void activation_quantize_lookup_msvc_avx2(
+    ActivationArgs const &args,
+    float const *scratch,
+    std::int64_t output_offset,
+    float norm) {
+  switch (args.scalar_kind) {
+    case ScalarKind::Float32:
+      quantize_lookup_avx2<float>(args, scratch, output_offset, norm);
+      return;
+    case ScalarKind::Float16:
+      quantize_lookup_avx2<c10::Half>(args, scratch, output_offset, norm);
+      return;
+    case ScalarKind::BFloat16:
+      quantize_lookup_avx2<c10::BFloat16>(
+          args, scratch, output_offset, norm);
+      return;
+  }
+}
+
+void packed_adaln_msvc_avx2_range(
+    AdalnArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  if (args.group_size % 8 != 0 || args.padded_in_features % 2 != 0) {
+    packed_adaln_scalar_range(args, out_start, out_end);
+    return;
+  }
+  packed_adaln_tiled_range<
+      packed_adaln_avx2_rows<8>,
+      packed_adaln_avx2_rows<4>,
+      packed_adaln_avx2_rows<3>,
+      packed_adaln_avx2_rows<2>,
+      packed_adaln_avx2_rows<1>>(args, out_start, out_end);
+}
+
+}  // namespace orbitquant::cpu
+#endif

--- a/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/cpu_threads.cpp
+++ b/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/cpu_threads.cpp
@@ -1,0 +1,103 @@
+#include "cpu_threads.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <fstream>
+#include <set>
+#include <string>
+#include <thread>
+#include <utility>
+
+#if defined(__APPLE__)
+#include <sys/sysctl.h>
+#endif
+
+#if defined(__linux__)
+#include <sched.h>
+#endif
+
+namespace orbitquant::cpu {
+namespace {
+
+int environment_thread_count() {
+  char const *value = std::getenv("ORBITQUANT_CPU_THREADS");
+  if (value == nullptr) {
+    value = std::getenv("OMP_NUM_THREADS");
+  }
+  if (value == nullptr) {
+    return 0;
+  }
+  char *end = nullptr;
+  const long parsed = std::strtol(value, &end, 10);
+  if (end == value || parsed <= 0) {
+    return 0;
+  }
+  return static_cast<int>(std::min<long>(parsed, 64));
+}
+
+#if defined(__linux__)
+int affinity_physical_core_count() {
+  cpu_set_t affinity;
+  CPU_ZERO(&affinity);
+  if (sched_getaffinity(0, sizeof(affinity), &affinity) != 0) {
+    return 0;
+  }
+
+  int logical_cpus = 0;
+  std::set<std::pair<int, int>> physical_cores;
+  for (int cpu = 0; cpu < CPU_SETSIZE; ++cpu) {
+    if (!CPU_ISSET(cpu, &affinity)) {
+      continue;
+    }
+    ++logical_cpus;
+    int package = -1;
+    int core = -1;
+    std::ifstream package_file(
+        "/sys/devices/system/cpu/cpu" + std::to_string(cpu) +
+        "/topology/physical_package_id");
+    std::ifstream core_file(
+        "/sys/devices/system/cpu/cpu" + std::to_string(cpu) +
+        "/topology/core_id");
+    if (package_file >> package && core_file >> core) {
+      physical_cores.emplace(package, core);
+    }
+  }
+  return physical_cores.empty()
+      ? logical_cpus
+      : static_cast<int>(physical_cores.size());
+}
+#endif
+
+int default_thread_count() {
+#if defined(__APPLE__)
+  int performance_cores = 0;
+  std::size_t size = sizeof(performance_cores);
+  if (sysctlbyname(
+          "hw.perflevel0.physicalcpu",
+          &performance_cores,
+          &size,
+          nullptr,
+          0) == 0 &&
+      performance_cores > 0) {
+    return std::min(performance_cores, 64);
+  }
+#endif
+#if defined(__linux__)
+  const int affinity_cores = affinity_physical_core_count();
+  if (affinity_cores > 0) {
+    return std::min(affinity_cores, 64);
+  }
+#endif
+  const unsigned hardware = std::thread::hardware_concurrency();
+  return static_cast<int>(hardware == 0 ? 1 : std::min<unsigned>(hardware, 64));
+}
+
+}  // namespace
+
+int requested_threads() {
+  const int environment = environment_thread_count();
+  static const int default_threads = default_thread_count();
+  return environment > 0 ? environment : default_threads;
+}
+
+}  // namespace orbitquant::cpu

--- a/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/cpu_threads.h
+++ b/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/cpu_threads.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace orbitquant::cpu {
+
+int requested_threads();
+
+}  // namespace orbitquant::cpu

--- a/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_adaln_cpu.cpp
+++ b/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_adaln_cpu.cpp
@@ -1,0 +1,877 @@
+#include "cpu_threads.h"
+#include "cpu_kernel_args.h"
+#include "packed_matmul_cpu.h"
+#include "../torch-ext/torch_binding.h"
+
+#include <torch/headeronly/core/DeviceType.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/macros/Macros.h>
+#include <torch/headeronly/util/BFloat16.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstdint>
+#include <cstring>
+#include <thread>
+#include <vector>
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+#include <arm_neon.h>
+#endif
+
+#if (defined(__x86_64__) || defined(_M_X64)) && !defined(_MSC_VER)
+#include <immintrin.h>
+#define ORBITQUANT_TARGET_AVX2 __attribute__((target("avx2,fma,f16c")))
+#define ORBITQUANT_TARGET_AVX512 \
+  __attribute__((target("avx512f,avx512dq,avx512bw,avx512vl,fma,f16c")))
+#define ORBITQUANT_TARGET_AVX512_BF16 \
+  __attribute__((target( \
+      "avx512f,avx512dq,avx512bw,avx512vl,avx512bf16,fma,f16c")))
+#define ORBITQUANT_HAS_AVX512_BF16_INTRINSICS 1
+#define ORBITQUANT_NOINLINE __attribute__((noinline))
+#endif
+
+namespace {
+
+using orbitquant::cpu::AdalnArgs;
+using orbitquant::cpu::AdalnRangeFn;
+
+inline float load_bfloat(
+    void const *data,
+    std::int64_t offset) {
+  return static_cast<float>(
+      static_cast<c10::BFloat16 const *>(data)[offset]);
+}
+
+inline void store_bfloat(
+    void *data,
+    std::int64_t offset,
+    float value) {
+  static_cast<c10::BFloat16 *>(data)[offset] = c10::BFloat16(value);
+}
+
+inline std::uint8_t unpack_adaln_index(
+    std::uint8_t const *packed,
+    std::int64_t flat_index) {
+  const std::uint8_t byte = packed[flat_index / 2];
+  return (flat_index & 1) == 0 ? byte & 15u : (byte >> 4) & 15u;
+}
+
+inline float dequantized_adaln_value(
+    std::uint8_t index,
+    float scale) {
+  return static_cast<float>(
+      c10::BFloat16((static_cast<int>(index) - 8) * scale));
+}
+
+inline void fill_group_lut(float *lut, float scale) {
+  for (int index = 0; index < 16; ++index) {
+    lut[index] = dequantized_adaln_value(
+        static_cast<std::uint8_t>(index),
+        scale);
+  }
+}
+
+void packed_adaln_scalar_range(
+    AdalnArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  for (std::int64_t out_col = out_start; out_col < out_end; ++out_col) {
+    for (std::int64_t row = 0; row < args.rows; ++row) {
+      float accumulator = 0.0f;
+      const std::int64_t input_offset = row * args.in_features;
+      for (std::int64_t k = 0; k < args.in_features; ++k) {
+        const std::int64_t weight_offset =
+            out_col * args.padded_in_features + k;
+        const std::uint8_t index =
+            unpack_adaln_index(args.packed_weight, weight_offset);
+        const float scale =
+            args.scales[out_col * args.num_groups + k / args.group_size];
+        accumulator += load_bfloat(args.x, input_offset + k) *
+            dequantized_adaln_value(index, scale);
+      }
+      if (args.has_bias) {
+        accumulator += args.bias[out_col];
+      }
+      store_bfloat(
+          args.out,
+          row * args.out_features + out_col,
+          accumulator);
+    }
+  }
+}
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+inline float32x4_t load_bfloat4(
+    void const *data,
+    std::int64_t offset) {
+  const uint16x4_t raw = vld1_u16(
+      static_cast<std::uint16_t const *>(data) + offset);
+  return vreinterpretq_f32_u32(vshlq_n_u32(vmovl_u16(raw), 16));
+}
+
+template <int row_tile>
+inline void packed_adaln_neon_rows(
+    AdalnArgs const &args,
+    std::uint8_t const *packed_row,
+    float const *scale_row,
+    std::int64_t out_col,
+    std::int64_t row_start) {
+  float32x4_t accumulators[row_tile];
+  float tails[row_tile]{};
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    accumulators[row] = vdupq_n_f32(0.0f);
+  }
+
+  for (std::int64_t group = 0; group < args.num_groups; ++group) {
+    float lut[16];
+    fill_group_lut(lut, scale_row[group]);
+    const std::int64_t group_start = group * args.group_size;
+    const std::int64_t group_end = std::min(
+        args.in_features,
+        group_start + args.group_size);
+    std::int64_t k = group_start;
+    for (; k + 4 <= group_end; k += 4) {
+      float weights[4];
+#pragma clang loop unroll(full)
+      for (int lane = 0; lane < 4; ++lane) {
+        weights[lane] = lut[unpack_adaln_index(packed_row, k + lane)];
+      }
+      const float32x4_t weight = vld1q_f32(weights);
+#pragma clang loop unroll(full)
+      for (int row = 0; row < row_tile; ++row) {
+        const std::int64_t input_offset =
+            (row_start + row) * args.in_features + k;
+        accumulators[row] = vfmaq_f32(
+            accumulators[row],
+            load_bfloat4(args.x, input_offset),
+            weight);
+      }
+    }
+    for (; k < group_end; ++k) {
+      const float weight = lut[unpack_adaln_index(packed_row, k)];
+#pragma clang loop unroll(full)
+      for (int row = 0; row < row_tile; ++row) {
+        tails[row] += load_bfloat(
+            args.x,
+            (row_start + row) * args.in_features + k) * weight;
+      }
+    }
+  }
+
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    float accumulator = vaddvq_f32(accumulators[row]) + tails[row];
+    if (args.has_bias) {
+      accumulator += args.bias[out_col];
+    }
+    store_bfloat(
+        args.out,
+        (row_start + row) * args.out_features + out_col,
+        accumulator);
+  }
+}
+
+void packed_adaln_neon_range(
+    AdalnArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  if (args.group_size % 4 != 0 || args.padded_in_features % 2 != 0) {
+    packed_adaln_scalar_range(args, out_start, out_end);
+    return;
+  }
+  constexpr int kPrimaryRowTile = 8;
+  const std::int64_t packed_row_bytes = args.padded_in_features / 2;
+  for (std::int64_t out_col = out_start; out_col < out_end; ++out_col) {
+    const auto *packed_row =
+        args.packed_weight + out_col * packed_row_bytes;
+    const auto *scale_row =
+        args.scales + out_col * args.num_groups;
+    std::int64_t row = 0;
+    for (; row + kPrimaryRowTile <= args.rows; row += kPrimaryRowTile) {
+      packed_adaln_neon_rows<kPrimaryRowTile>(
+          args, packed_row, scale_row, out_col, row);
+    }
+    if (row + 4 <= args.rows) {
+      packed_adaln_neon_rows<4>(
+          args, packed_row, scale_row, out_col, row);
+      row += 4;
+    }
+    switch (args.rows - row) {
+      case 3:
+        packed_adaln_neon_rows<3>(
+            args, packed_row, scale_row, out_col, row);
+        break;
+      case 2:
+        packed_adaln_neon_rows<2>(
+            args, packed_row, scale_row, out_col, row);
+        break;
+      case 1:
+        packed_adaln_neon_rows<1>(
+            args, packed_row, scale_row, out_col, row);
+        break;
+      default:
+        break;
+    }
+  }
+}
+#else
+void packed_adaln_neon_range(
+    AdalnArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  packed_adaln_scalar_range(args, out_start, out_end);
+}
+#endif
+
+#if (defined(__x86_64__) || defined(_M_X64)) && !defined(_MSC_VER)
+ORBITQUANT_TARGET_AVX2 inline __m256 load_bfloat8(
+    void const *data,
+    std::int64_t offset) {
+  const auto *source =
+      static_cast<std::uint16_t const *>(data) + offset;
+  const __m128i packed =
+      _mm_loadu_si128(reinterpret_cast<__m128i const *>(source));
+  return _mm256_castsi256_ps(
+      _mm256_slli_epi32(_mm256_cvtepu16_epi32(packed), 16));
+}
+
+ORBITQUANT_TARGET_AVX512 inline __m512 load_bfloat16(
+    void const *data,
+    std::int64_t offset) {
+  const auto *source =
+      static_cast<std::uint16_t const *>(data) + offset;
+  const __m256i packed =
+      _mm256_loadu_si256(reinterpret_cast<__m256i const *>(source));
+  return _mm512_castsi512_ps(
+      _mm512_slli_epi32(_mm512_cvtepu16_epi32(packed), 16));
+}
+
+ORBITQUANT_TARGET_AVX2 inline float horizontal_sum(__m256 value) {
+  const __m128 halves = _mm_add_ps(
+      _mm256_castps256_ps128(value),
+      _mm256_extractf128_ps(value, 1));
+  const __m128 pairs = _mm_hadd_ps(halves, halves);
+  return _mm_cvtss_f32(_mm_hadd_ps(pairs, pairs));
+}
+
+ORBITQUANT_TARGET_AVX512 inline float horizontal_sum(__m512 value) {
+  return _mm512_reduce_add_ps(value);
+}
+
+template <int row_tile>
+ORBITQUANT_TARGET_AVX2 inline void packed_adaln_avx2_rows(
+    AdalnArgs const &args,
+    std::uint8_t const *packed_row,
+    float const *scale_row,
+    std::int64_t out_col,
+    std::int64_t row_start) {
+  __m256 accumulators[row_tile];
+  float tails[row_tile]{};
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    accumulators[row] = _mm256_setzero_ps();
+  }
+  const __m128i nibble_mask = _mm_set1_epi8(15);
+  const __m256i low_table_limit = _mm256_set1_epi32(7);
+
+  for (std::int64_t group = 0; group < args.num_groups; ++group) {
+    float lut[16];
+    fill_group_lut(lut, scale_row[group]);
+    const __m256 lut_low = _mm256_loadu_ps(lut);
+    const __m256 lut_high = _mm256_loadu_ps(lut + 8);
+    const std::int64_t group_start = group * args.group_size;
+    const std::int64_t group_end = std::min(
+        args.in_features,
+        group_start + args.group_size);
+    std::int64_t k = group_start;
+    for (; k + 8 <= group_end; k += 8) {
+      std::int32_t packed;
+      std::memcpy(&packed, packed_row + k / 2, sizeof(packed));
+      const __m128i bytes = _mm_cvtsi32_si128(packed);
+      const __m128i low = _mm_and_si128(bytes, nibble_mask);
+      const __m128i high = _mm_and_si128(
+          _mm_srli_epi16(bytes, 4),
+          nibble_mask);
+      const __m256i indices =
+          _mm256_cvtepu8_epi32(_mm_unpacklo_epi8(low, high));
+      const __m256 weight = _mm256_blendv_ps(
+          _mm256_permutevar8x32_ps(lut_low, indices),
+          _mm256_permutevar8x32_ps(lut_high, indices),
+          _mm256_castsi256_ps(
+              _mm256_cmpgt_epi32(indices, low_table_limit)));
+#pragma clang loop unroll(full)
+      for (int row = 0; row < row_tile; ++row) {
+        const std::int64_t input_offset =
+            (row_start + row) * args.in_features + k;
+        accumulators[row] = _mm256_fmadd_ps(
+            load_bfloat8(args.x, input_offset),
+            weight,
+            accumulators[row]);
+      }
+    }
+    for (; k < group_end; ++k) {
+      const float weight = lut[unpack_adaln_index(packed_row, k)];
+#pragma clang loop unroll(full)
+      for (int row = 0; row < row_tile; ++row) {
+        tails[row] += load_bfloat(
+            args.x,
+            (row_start + row) * args.in_features + k) * weight;
+      }
+    }
+  }
+
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    float accumulator = horizontal_sum(accumulators[row]) + tails[row];
+    if (args.has_bias) {
+      accumulator += args.bias[out_col];
+    }
+    store_bfloat(
+        args.out,
+        (row_start + row) * args.out_features + out_col,
+        accumulator);
+  }
+}
+
+template <int row_tile>
+ORBITQUANT_TARGET_AVX512 inline void packed_adaln_avx512_rows(
+    AdalnArgs const &args,
+    std::uint8_t const *packed_row,
+    float const *scale_row,
+    std::int64_t out_col,
+    std::int64_t row_start) {
+  __m512 accumulators[row_tile];
+  float tails[row_tile]{};
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    accumulators[row] = _mm512_setzero_ps();
+  }
+  const __m128i nibble_mask = _mm_set1_epi8(15);
+
+  for (std::int64_t group = 0; group < args.num_groups; ++group) {
+    float lut[16];
+    fill_group_lut(lut, scale_row[group]);
+    const __m512 centroid_lut = _mm512_loadu_ps(lut);
+    const std::int64_t group_start = group * args.group_size;
+    const std::int64_t group_end = std::min(
+        args.in_features,
+        group_start + args.group_size);
+    std::int64_t k = group_start;
+    for (; k + 16 <= group_end; k += 16) {
+      std::int64_t packed;
+      std::memcpy(&packed, packed_row + k / 2, sizeof(packed));
+      const __m128i bytes = _mm_cvtsi64_si128(packed);
+      const __m128i low = _mm_and_si128(bytes, nibble_mask);
+      const __m128i high = _mm_and_si128(
+          _mm_srli_epi16(bytes, 4),
+          nibble_mask);
+      const __m512i indices =
+          _mm512_cvtepu8_epi32(_mm_unpacklo_epi8(low, high));
+      const __m512 weight =
+          _mm512_permutexvar_ps(indices, centroid_lut);
+#pragma clang loop unroll(full)
+      for (int row = 0; row < row_tile; ++row) {
+        const std::int64_t input_offset =
+            (row_start + row) * args.in_features + k;
+        accumulators[row] = _mm512_fmadd_ps(
+            load_bfloat16(args.x, input_offset),
+            weight,
+            accumulators[row]);
+      }
+    }
+    for (; k < group_end; ++k) {
+      const float weight = lut[unpack_adaln_index(packed_row, k)];
+#pragma clang loop unroll(full)
+      for (int row = 0; row < row_tile; ++row) {
+        tails[row] += load_bfloat(
+            args.x,
+            (row_start + row) * args.in_features + k) * weight;
+      }
+    }
+  }
+
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    float accumulator = horizontal_sum(accumulators[row]) + tails[row];
+    if (args.has_bias) {
+      accumulator += args.bias[out_col];
+    }
+    store_bfloat(
+        args.out,
+        (row_start + row) * args.out_features + out_col,
+        accumulator);
+  }
+}
+
+#if defined(ORBITQUANT_HAS_AVX512_BF16_INTRINSICS)
+template <bool aligned_k>
+ORBITQUANT_TARGET_AVX512_BF16 inline __m512bh load_bfloat32(
+    std::uint16_t const *data,
+    __mmask32 valid_mask) {
+  if constexpr (aligned_k) {
+    return (__m512bh)_mm512_loadu_si512(data);
+  }
+  return (__m512bh)_mm512_maskz_loadu_epi16(valid_mask, data);
+}
+
+template <int row_tile, bool aligned_k>
+ORBITQUANT_TARGET_AVX512_BF16 inline void packed_adaln_avx512_bf16_rows(
+    AdalnArgs const &args,
+    std::uint8_t const *packed_row,
+    float const *scale_row,
+    std::int64_t out_col,
+    std::int64_t row_start) {
+  static_assert(row_tile >= 1 && row_tile <= 8);
+  __m512 accumulator0 = _mm512_setzero_ps();
+  __m512 accumulator1 = _mm512_setzero_ps();
+  __m512 accumulator2 = _mm512_setzero_ps();
+  __m512 accumulator3 = _mm512_setzero_ps();
+  __m512 accumulator4 = _mm512_setzero_ps();
+  __m512 accumulator5 = _mm512_setzero_ps();
+  __m512 accumulator6 = _mm512_setzero_ps();
+  __m512 accumulator7 = _mm512_setzero_ps();
+  const __m128i nibble_mask = _mm_set1_epi8(15);
+  const __m512 signed_codes = _mm512_setr_ps(
+      -8.0f, -7.0f, -6.0f, -5.0f,
+      -4.0f, -3.0f, -2.0f, -1.0f,
+      0.0f, 1.0f, 2.0f, 3.0f,
+      4.0f, 5.0f, 6.0f, 7.0f);
+  const auto *input_base =
+      static_cast<std::uint16_t const *>(args.x) +
+      row_start * args.in_features;
+  const std::int64_t input_stride = args.in_features;
+
+  for (std::int64_t group = 0; group < args.num_groups; ++group) {
+    const __m512 scaled_codes = _mm512_mul_ps(
+        signed_codes,
+        _mm512_set1_ps(scale_row[group]));
+    const __m512i lut_words = (__m512i)_mm512_cvtne2ps_pbh(
+        scaled_codes,
+        scaled_codes);
+    const std::int64_t group_start = group * args.group_size;
+    for (std::int64_t offset = 0; offset < args.group_size; offset += 32) {
+      const std::int64_t k = group_start + offset;
+      __mmask32 valid_mask = static_cast<__mmask32>(0xffffffffu);
+      if constexpr (!aligned_k) {
+        const std::int64_t valid = std::max<std::int64_t>(
+            0,
+            std::min<std::int64_t>(32, args.in_features - k));
+        if (valid == 0) {
+          continue;
+        }
+        valid_mask = valid == 32
+            ? static_cast<__mmask32>(0xffffffffu)
+            : static_cast<__mmask32>((1u << valid) - 1u);
+      }
+      const __m128i bytes = _mm_loadu_si128(
+          reinterpret_cast<__m128i const *>(packed_row + k / 2));
+      const __m128i low = _mm_and_si128(bytes, nibble_mask);
+      const __m128i high = _mm_and_si128(
+          _mm_srli_epi16(bytes, 4),
+          nibble_mask);
+      const __m256i packed_indices = _mm256_set_m128i(
+          _mm_unpackhi_epi8(low, high),
+          _mm_unpacklo_epi8(low, high));
+      const __m512i indices =
+          _mm512_cvtepu8_epi16(packed_indices);
+      const __m512bh weights = (__m512bh)_mm512_permutexvar_epi16(
+          indices,
+          lut_words);
+      accumulator0 = _mm512_dpbf16_ps(
+          accumulator0,
+          load_bfloat32<aligned_k>(input_base + k, valid_mask),
+          weights);
+      if constexpr (row_tile > 1) {
+        accumulator1 = _mm512_dpbf16_ps(
+            accumulator1,
+            load_bfloat32<aligned_k>(
+                input_base + input_stride + k,
+                valid_mask),
+            weights);
+      }
+      if constexpr (row_tile > 2) {
+        accumulator2 = _mm512_dpbf16_ps(
+            accumulator2,
+            load_bfloat32<aligned_k>(
+                input_base + 2 * input_stride + k,
+                valid_mask),
+            weights);
+      }
+      if constexpr (row_tile > 3) {
+        accumulator3 = _mm512_dpbf16_ps(
+            accumulator3,
+            load_bfloat32<aligned_k>(
+                input_base + 3 * input_stride + k,
+                valid_mask),
+            weights);
+      }
+      if constexpr (row_tile > 4) {
+        accumulator4 = _mm512_dpbf16_ps(
+            accumulator4,
+            load_bfloat32<aligned_k>(
+                input_base + 4 * input_stride + k,
+                valid_mask),
+            weights);
+      }
+      if constexpr (row_tile > 5) {
+        accumulator5 = _mm512_dpbf16_ps(
+            accumulator5,
+            load_bfloat32<aligned_k>(
+                input_base + 5 * input_stride + k,
+                valid_mask),
+            weights);
+      }
+      if constexpr (row_tile > 6) {
+        accumulator6 = _mm512_dpbf16_ps(
+            accumulator6,
+            load_bfloat32<aligned_k>(
+                input_base + 6 * input_stride + k,
+                valid_mask),
+            weights);
+      }
+      if constexpr (row_tile > 7) {
+        accumulator7 = _mm512_dpbf16_ps(
+            accumulator7,
+            load_bfloat32<aligned_k>(
+                input_base + 7 * input_stride + k,
+                valid_mask),
+            weights);
+      }
+    }
+  }
+
+  const float bias = args.has_bias ? args.bias[out_col] : 0.0f;
+  const std::int64_t output_offset =
+      row_start * args.out_features + out_col;
+  store_bfloat(
+      args.out,
+      output_offset,
+      horizontal_sum(accumulator0) + bias);
+  if constexpr (row_tile > 1) {
+    store_bfloat(
+        args.out,
+        output_offset + args.out_features,
+        horizontal_sum(accumulator1) + bias);
+  }
+  if constexpr (row_tile > 2) {
+    store_bfloat(
+        args.out,
+        output_offset + 2 * args.out_features,
+        horizontal_sum(accumulator2) + bias);
+  }
+  if constexpr (row_tile > 3) {
+    store_bfloat(
+        args.out,
+        output_offset + 3 * args.out_features,
+        horizontal_sum(accumulator3) + bias);
+  }
+  if constexpr (row_tile > 4) {
+    store_bfloat(
+        args.out,
+        output_offset + 4 * args.out_features,
+        horizontal_sum(accumulator4) + bias);
+  }
+  if constexpr (row_tile > 5) {
+    store_bfloat(
+        args.out,
+        output_offset + 5 * args.out_features,
+        horizontal_sum(accumulator5) + bias);
+  }
+  if constexpr (row_tile > 6) {
+    store_bfloat(
+        args.out,
+        output_offset + 6 * args.out_features,
+        horizontal_sum(accumulator6) + bias);
+  }
+  if constexpr (row_tile > 7) {
+    store_bfloat(
+        args.out,
+        output_offset + 7 * args.out_features,
+        horizontal_sum(accumulator7) + bias);
+  }
+}
+
+bool adaln_avx512_bf16_available() {
+  __builtin_cpu_init();
+  return orbitquant::cpu::packed_matmul_x86_avx512_available() &&
+      __builtin_cpu_supports("avx512bf16");
+}
+#else
+bool adaln_avx512_bf16_available() {
+  return false;
+}
+#endif
+
+template <
+    void (*rows8)(AdalnArgs const &, std::uint8_t const *, float const *, std::int64_t, std::int64_t),
+    void (*rows4)(AdalnArgs const &, std::uint8_t const *, float const *, std::int64_t, std::int64_t),
+    void (*rows3)(AdalnArgs const &, std::uint8_t const *, float const *, std::int64_t, std::int64_t),
+    void (*rows2)(AdalnArgs const &, std::uint8_t const *, float const *, std::int64_t, std::int64_t),
+    void (*rows1)(AdalnArgs const &, std::uint8_t const *, float const *, std::int64_t, std::int64_t)>
+void packed_adaln_x86_tiled_range(
+    AdalnArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  const std::int64_t packed_row_bytes = args.padded_in_features / 2;
+  for (std::int64_t out_col = out_start; out_col < out_end; ++out_col) {
+    const auto *packed_row =
+        args.packed_weight + out_col * packed_row_bytes;
+    const auto *scale_row =
+        args.scales + out_col * args.num_groups;
+    std::int64_t row = 0;
+    for (; row + 8 <= args.rows; row += 8) {
+      rows8(args, packed_row, scale_row, out_col, row);
+    }
+    if (row + 4 <= args.rows) {
+      rows4(args, packed_row, scale_row, out_col, row);
+      row += 4;
+    }
+    switch (args.rows - row) {
+      case 3:
+        rows3(args, packed_row, scale_row, out_col, row);
+        break;
+      case 2:
+        rows2(args, packed_row, scale_row, out_col, row);
+        break;
+      case 1:
+        rows1(args, packed_row, scale_row, out_col, row);
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+void packed_adaln_avx2_range(
+    AdalnArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  if (args.group_size % 8 != 0 || args.padded_in_features % 2 != 0) {
+    packed_adaln_scalar_range(args, out_start, out_end);
+    return;
+  }
+  packed_adaln_x86_tiled_range<
+      packed_adaln_avx2_rows<8>,
+      packed_adaln_avx2_rows<4>,
+      packed_adaln_avx2_rows<3>,
+      packed_adaln_avx2_rows<2>,
+      packed_adaln_avx2_rows<1>>(args, out_start, out_end);
+}
+
+void packed_adaln_avx512_range(
+    AdalnArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+#if defined(ORBITQUANT_HAS_AVX512_BF16_INTRINSICS)
+  if (args.group_size % 32 == 0 &&
+      args.padded_in_features % 2 == 0 &&
+      adaln_avx512_bf16_available()) {
+    if (args.in_features % args.group_size == 0) {
+      packed_adaln_x86_tiled_range<
+          packed_adaln_avx512_bf16_rows<8, true>,
+          packed_adaln_avx512_bf16_rows<4, true>,
+          packed_adaln_avx512_bf16_rows<3, true>,
+          packed_adaln_avx512_bf16_rows<2, true>,
+          packed_adaln_avx512_bf16_rows<1, true>>(args, out_start, out_end);
+      return;
+    }
+    packed_adaln_x86_tiled_range<
+        packed_adaln_avx512_bf16_rows<8, false>,
+        packed_adaln_avx512_bf16_rows<4, false>,
+        packed_adaln_avx512_bf16_rows<3, false>,
+        packed_adaln_avx512_bf16_rows<2, false>,
+        packed_adaln_avx512_bf16_rows<1, false>>(args, out_start, out_end);
+    return;
+  }
+#endif
+  if (args.group_size % 16 != 0 || args.padded_in_features % 2 != 0) {
+    packed_adaln_scalar_range(args, out_start, out_end);
+    return;
+  }
+  packed_adaln_x86_tiled_range<
+      packed_adaln_avx512_rows<8>,
+      packed_adaln_avx512_rows<4>,
+      packed_adaln_avx512_rows<3>,
+      packed_adaln_avx512_rows<2>,
+      packed_adaln_avx512_rows<1>>(args, out_start, out_end);
+}
+#else
+void packed_adaln_avx2_range(
+    AdalnArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  packed_adaln_scalar_range(args, out_start, out_end);
+}
+
+void packed_adaln_avx512_range(
+    AdalnArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  packed_adaln_scalar_range(args, out_start, out_end);
+}
+#endif
+
+AdalnRangeFn select_adaln_kernel() {
+  const char *requested = std::getenv("ORBITQUANT_CPU_ISA");
+  if (requested == nullptr || std::strcmp(requested, "auto") == 0) {
+    if (orbitquant::cpu::packed_matmul_x86_avx512_available()) {
+      return packed_adaln_avx512_range;
+    }
+    if (orbitquant::cpu::packed_matmul_x86_avx2_available()) {
+#if defined(_MSC_VER) && defined(_M_X64)
+      return orbitquant::cpu::packed_adaln_msvc_avx2_range;
+#else
+      return packed_adaln_avx2_range;
+#endif
+    }
+    if (orbitquant::cpu::packed_matmul_neon_available()) {
+      return packed_adaln_neon_range;
+    }
+    return packed_adaln_scalar_range;
+  }
+  if (std::strcmp(requested, "scalar") == 0) {
+    return packed_adaln_scalar_range;
+  }
+  if (std::strcmp(requested, "avx2") == 0) {
+    STD_TORCH_CHECK(
+        orbitquant::cpu::packed_matmul_x86_avx2_available(),
+        "ORBITQUANT_CPU_ISA=avx2 requested AVX2/FMA/F16C on an unsupported CPU");
+#if defined(_MSC_VER) && defined(_M_X64)
+    return orbitquant::cpu::packed_adaln_msvc_avx2_range;
+#else
+    return packed_adaln_avx2_range;
+#endif
+  }
+  if (std::strcmp(requested, "avx512") == 0) {
+    STD_TORCH_CHECK(
+        orbitquant::cpu::packed_matmul_x86_avx512_available(),
+        "ORBITQUANT_CPU_ISA=avx512 requested AVX-512F/DQ/BW/VL on an unsupported CPU");
+    return packed_adaln_avx512_range;
+  }
+  if (std::strcmp(requested, "neon") == 0) {
+    STD_TORCH_CHECK(
+        orbitquant::cpu::packed_matmul_neon_available(),
+        "ORBITQUANT_CPU_ISA=neon requested NEON on an unsupported CPU");
+    return packed_adaln_neon_range;
+  }
+  STD_TORCH_CHECK(
+      false,
+      "ORBITQUANT_CPU_ISA must be auto, scalar, avx2, avx512, or neon");
+  return packed_adaln_scalar_range;
+}
+
+void parallel_packed_adaln(
+    AdalnArgs const &args,
+    AdalnRangeFn function) {
+  const std::int64_t arithmetic =
+      args.rows * args.out_features * args.in_features;
+  const int max_threads = orbitquant::cpu::requested_threads();
+  const int threads = arithmetic < 1'000'000
+      ? 1
+      : std::max<int>(
+            1,
+            std::min<std::int64_t>(
+                max_threads,
+                args.out_features / 16));
+  if (threads == 1) {
+    function(args, 0, args.out_features);
+    return;
+  }
+
+  std::vector<std::thread> workers;
+  workers.reserve(threads);
+  const std::int64_t columns_per_thread =
+      (args.out_features + threads - 1) / threads;
+  for (int thread = 0; thread < threads; ++thread) {
+    const std::int64_t start = thread * columns_per_thread;
+    const std::int64_t end = std::min(
+        args.out_features,
+        start + columns_per_thread);
+    if (start >= end) {
+      break;
+    }
+    workers.emplace_back([&args, function, start, end] {
+      function(args, start, end);
+    });
+  }
+  for (auto &worker : workers) {
+    worker.join();
+  }
+}
+
+}  // namespace
+
+void matmul_packed_adaln_int4_cpu(
+    OrbitQuantTensor &out,
+    OrbitQuantTensor const &x,
+    OrbitQuantTensor const &packed_weight,
+    OrbitQuantTensor const &scales,
+    OrbitQuantTensor const &bias,
+    bool has_bias,
+    int64_t out_features,
+    int64_t in_features,
+    int64_t group_size) {
+  using torch::headeronly::DeviceType;
+  using torch::headeronly::ScalarType;
+
+  STD_TORCH_CHECK(x.device().type() == DeviceType::CPU, "x must be a CPU tensor");
+  STD_TORCH_CHECK(out.device().type() == DeviceType::CPU, "out must be a CPU tensor");
+  STD_TORCH_CHECK(
+      packed_weight.device().type() == DeviceType::CPU,
+      "packed_weight must be a CPU tensor");
+  STD_TORCH_CHECK(
+      scales.device().type() == DeviceType::CPU,
+      "scales must be a CPU tensor");
+  STD_TORCH_CHECK(x.is_contiguous(), "x must be contiguous");
+  STD_TORCH_CHECK(out.is_contiguous(), "out must be contiguous");
+  STD_TORCH_CHECK(packed_weight.is_contiguous(), "packed_weight must be contiguous");
+  STD_TORCH_CHECK(scales.is_contiguous(), "scales must be contiguous");
+  STD_TORCH_CHECK(x.scalar_type() == ScalarType::BFloat16, "x must be bfloat16");
+  STD_TORCH_CHECK(out.scalar_type() == ScalarType::BFloat16, "out must be bfloat16");
+  STD_TORCH_CHECK(
+      packed_weight.scalar_type() == ScalarType::Byte,
+      "packed_weight must be uint8");
+  STD_TORCH_CHECK(scales.scalar_type() == ScalarType::Float, "scales must be float32");
+  STD_TORCH_CHECK(x.dim() == 2, "x must be rank 2");
+  STD_TORCH_CHECK(out.dim() == 2, "out must be rank 2");
+  STD_TORCH_CHECK(group_size > 0, "group_size must be positive");
+  STD_TORCH_CHECK(x.size(1) == in_features, "x has an unexpected input dimension");
+  STD_TORCH_CHECK(out.size(0) == x.size(0), "out has an unexpected row count");
+  STD_TORCH_CHECK(out.size(1) == out_features, "out has an unexpected output dimension");
+  const int64_t num_groups = (in_features + group_size - 1) / group_size;
+  const int64_t padded_in_features = num_groups * group_size;
+  const int64_t packed_values = out_features * padded_in_features;
+  STD_TORCH_CHECK(
+      packed_weight.numel() >= (packed_values + 1) / 2,
+      "packed_weight is too short");
+  STD_TORCH_CHECK(
+      scales.numel() == out_features * num_groups,
+      "scales must match out_features and num_groups");
+  if (has_bias) {
+    STD_TORCH_CHECK(bias.device().type() == DeviceType::CPU, "bias must be a CPU tensor");
+    STD_TORCH_CHECK(bias.is_contiguous(), "bias must be contiguous");
+    STD_TORCH_CHECK(bias.scalar_type() == ScalarType::Float, "bias must be float32");
+    STD_TORCH_CHECK(bias.numel() == out_features, "bias must match out_features");
+  }
+  if (x.numel() == 0 || out_features == 0) {
+    return;
+  }
+
+  const AdalnArgs args{
+      out.mutable_data_ptr(),
+      x.const_data_ptr(),
+      packed_weight.const_data_ptr<std::uint8_t>(),
+      scales.const_data_ptr<float>(),
+      has_bias ? bias.const_data_ptr<float>() : nullptr,
+      has_bias,
+      x.size(0),
+      out_features,
+      in_features,
+      group_size,
+      num_groups,
+      padded_in_features,
+  };
+  parallel_packed_adaln(args, select_adaln_kernel());
+}

--- a/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_matmul_cpu.cpp
+++ b/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_matmul_cpu.cpp
@@ -1,0 +1,200 @@
+#include "cpu_threads.h"
+#include "packed_matmul_cpu.h"
+#include "../torch-ext/torch_binding.h"
+
+#include <torch/headeronly/core/DeviceType.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/macros/Macros.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <thread>
+#include <vector>
+
+namespace {
+
+orbitquant::cpu::ScalarKind scalar_kind(OrbitQuantTensor const &tensor) {
+  using torch::headeronly::ScalarType;
+  switch (tensor.scalar_type()) {
+    case ScalarType::Float:
+      return orbitquant::cpu::ScalarKind::Float32;
+    case ScalarType::Half:
+      return orbitquant::cpu::ScalarKind::Float16;
+    case ScalarType::BFloat16:
+      return orbitquant::cpu::ScalarKind::BFloat16;
+    default:
+      STD_TORCH_CHECK(
+          false,
+          "CPU packed matmul supports float32, float16, and bfloat16 inputs");
+  }
+  return orbitquant::cpu::ScalarKind::Float32;
+}
+
+void parallel_packed_matmul(
+    orbitquant::cpu::PackedMatmulArgs const &args,
+    orbitquant::cpu::PackedMatmulRangeFn function) {
+  const std::int64_t arithmetic =
+      args.rows * args.out_features * args.in_features;
+  const int max_threads = orbitquant::cpu::requested_threads();
+  const int threads = arithmetic < 1'000'000
+      ? 1
+      : std::max<int>(
+            1,
+            std::min<std::int64_t>(max_threads, args.out_features / 16));
+  if (threads == 1) {
+    function(args, 0, args.out_features);
+    return;
+  }
+
+  std::vector<std::thread> workers;
+  workers.reserve(threads);
+  const std::int64_t columns_per_thread =
+      (args.out_features + threads - 1) / threads;
+  for (int thread = 0; thread < threads; ++thread) {
+    const std::int64_t start = thread * columns_per_thread;
+    const std::int64_t end = std::min(
+        args.out_features,
+        start + columns_per_thread);
+    if (start >= end) {
+      break;
+    }
+    workers.emplace_back([&args, function, start, end] {
+      function(args, start, end);
+    });
+  }
+  for (auto &worker : workers) {
+    worker.join();
+  }
+}
+
+orbitquant::cpu::PackedMatmulRangeFn select_packed_matmul() {
+  const char *requested = std::getenv("ORBITQUANT_CPU_ISA");
+  if (requested == nullptr || std::strcmp(requested, "auto") == 0) {
+    if (orbitquant::cpu::packed_matmul_x86_avx512_available()) {
+      return orbitquant::cpu::packed_matmul_x86_avx512_range;
+    }
+    if (orbitquant::cpu::packed_matmul_x86_avx2_available()) {
+      return orbitquant::cpu::packed_matmul_x86_avx2_range;
+    }
+    if (orbitquant::cpu::packed_matmul_neon_available()) {
+      return orbitquant::cpu::packed_matmul_neon_range;
+    }
+    return orbitquant::cpu::packed_matmul_scalar_range;
+  }
+  if (std::strcmp(requested, "scalar") == 0) {
+    return orbitquant::cpu::packed_matmul_scalar_range;
+  }
+  if (std::strcmp(requested, "avx2") == 0) {
+    STD_TORCH_CHECK(
+        orbitquant::cpu::packed_matmul_x86_avx2_available(),
+        "ORBITQUANT_CPU_ISA=avx2 requested AVX2/FMA/F16C on an unsupported CPU");
+    return orbitquant::cpu::packed_matmul_x86_avx2_range;
+  }
+  if (std::strcmp(requested, "avx512") == 0) {
+    STD_TORCH_CHECK(
+        orbitquant::cpu::packed_matmul_x86_avx512_available(),
+        "ORBITQUANT_CPU_ISA=avx512 requested AVX-512F/DQ/BW/VL on an unsupported CPU");
+    return orbitquant::cpu::packed_matmul_x86_avx512_range;
+  }
+  if (std::strcmp(requested, "neon") == 0) {
+    STD_TORCH_CHECK(
+        orbitquant::cpu::packed_matmul_neon_available(),
+        "ORBITQUANT_CPU_ISA=neon requested NEON on an unsupported CPU");
+    return orbitquant::cpu::packed_matmul_neon_range;
+  }
+  STD_TORCH_CHECK(
+      false,
+      "ORBITQUANT_CPU_ISA must be auto, scalar, avx2, avx512, or neon");
+  return orbitquant::cpu::packed_matmul_scalar_range;
+}
+
+}  // namespace
+
+void matmul_packed_weight(
+    OrbitQuantTensor &out,
+    OrbitQuantTensor const &x,
+    OrbitQuantTensor const &packed_weight_indices,
+    OrbitQuantTensor const &row_norms,
+    OrbitQuantTensor const &centroids,
+    OrbitQuantTensor const &bias,
+    bool has_bias,
+    int64_t bits,
+    int64_t out_features,
+    int64_t in_features,
+    int64_t block_m,
+    int64_t block_n,
+    int64_t block_k) {
+  using torch::headeronly::DeviceType;
+  using torch::headeronly::ScalarType;
+
+  STD_TORCH_CHECK(x.device().type() == DeviceType::CPU, "x must be a CPU tensor");
+  STD_TORCH_CHECK(out.device().type() == DeviceType::CPU, "out must be a CPU tensor");
+  STD_TORCH_CHECK(
+      packed_weight_indices.device().type() == DeviceType::CPU,
+      "packed weights must be CPU tensors");
+  STD_TORCH_CHECK(
+      row_norms.device().type() == DeviceType::CPU,
+      "row norms must be CPU tensors");
+  STD_TORCH_CHECK(
+      centroids.device().type() == DeviceType::CPU,
+      "centroids must be CPU tensors");
+  STD_TORCH_CHECK(x.is_contiguous(), "x must be contiguous");
+  STD_TORCH_CHECK(out.is_contiguous(), "out must be contiguous");
+  STD_TORCH_CHECK(
+      packed_weight_indices.is_contiguous(), "packed weights must be contiguous");
+  STD_TORCH_CHECK(row_norms.is_contiguous(), "row norms must be contiguous");
+  STD_TORCH_CHECK(centroids.is_contiguous(), "centroids must be contiguous");
+  STD_TORCH_CHECK(
+      packed_weight_indices.scalar_type() == ScalarType::Byte,
+      "packed weights must be uint8");
+  STD_TORCH_CHECK(
+      row_norms.scalar_type() == ScalarType::Float,
+      "row_norms must be float32");
+  STD_TORCH_CHECK(
+      centroids.scalar_type() == ScalarType::Float,
+      "centroids must be float32");
+  STD_TORCH_CHECK(out.scalar_type() == x.scalar_type(), "out dtype must match x dtype");
+  STD_TORCH_CHECK(x.dim() == 2, "x must be rank 2");
+  STD_TORCH_CHECK(out.dim() == 2, "out must be rank 2");
+  STD_TORCH_CHECK(bits > 0 && bits <= 8, "bits must be in [1, 8]");
+  STD_TORCH_CHECK(block_m > 0 && block_n > 0 && block_k > 0, "tile sizes must be positive");
+  STD_TORCH_CHECK(x.size(1) == in_features, "x has an unexpected input dimension");
+  STD_TORCH_CHECK(out.size(0) == x.size(0), "out has an unexpected row count");
+  STD_TORCH_CHECK(out.size(1) == out_features, "out has an unexpected output dimension");
+  STD_TORCH_CHECK(row_norms.numel() == out_features, "row_norms must match out_features");
+  STD_TORCH_CHECK(centroids.numel() >= (1LL << bits), "centroids are too short");
+  const int64_t packed_bytes = (out_features * in_features * bits + 7) / 8;
+  STD_TORCH_CHECK(
+      packed_weight_indices.numel() >= packed_bytes,
+      "packed weights are too short");
+  if (has_bias) {
+    STD_TORCH_CHECK(
+        bias.device().type() == DeviceType::CPU,
+        "bias must be a CPU tensor");
+    STD_TORCH_CHECK(bias.is_contiguous(), "bias must be contiguous");
+    STD_TORCH_CHECK(
+        bias.scalar_type() == ScalarType::Float,
+        "bias must be float32");
+    STD_TORCH_CHECK(bias.numel() == out_features, "bias must match out_features");
+  }
+  if (x.numel() == 0 || out_features == 0) {
+    return;
+  }
+
+  orbitquant::cpu::PackedMatmulArgs args{
+      out.mutable_data_ptr(),
+      x.const_data_ptr(),
+      packed_weight_indices.const_data_ptr<std::uint8_t>(),
+      row_norms.const_data_ptr<float>(),
+      centroids.const_data_ptr<float>(),
+      has_bias ? bias.const_data_ptr<float>() : nullptr,
+      has_bias,
+      scalar_kind(x),
+      x.size(0),
+      out_features,
+      in_features,
+      bits,
+  };
+  parallel_packed_matmul(args, select_packed_matmul());
+}

--- a/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_matmul_cpu.h
+++ b/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_matmul_cpu.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <cstdint>
+
+namespace orbitquant::cpu {
+
+enum class ScalarKind : std::uint8_t {
+  Float32,
+  Float16,
+  BFloat16,
+};
+
+struct PackedMatmulArgs {
+  void *out;
+  void const *x;
+  std::uint8_t const *packed_weight_indices;
+  float const *row_norms;
+  float const *centroids;
+  float const *bias;
+  bool has_bias;
+  ScalarKind scalar_kind;
+  std::int64_t rows;
+  std::int64_t out_features;
+  std::int64_t in_features;
+  std::int64_t bits;
+};
+
+using PackedMatmulRangeFn = void (*)(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end);
+
+void packed_matmul_scalar_range(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end);
+
+bool packed_matmul_neon_available();
+
+void packed_matmul_neon_range(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end);
+
+bool packed_matmul_x86_avx2_available();
+
+void packed_matmul_x86_avx2_range(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end);
+
+bool packed_matmul_x86_avx512_available();
+
+void packed_matmul_x86_avx512_range(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end);
+
+}  // namespace orbitquant::cpu

--- a/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_matmul_neon.cpp
+++ b/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_matmul_neon.cpp
@@ -1,0 +1,216 @@
+#include "packed_matmul_cpu.h"
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+#include <arm_neon.h>
+
+#include <torch/headeronly/util/BFloat16.h>
+#include <torch/headeronly/util/Half.h>
+
+#include <type_traits>
+
+namespace orbitquant::cpu {
+namespace {
+
+inline float horizontal_sum(float32x4_t value) {
+#if defined(__aarch64__)
+  return vaddvq_f32(value);
+#else
+  const float32x2_t pair = vadd_f32(vget_low_f32(value), vget_high_f32(value));
+  return vget_lane_f32(vpadd_f32(pair, pair), 0);
+#endif
+}
+
+inline float32x4_t load_float4(void const *data, std::int64_t offset) {
+  return vld1q_f32(static_cast<float const *>(data) + offset);
+}
+
+inline float32x4_t load_half4(void const *data, std::int64_t offset) {
+  const auto *source = reinterpret_cast<float16_t const *>(
+      static_cast<std::uint16_t const *>(data) + offset);
+  return vcvt_f32_f16(vld1_f16(source));
+}
+
+inline float32x4_t load_bfloat4(void const *data, std::int64_t offset) {
+  const uint16x4_t raw = vld1_u16(
+      static_cast<std::uint16_t const *>(data) + offset);
+  return vreinterpretq_f32_u32(vshlq_n_u32(vmovl_u16(raw), 16));
+}
+
+template <typename scalar_t>
+inline void store_value(void *data, std::int64_t offset, float value) {
+  static_cast<scalar_t *>(data)[offset] = scalar_t(value);
+}
+
+template <>
+inline void store_value<float>(void *data, std::int64_t offset, float value) {
+  static_cast<float *>(data)[offset] = value;
+}
+
+template <
+    typename scalar_t,
+    float32x4_t (*load4)(void const *, std::int64_t),
+    int row_tile>
+inline void packed_matmul_neon_w4_rows(
+    PackedMatmulArgs const &args,
+    std::uint8_t const *packed_row,
+    std::int64_t out_col,
+    std::int64_t row_start) {
+  float32x4_t accumulator0[row_tile];
+  float32x4_t accumulator1[row_tile];
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    accumulator0[row] = vdupq_n_f32(0.0f);
+    accumulator1[row] = vdupq_n_f32(0.0f);
+  }
+
+  std::int64_t k = 0;
+  for (; k + 8 <= args.in_features; k += 8) {
+    const std::int64_t byte_offset = k / 2;
+    float weights0[4];
+    float weights1[4];
+#pragma clang loop unroll(full)
+    for (int pair = 0; pair < 4; ++pair) {
+      const std::uint8_t packed = packed_row[byte_offset + pair];
+      const int value = pair * 2;
+      if (value < 4) {
+        weights0[value] = args.centroids[packed & 15u];
+        weights0[value + 1] = args.centroids[(packed >> 4) & 15u];
+      } else {
+        weights1[value - 4] = args.centroids[packed & 15u];
+        weights1[value - 3] = args.centroids[(packed >> 4) & 15u];
+      }
+    }
+    const float32x4_t weight0 = vld1q_f32(weights0);
+    const float32x4_t weight1 = vld1q_f32(weights1);
+#pragma clang loop unroll(full)
+    for (int row = 0; row < row_tile; ++row) {
+      const std::int64_t input_offset =
+          (row_start + row) * args.in_features + k;
+      accumulator0[row] =
+          vfmaq_f32(accumulator0[row], load4(args.x, input_offset), weight0);
+      accumulator1[row] = vfmaq_f32(
+          accumulator1[row], load4(args.x, input_offset + 4), weight1);
+    }
+  }
+
+  const float row_norm = args.row_norms[out_col];
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    const std::int64_t input_row_offset =
+        (row_start + row) * args.in_features;
+    float accumulator =
+        horizontal_sum(vaddq_f32(accumulator0[row], accumulator1[row]));
+    for (std::int64_t tail = k; tail < args.in_features; ++tail) {
+      const std::uint8_t packed = packed_row[tail / 2];
+      const std::uint8_t index =
+          (tail & 1) == 0 ? packed & 15u : (packed >> 4) & 15u;
+      if constexpr (std::is_same_v<scalar_t, float>) {
+        accumulator +=
+            static_cast<float const *>(args.x)[input_row_offset + tail] *
+            args.centroids[index];
+      } else {
+        accumulator += static_cast<float>(
+                           static_cast<scalar_t const *>(
+                               args.x)[input_row_offset + tail]) *
+            args.centroids[index];
+      }
+    }
+    accumulator *= row_norm;
+    if (args.has_bias) {
+      accumulator += args.bias[out_col];
+    }
+    store_value<scalar_t>(
+        args.out,
+        (row_start + row) * args.out_features + out_col,
+        accumulator);
+  }
+}
+
+template <typename scalar_t, float32x4_t (*load4)(void const *, std::int64_t)>
+void packed_matmul_neon_w4_typed(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  constexpr int kPrimaryRowTile = 8;
+  const std::int64_t packed_row_bytes = args.in_features / 2;
+  for (std::int64_t out_col = out_start; out_col < out_end; ++out_col) {
+    const auto *packed_row =
+        args.packed_weight_indices + out_col * packed_row_bytes;
+    std::int64_t row = 0;
+    if constexpr (kPrimaryRowTile == 8) {
+      for (; row + 8 <= args.rows; row += 8) {
+        packed_matmul_neon_w4_rows<scalar_t, load4, 8>(
+            args, packed_row, out_col, row);
+      }
+    }
+    for (; row + 4 <= args.rows; row += 4) {
+      packed_matmul_neon_w4_rows<scalar_t, load4, 4>(
+          args, packed_row, out_col, row);
+    }
+    switch (args.rows - row) {
+      case 3:
+        packed_matmul_neon_w4_rows<scalar_t, load4, 3>(
+            args, packed_row, out_col, row);
+        break;
+      case 2:
+        packed_matmul_neon_w4_rows<scalar_t, load4, 2>(
+            args, packed_row, out_col, row);
+        break;
+      case 1:
+        packed_matmul_neon_w4_rows<scalar_t, load4, 1>(
+            args, packed_row, out_col, row);
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+}  // namespace
+
+bool packed_matmul_neon_available() {
+  return true;
+}
+
+void packed_matmul_neon_range(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  if (args.bits != 4 || args.in_features % 2 != 0) {
+    packed_matmul_scalar_range(args, out_start, out_end);
+    return;
+  }
+  switch (args.scalar_kind) {
+    case ScalarKind::Float32:
+      packed_matmul_neon_w4_typed<float, load_float4>(args, out_start, out_end);
+      return;
+    case ScalarKind::Float16:
+      packed_matmul_neon_w4_typed<c10::Half, load_half4>(args, out_start, out_end);
+      return;
+    case ScalarKind::BFloat16:
+      packed_matmul_neon_w4_typed<c10::BFloat16, load_bfloat4>(
+          args, out_start, out_end);
+      return;
+  }
+}
+
+}  // namespace orbitquant::cpu
+
+#else
+
+namespace orbitquant::cpu {
+
+bool packed_matmul_neon_available() {
+  return false;
+}
+
+void packed_matmul_neon_range(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  packed_matmul_scalar_range(args, out_start, out_end);
+}
+
+}  // namespace orbitquant::cpu
+
+#endif

--- a/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_matmul_scalar.cpp
+++ b/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_matmul_scalar.cpp
@@ -1,0 +1,95 @@
+#include "packed_matmul_cpu.h"
+
+#include <torch/headeronly/util/BFloat16.h>
+#include <torch/headeronly/util/Half.h>
+
+#include <cstddef>
+
+namespace orbitquant::cpu {
+namespace {
+
+template <typename scalar_t>
+inline float load_scalar(void const *data, std::int64_t offset) {
+  return static_cast<float>(static_cast<scalar_t const *>(data)[offset]);
+}
+
+template <typename scalar_t>
+inline void store_scalar(void *data, std::int64_t offset, float value) {
+  static_cast<scalar_t *>(data)[offset] = scalar_t(value);
+}
+
+template <>
+inline float load_scalar<float>(void const *data, std::int64_t offset) {
+  return static_cast<float const *>(data)[offset];
+}
+
+template <>
+inline void store_scalar<float>(void *data, std::int64_t offset, float value) {
+  static_cast<float *>(data)[offset] = value;
+}
+
+inline std::uint32_t unpack_index(
+    std::uint8_t const *packed,
+    std::int64_t value_offset,
+    std::int64_t bits) {
+  const std::int64_t bit_start = value_offset * bits;
+  const std::int64_t byte_index = bit_start >> 3;
+  const unsigned bit_offset = static_cast<unsigned>(bit_start & 7);
+  std::uint32_t raw = packed[byte_index];
+  if (bit_offset + static_cast<unsigned>(bits) > 8) {
+    raw |= static_cast<std::uint32_t>(packed[byte_index + 1]) << 8;
+  }
+  return (raw >> bit_offset) & ((1u << static_cast<unsigned>(bits)) - 1u);
+}
+
+template <typename scalar_t>
+void packed_matmul_scalar_typed(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  for (std::int64_t out_col = out_start; out_col < out_end; ++out_col) {
+    const float row_norm = args.row_norms[out_col];
+    const std::int64_t weight_row_offset = out_col * args.in_features;
+    for (std::int64_t row = 0; row < args.rows; ++row) {
+      const std::int64_t input_row_offset = row * args.in_features;
+      float accumulator = 0.0f;
+      for (std::int64_t k = 0; k < args.in_features; ++k) {
+        const std::uint32_t index = unpack_index(
+            args.packed_weight_indices,
+            weight_row_offset + k,
+            args.bits);
+        accumulator += load_scalar<scalar_t>(args.x, input_row_offset + k) *
+            args.centroids[index];
+      }
+      accumulator *= row_norm;
+      if (args.has_bias) {
+        accumulator += args.bias[out_col];
+      }
+      store_scalar<scalar_t>(
+          args.out,
+          row * args.out_features + out_col,
+          accumulator);
+    }
+  }
+}
+
+}  // namespace
+
+void packed_matmul_scalar_range(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  switch (args.scalar_kind) {
+    case ScalarKind::Float32:
+      packed_matmul_scalar_typed<float>(args, out_start, out_end);
+      return;
+    case ScalarKind::Float16:
+      packed_matmul_scalar_typed<c10::Half>(args, out_start, out_end);
+      return;
+    case ScalarKind::BFloat16:
+      packed_matmul_scalar_typed<c10::BFloat16>(args, out_start, out_end);
+      return;
+  }
+}
+
+}  // namespace orbitquant::cpu

--- a/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_matmul_x86.cpp
+++ b/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_matmul_x86.cpp
@@ -1,0 +1,227 @@
+#include "packed_matmul_cpu.h"
+
+#if defined(__x86_64__) || defined(_M_X64)
+#include <immintrin.h>
+
+#include <torch/headeronly/util/BFloat16.h>
+#include <torch/headeronly/util/Half.h>
+
+#include <cstring>
+#include <cstdint>
+#include <type_traits>
+
+#if defined(_MSC_VER)
+#define ORBITQUANT_TARGET_AVX2
+#define ORBITQUANT_NOINLINE __declspec(noinline)
+#else
+#define ORBITQUANT_TARGET_AVX2 __attribute__((target("avx2,fma,f16c")))
+#define ORBITQUANT_NOINLINE __attribute__((noinline))
+#endif
+
+namespace orbitquant::cpu {
+namespace {
+
+ORBITQUANT_TARGET_AVX2 inline float horizontal_sum(__m256 value) {
+  const __m128 halves =
+      _mm_add_ps(_mm256_castps256_ps128(value), _mm256_extractf128_ps(value, 1));
+  const __m128 pairs = _mm_hadd_ps(halves, halves);
+  return _mm_cvtss_f32(_mm_hadd_ps(pairs, pairs));
+}
+
+ORBITQUANT_TARGET_AVX2 inline __m256 load_float8(
+    void const *data,
+    std::int64_t offset) {
+  return _mm256_loadu_ps(static_cast<float const *>(data) + offset);
+}
+
+ORBITQUANT_TARGET_AVX2 inline __m256 load_half8(
+    void const *data,
+    std::int64_t offset) {
+  const auto *source = static_cast<std::uint16_t const *>(data) + offset;
+  const __m128i packed =
+      _mm_loadu_si128(reinterpret_cast<__m128i const *>(source));
+  return _mm256_cvtph_ps(packed);
+}
+
+ORBITQUANT_TARGET_AVX2 inline __m256 load_bfloat8(
+    void const *data,
+    std::int64_t offset) {
+  const auto *source = static_cast<std::uint16_t const *>(data) + offset;
+  const __m128i packed =
+      _mm_loadu_si128(reinterpret_cast<__m128i const *>(source));
+  const __m256i widened = _mm256_cvtepu16_epi32(packed);
+  return _mm256_castsi256_ps(_mm256_slli_epi32(widened, 16));
+}
+
+template <typename scalar_t>
+inline void store_value(void *data, std::int64_t offset, float value) {
+  static_cast<scalar_t *>(data)[offset] = scalar_t(value);
+}
+
+template <>
+inline void store_value<float>(void *data, std::int64_t offset, float value) {
+  static_cast<float *>(data)[offset] = value;
+}
+
+template <
+    typename scalar_t,
+    __m256 (*load8)(void const *, std::int64_t),
+    int row_tile>
+ORBITQUANT_TARGET_AVX2 inline void packed_matmul_avx2_w4_rows(
+    PackedMatmulArgs const &args,
+    std::uint8_t const *packed_row,
+    std::int64_t out_col,
+    std::int64_t row_start) {
+  __m256 accumulators[row_tile];
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    accumulators[row] = _mm256_setzero_ps();
+  }
+  const __m256 centroid_lut_low = _mm256_loadu_ps(args.centroids);
+  const __m256 centroid_lut_high = _mm256_loadu_ps(args.centroids + 8);
+  const __m128i nibble_mask = _mm_set1_epi8(15);
+  const __m256i low_table_limit = _mm256_set1_epi32(7);
+
+  std::int64_t k = 0;
+  for (; k + 8 <= args.in_features; k += 8) {
+    const std::int64_t byte_offset = k / 2;
+    std::int32_t packed;
+    std::memcpy(&packed, packed_row + byte_offset, sizeof(packed));
+    const __m128i bytes = _mm_cvtsi32_si128(packed);
+    const __m128i low = _mm_and_si128(bytes, nibble_mask);
+    const __m128i high = _mm_and_si128(
+        _mm_srli_epi16(bytes, 4),
+        nibble_mask);
+    const __m256i indices =
+        _mm256_cvtepu8_epi32(_mm_unpacklo_epi8(low, high));
+    const __m256 low_weights =
+        _mm256_permutevar8x32_ps(centroid_lut_low, indices);
+    const __m256 high_weights =
+        _mm256_permutevar8x32_ps(centroid_lut_high, indices);
+    const __m256 weight = _mm256_blendv_ps(
+        low_weights,
+        high_weights,
+        _mm256_castsi256_ps(_mm256_cmpgt_epi32(indices, low_table_limit)));
+#pragma clang loop unroll(full)
+    for (int row = 0; row < row_tile; ++row) {
+      const std::int64_t input_offset =
+          (row_start + row) * args.in_features + k;
+      accumulators[row] = _mm256_fmadd_ps(
+          load8(args.x, input_offset),
+          weight,
+          accumulators[row]);
+    }
+  }
+
+  const float row_norm = args.row_norms[out_col];
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    const std::int64_t input_row_offset =
+        (row_start + row) * args.in_features;
+    float accumulator = horizontal_sum(accumulators[row]);
+    for (std::int64_t tail = k; tail < args.in_features; ++tail) {
+      const std::uint8_t packed = packed_row[tail / 2];
+      const std::uint8_t index =
+          (tail & 1) == 0 ? packed & 15u : (packed >> 4) & 15u;
+      if constexpr (std::is_same_v<scalar_t, float>) {
+        accumulator +=
+            static_cast<float const *>(args.x)[input_row_offset + tail] *
+            args.centroids[index];
+      } else {
+        accumulator += static_cast<float>(
+                           static_cast<scalar_t const *>(
+                               args.x)[input_row_offset + tail]) *
+            args.centroids[index];
+      }
+    }
+    accumulator *= row_norm;
+    if (args.has_bias) {
+      accumulator += args.bias[out_col];
+    }
+    store_value<scalar_t>(
+        args.out,
+        (row_start + row) * args.out_features + out_col,
+        accumulator);
+  }
+}
+
+template <typename scalar_t, __m256 (*load8)(void const *, std::int64_t)>
+ORBITQUANT_TARGET_AVX2 ORBITQUANT_NOINLINE void packed_matmul_avx2_w4_typed(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  constexpr int kPrimaryRowTile = 8;
+  const std::int64_t packed_row_bytes = args.in_features / 2;
+  for (std::int64_t out_col = out_start; out_col < out_end; ++out_col) {
+    const auto *packed_row =
+        args.packed_weight_indices + out_col * packed_row_bytes;
+    std::int64_t row = 0;
+    for (; row + kPrimaryRowTile <= args.rows; row += kPrimaryRowTile) {
+      packed_matmul_avx2_w4_rows<scalar_t, load8, kPrimaryRowTile>(
+          args, packed_row, out_col, row);
+    }
+    if (row + 4 <= args.rows) {
+      packed_matmul_avx2_w4_rows<scalar_t, load8, 4>(
+          args, packed_row, out_col, row);
+      row += 4;
+    }
+    switch (args.rows - row) {
+      case 3:
+        packed_matmul_avx2_w4_rows<scalar_t, load8, 3>(
+            args, packed_row, out_col, row);
+        break;
+      case 2:
+        packed_matmul_avx2_w4_rows<scalar_t, load8, 2>(
+            args, packed_row, out_col, row);
+        break;
+      case 1:
+        packed_matmul_avx2_w4_rows<scalar_t, load8, 1>(
+            args, packed_row, out_col, row);
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+}  // namespace
+
+void packed_matmul_x86_avx2_range(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  if (!packed_matmul_x86_avx2_available() || args.bits != 4 ||
+      args.in_features % 2 != 0) {
+    packed_matmul_scalar_range(args, out_start, out_end);
+    return;
+  }
+  switch (args.scalar_kind) {
+    case ScalarKind::Float32:
+      packed_matmul_avx2_w4_typed<float, load_float8>(args, out_start, out_end);
+      return;
+    case ScalarKind::Float16:
+      packed_matmul_avx2_w4_typed<c10::Half, load_half8>(args, out_start, out_end);
+      return;
+    case ScalarKind::BFloat16:
+      packed_matmul_avx2_w4_typed<c10::BFloat16, load_bfloat8>(
+          args, out_start, out_end);
+      return;
+  }
+}
+
+}  // namespace orbitquant::cpu
+
+#else
+
+namespace orbitquant::cpu {
+
+void packed_matmul_x86_avx2_range(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  packed_matmul_scalar_range(args, out_start, out_end);
+}
+
+}  // namespace orbitquant::cpu
+
+#endif

--- a/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_matmul_x86_avx512.cpp
+++ b/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_matmul_x86_avx512.cpp
@@ -1,0 +1,393 @@
+#include "packed_matmul_cpu.h"
+
+#if (defined(__x86_64__) || defined(_M_X64)) && !defined(_MSC_VER)
+#include <immintrin.h>
+
+#include <torch/headeronly/util/BFloat16.h>
+#include <torch/headeronly/util/Half.h>
+
+#include <cstring>
+#include <cstdint>
+#include <type_traits>
+
+#define ORBITQUANT_TARGET_AVX512 \
+  __attribute__((target("avx512f,avx512dq,avx512bw,avx512vl,fma,f16c")))
+#define ORBITQUANT_TARGET_AVX512_BF16 \
+  __attribute__((target( \
+      "avx512f,avx512dq,avx512bw,avx512vl,avx512bf16,fma,f16c")))
+#define ORBITQUANT_HAS_AVX512_BF16_INTRINSICS 1
+#define ORBITQUANT_NOINLINE __attribute__((noinline))
+
+namespace orbitquant::cpu {
+namespace {
+
+ORBITQUANT_TARGET_AVX512 inline float horizontal_sum(__m512 value) {
+  return _mm512_reduce_add_ps(value);
+}
+
+ORBITQUANT_TARGET_AVX512 inline __m512 load_float16(
+    void const *data,
+    std::int64_t offset) {
+  return _mm512_loadu_ps(static_cast<float const *>(data) + offset);
+}
+
+ORBITQUANT_TARGET_AVX512 inline __m512 load_half16(
+    void const *data,
+    std::int64_t offset) {
+  const auto *source = static_cast<std::uint16_t const *>(data) + offset;
+  const __m256i packed =
+      _mm256_loadu_si256(reinterpret_cast<__m256i const *>(source));
+  return _mm512_cvtph_ps(packed);
+}
+
+ORBITQUANT_TARGET_AVX512 inline __m512 load_bfloat16(
+    void const *data,
+    std::int64_t offset) {
+  const auto *source = static_cast<std::uint16_t const *>(data) + offset;
+  const __m256i packed =
+      _mm256_loadu_si256(reinterpret_cast<__m256i const *>(source));
+  const __m512i widened = _mm512_cvtepu16_epi32(packed);
+  return _mm512_castsi512_ps(_mm512_slli_epi32(widened, 16));
+}
+
+template <typename scalar_t>
+inline void store_value(void *data, std::int64_t offset, float value) {
+  static_cast<scalar_t *>(data)[offset] = scalar_t(value);
+}
+
+template <>
+inline void store_value<float>(void *data, std::int64_t offset, float value) {
+  static_cast<float *>(data)[offset] = value;
+}
+
+template <
+    typename scalar_t,
+    __m512 (*load16)(void const *, std::int64_t),
+    int row_tile>
+ORBITQUANT_TARGET_AVX512 inline void packed_matmul_avx512_w4_rows(
+    PackedMatmulArgs const &args,
+    std::uint8_t const *packed_row,
+    std::int64_t out_col,
+    std::int64_t row_start) {
+  __m512 accumulators[row_tile];
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    accumulators[row] = _mm512_setzero_ps();
+  }
+  const __m512 centroid_lut = _mm512_loadu_ps(args.centroids);
+  const __m128i nibble_mask = _mm_set1_epi8(15);
+
+  std::int64_t k = 0;
+  for (; k + 16 <= args.in_features; k += 16) {
+    const std::int64_t byte_offset = k / 2;
+    std::int64_t packed;
+    std::memcpy(&packed, packed_row + byte_offset, sizeof(packed));
+    const __m128i bytes = _mm_cvtsi64_si128(packed);
+    const __m128i low = _mm_and_si128(bytes, nibble_mask);
+    const __m128i high = _mm_and_si128(
+        _mm_srli_epi16(bytes, 4),
+        nibble_mask);
+    const __m512i indices =
+        _mm512_cvtepu8_epi32(_mm_unpacklo_epi8(low, high));
+    const __m512 weight = _mm512_permutexvar_ps(indices, centroid_lut);
+#pragma clang loop unroll(full)
+    for (int row = 0; row < row_tile; ++row) {
+      const std::int64_t input_offset =
+          (row_start + row) * args.in_features + k;
+      accumulators[row] = _mm512_fmadd_ps(
+          load16(args.x, input_offset),
+          weight,
+          accumulators[row]);
+    }
+  }
+
+  const float row_norm = args.row_norms[out_col];
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    const std::int64_t input_row_offset =
+        (row_start + row) * args.in_features;
+    float accumulator = horizontal_sum(accumulators[row]);
+    for (std::int64_t tail = k; tail < args.in_features; ++tail) {
+      const std::uint8_t packed = packed_row[tail / 2];
+      const std::uint8_t index =
+          (tail & 1) == 0 ? packed & 15u : (packed >> 4) & 15u;
+      if constexpr (std::is_same_v<scalar_t, float>) {
+        accumulator +=
+            static_cast<float const *>(args.x)[input_row_offset + tail] *
+            args.centroids[index];
+      } else {
+        accumulator += static_cast<float>(
+                           static_cast<scalar_t const *>(
+                               args.x)[input_row_offset + tail]) *
+            args.centroids[index];
+      }
+    }
+    accumulator *= row_norm;
+    if (args.has_bias) {
+      accumulator += args.bias[out_col];
+    }
+    store_value<scalar_t>(
+        args.out,
+        (row_start + row) * args.out_features + out_col,
+        accumulator);
+  }
+}
+
+template <typename scalar_t, __m512 (*load16)(void const *, std::int64_t)>
+ORBITQUANT_TARGET_AVX512 ORBITQUANT_NOINLINE void packed_matmul_avx512_w4_typed(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  constexpr int kPrimaryRowTile = 8;
+  const std::int64_t packed_row_bytes = args.in_features / 2;
+  for (std::int64_t out_col = out_start; out_col < out_end; ++out_col) {
+    const auto *packed_row =
+        args.packed_weight_indices + out_col * packed_row_bytes;
+    std::int64_t row = 0;
+    for (; row + kPrimaryRowTile <= args.rows; row += kPrimaryRowTile) {
+      packed_matmul_avx512_w4_rows<scalar_t, load16, kPrimaryRowTile>(
+          args, packed_row, out_col, row);
+    }
+    if (row + 8 <= args.rows) {
+      packed_matmul_avx512_w4_rows<scalar_t, load16, 8>(
+          args, packed_row, out_col, row);
+      row += 8;
+    }
+    if (row + 4 <= args.rows) {
+      packed_matmul_avx512_w4_rows<scalar_t, load16, 4>(
+          args, packed_row, out_col, row);
+      row += 4;
+    }
+    switch (args.rows - row) {
+      case 3:
+        packed_matmul_avx512_w4_rows<scalar_t, load16, 3>(
+            args, packed_row, out_col, row);
+        break;
+      case 2:
+        packed_matmul_avx512_w4_rows<scalar_t, load16, 2>(
+            args, packed_row, out_col, row);
+        break;
+      case 1:
+        packed_matmul_avx512_w4_rows<scalar_t, load16, 1>(
+            args, packed_row, out_col, row);
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+#if defined(ORBITQUANT_HAS_AVX512_BF16_INTRINSICS)
+template <int row_tile, bool aligned_k>
+ORBITQUANT_TARGET_AVX512_BF16 inline void packed_matmul_avx512_bf16_w4_rows(
+    PackedMatmulArgs const &args,
+    std::uint8_t const *packed_row,
+    std::int64_t out_col,
+    std::int64_t row_start) {
+  __m512 accumulators[row_tile];
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    accumulators[row] = _mm512_setzero_ps();
+  }
+  const float row_norm = args.row_norms[out_col];
+  const __m512 centroid_lut = _mm512_mul_ps(
+      _mm512_loadu_ps(args.centroids),
+      _mm512_set1_ps(row_norm));
+  const __m512i centroid_lut_words = (__m512i)_mm512_cvtne2ps_pbh(
+      centroid_lut,
+      centroid_lut);
+  const __m128i nibble_mask = _mm_set1_epi8(15);
+
+  std::int64_t k = 0;
+  for (; k + 32 <= args.in_features; k += 32) {
+    const std::int64_t byte_offset = k / 2;
+    const __m128i bytes = _mm_loadu_si128(
+        reinterpret_cast<__m128i const *>(packed_row + byte_offset));
+    const __m128i low = _mm_and_si128(bytes, nibble_mask);
+    const __m128i high = _mm_and_si128(
+        _mm_srli_epi16(bytes, 4),
+        nibble_mask);
+    const __m256i packed_indices = _mm256_set_m128i(
+        _mm_unpackhi_epi8(low, high),
+        _mm_unpacklo_epi8(low, high));
+    const __m512i indices = _mm512_cvtepu8_epi16(packed_indices);
+    const __m512bh weights = (__m512bh)_mm512_permutexvar_epi16(
+        indices,
+        centroid_lut_words);
+#pragma clang loop unroll(full)
+    for (int row = 0; row < row_tile; ++row) {
+      const std::int64_t input_offset =
+          (row_start + row) * args.in_features + k;
+      const __m512bh activations = (__m512bh)_mm512_loadu_si512(
+          static_cast<std::uint16_t const *>(args.x) + input_offset);
+      accumulators[row] =
+          _mm512_dpbf16_ps(accumulators[row], activations, weights);
+    }
+  }
+
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    const std::int64_t input_row_offset =
+        (row_start + row) * args.in_features;
+    float accumulator = horizontal_sum(accumulators[row]);
+    if constexpr (!aligned_k) {
+      for (std::int64_t tail = k; tail < args.in_features; ++tail) {
+        const std::uint8_t packed = packed_row[tail / 2];
+        const std::uint8_t index =
+            (tail & 1) == 0 ? packed & 15u : (packed >> 4) & 15u;
+        const float activation = static_cast<float>(
+            static_cast<c10::BFloat16 const *>(args.x)[input_row_offset + tail]);
+        const float weight = static_cast<float>(
+            c10::BFloat16(args.centroids[index] * row_norm));
+        accumulator += activation * weight;
+      }
+    }
+    if (args.has_bias) {
+      accumulator += args.bias[out_col];
+    }
+    store_value<c10::BFloat16>(
+        args.out,
+        (row_start + row) * args.out_features + out_col,
+        accumulator);
+  }
+}
+
+template <bool aligned_k>
+ORBITQUANT_TARGET_AVX512_BF16 ORBITQUANT_NOINLINE void
+packed_matmul_avx512_bf16_w4_typed(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  constexpr int kPrimaryRowTile = 8;
+  const std::int64_t packed_row_bytes = args.in_features / 2;
+  for (std::int64_t out_col = out_start; out_col < out_end; ++out_col) {
+    const auto *packed_row =
+        args.packed_weight_indices + out_col * packed_row_bytes;
+    std::int64_t row = 0;
+    for (; row + kPrimaryRowTile <= args.rows; row += kPrimaryRowTile) {
+      packed_matmul_avx512_bf16_w4_rows<kPrimaryRowTile, aligned_k>(
+          args, packed_row, out_col, row);
+    }
+    if (row + 4 <= args.rows) {
+      packed_matmul_avx512_bf16_w4_rows<4, aligned_k>(
+          args, packed_row, out_col, row);
+      row += 4;
+    }
+    switch (args.rows - row) {
+      case 3:
+        packed_matmul_avx512_bf16_w4_rows<3, aligned_k>(
+            args, packed_row, out_col, row);
+        break;
+      case 2:
+        packed_matmul_avx512_bf16_w4_rows<2, aligned_k>(
+            args, packed_row, out_col, row);
+        break;
+      case 1:
+        packed_matmul_avx512_bf16_w4_rows<1, aligned_k>(
+            args, packed_row, out_col, row);
+        break;
+      default:
+        break;
+    }
+  }
+}
+#endif
+
+bool runtime_has_avx512() {
+#if defined(_MSC_VER)
+  int registers[4]{};
+  __cpuid(registers, 1);
+  const bool osxsave = (registers[2] & (1 << 27)) != 0;
+  const bool avx = (registers[2] & (1 << 28)) != 0;
+  const bool fma = (registers[2] & (1 << 12)) != 0;
+  const bool f16c = (registers[2] & (1 << 29)) != 0;
+  if (!osxsave || !avx || !fma || !f16c || (_xgetbv(0) & 0xE6) != 0xE6) {
+    return false;
+  }
+  __cpuidex(registers, 7, 0);
+  constexpr unsigned required_ebx =
+      (1u << 16) | (1u << 17) | (1u << 30) | (1u << 31);
+  return (static_cast<unsigned>(registers[1]) & required_ebx) == required_ebx;
+#else
+  __builtin_cpu_init();
+  return __builtin_cpu_supports("avx512f") &&
+      __builtin_cpu_supports("avx512dq") &&
+      __builtin_cpu_supports("avx512bw") &&
+      __builtin_cpu_supports("avx512vl") &&
+      __builtin_cpu_supports("fma") && __builtin_cpu_supports("f16c");
+#endif
+}
+
+bool runtime_has_avx512_bf16() {
+#if defined(ORBITQUANT_HAS_AVX512_BF16_INTRINSICS)
+  __builtin_cpu_init();
+  return runtime_has_avx512() && __builtin_cpu_supports("avx512bf16");
+#else
+  return false;
+#endif
+}
+
+}  // namespace
+
+bool packed_matmul_x86_avx512_available() {
+  static const bool available = runtime_has_avx512();
+  return available;
+}
+
+void packed_matmul_x86_avx512_range(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  if (!packed_matmul_x86_avx512_available() || args.bits != 4 ||
+      args.in_features % 2 != 0) {
+    packed_matmul_scalar_range(args, out_start, out_end);
+    return;
+  }
+  switch (args.scalar_kind) {
+    case ScalarKind::Float32:
+      packed_matmul_avx512_w4_typed<float, load_float16>(
+          args, out_start, out_end);
+      return;
+    case ScalarKind::Float16:
+      packed_matmul_avx512_w4_typed<c10::Half, load_half16>(
+          args, out_start, out_end);
+      return;
+    case ScalarKind::BFloat16:
+#if defined(ORBITQUANT_HAS_AVX512_BF16_INTRINSICS)
+      if (runtime_has_avx512_bf16()) {
+        if (args.in_features % 32 == 0) {
+          packed_matmul_avx512_bf16_w4_typed<true>(
+              args, out_start, out_end);
+        } else {
+          packed_matmul_avx512_bf16_w4_typed<false>(
+              args, out_start, out_end);
+        }
+        return;
+      }
+#endif
+      packed_matmul_avx512_w4_typed<c10::BFloat16, load_bfloat16>(
+          args, out_start, out_end);
+      return;
+  }
+}
+
+}  // namespace orbitquant::cpu
+
+#else
+
+namespace orbitquant::cpu {
+
+bool packed_matmul_x86_avx512_available() {
+  return false;
+}
+
+void packed_matmul_x86_avx512_range(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  packed_matmul_scalar_range(args, out_start, out_end);
+}
+
+}  // namespace orbitquant::cpu
+
+#endif

--- a/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/quantize_activations_cpu.cpp
+++ b/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/quantize_activations_cpu.cpp
@@ -1,0 +1,763 @@
+#include "cpu_threads.h"
+#include "cpu_kernel_args.h"
+#include "packed_matmul_cpu.h"
+#include "../torch-ext/torch_binding.h"
+
+#include <torch/headeronly/core/DeviceType.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/macros/Macros.h>
+#include <torch/headeronly/util/BFloat16.h>
+#include <torch/headeronly/util/Half.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <cstdint>
+#include <cstring>
+#include <thread>
+#include <type_traits>
+#include <vector>
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+#include <arm_neon.h>
+#endif
+
+#if (defined(__x86_64__) || defined(_M_X64)) && !defined(_MSC_VER)
+#include <immintrin.h>
+#define ORBITQUANT_TARGET_AVX2 __attribute__((target("avx2,fma,f16c")))
+#define ORBITQUANT_TARGET_AVX512 \
+  __attribute__((target("avx512f,avx512dq,avx512bw,avx512vl,fma,f16c")))
+#endif
+
+namespace {
+
+using orbitquant::cpu::ActivationArgs;
+using orbitquant::cpu::ActivationIsa;
+
+ActivationIsa select_activation_isa() {
+  const char *requested = std::getenv("ORBITQUANT_CPU_ISA");
+  if (requested == nullptr || std::strcmp(requested, "auto") == 0) {
+    if (orbitquant::cpu::packed_matmul_x86_avx512_available()) {
+      return ActivationIsa::Avx512;
+    }
+    if (orbitquant::cpu::packed_matmul_x86_avx2_available()) {
+      return ActivationIsa::Avx2;
+    }
+    if (orbitquant::cpu::packed_matmul_neon_available()) {
+      return ActivationIsa::Neon;
+    }
+    return ActivationIsa::Portable;
+  }
+  if (std::strcmp(requested, "scalar") == 0) {
+    return ActivationIsa::Portable;
+  }
+  if (std::strcmp(requested, "avx2") == 0) {
+    STD_TORCH_CHECK(
+        orbitquant::cpu::packed_matmul_x86_avx2_available(),
+        "ORBITQUANT_CPU_ISA=avx2 requested AVX2/FMA/F16C on an unsupported CPU");
+    return ActivationIsa::Avx2;
+  }
+  if (std::strcmp(requested, "avx512") == 0) {
+    STD_TORCH_CHECK(
+        orbitquant::cpu::packed_matmul_x86_avx512_available(),
+        "ORBITQUANT_CPU_ISA=avx512 requested AVX-512F/DQ/BW/VL on an unsupported CPU");
+    return ActivationIsa::Avx512;
+  }
+  if (std::strcmp(requested, "neon") == 0) {
+    STD_TORCH_CHECK(
+        orbitquant::cpu::packed_matmul_neon_available(),
+        "ORBITQUANT_CPU_ISA=neon requested NEON on an unsupported CPU");
+    return ActivationIsa::Neon;
+  }
+  STD_TORCH_CHECK(
+      false,
+      "ORBITQUANT_CPU_ISA must be auto, scalar, avx2, avx512, or neon");
+  return ActivationIsa::Portable;
+}
+
+orbitquant::cpu::ScalarKind activation_scalar_kind(
+    OrbitQuantTensor const &tensor) {
+  using torch::headeronly::ScalarType;
+  switch (tensor.scalar_type()) {
+    case ScalarType::Float:
+      return orbitquant::cpu::ScalarKind::Float32;
+    case ScalarType::Half:
+      return orbitquant::cpu::ScalarKind::Float16;
+    case ScalarType::BFloat16:
+      return orbitquant::cpu::ScalarKind::BFloat16;
+    default:
+      STD_TORCH_CHECK(
+          false,
+          "CPU activation quantization supports float32, float16, and bfloat16 inputs");
+  }
+  return orbitquant::cpu::ScalarKind::Float32;
+}
+
+template <typename scalar_t>
+inline float load_scalar(void const *data, std::int64_t offset) {
+  return static_cast<float>(static_cast<scalar_t const *>(data)[offset]);
+}
+
+template <>
+inline float load_scalar<float>(void const *data, std::int64_t offset) {
+  return static_cast<float const *>(data)[offset];
+}
+
+template <typename scalar_t>
+inline void store_scalar(void *data, std::int64_t offset, float value) {
+  static_cast<scalar_t *>(data)[offset] = scalar_t(value);
+}
+
+template <>
+inline void store_scalar<float>(void *data, std::int64_t offset, float value) {
+  static_cast<float *>(data)[offset] = value;
+}
+
+inline void fwht_block_portable(float *values, std::int64_t block_size) {
+  for (std::int64_t half = 1; half < block_size; half *= 2) {
+    for (std::int64_t base = 0; base < block_size; base += 2 * half) {
+      for (std::int64_t offset = 0; offset < half; ++offset) {
+        const float left = values[base + offset];
+        const float right = values[base + half + offset];
+        values[base + offset] = left + right;
+        values[base + half + offset] = left - right;
+      }
+    }
+  }
+}
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+inline void fwht_block_neon(float *values, std::int64_t block_size) {
+  for (std::int64_t half = 1; half < block_size; half *= 2) {
+    for (std::int64_t base = 0; base < block_size; base += 2 * half) {
+      std::int64_t offset = 0;
+      for (; offset + 4 <= half; offset += 4) {
+        const float32x4_t left = vld1q_f32(values + base + offset);
+        const float32x4_t right = vld1q_f32(values + base + half + offset);
+        vst1q_f32(values + base + offset, vaddq_f32(left, right));
+        vst1q_f32(values + base + half + offset, vsubq_f32(left, right));
+      }
+      for (; offset < half; ++offset) {
+        const float left = values[base + offset];
+        const float right = values[base + half + offset];
+        values[base + offset] = left + right;
+        values[base + half + offset] = left - right;
+      }
+    }
+  }
+}
+#endif
+
+#if (defined(__x86_64__) || defined(_M_X64)) && !defined(_MSC_VER)
+ORBITQUANT_TARGET_AVX2 void fwht_block_avx2(
+    float *values,
+    std::int64_t block_size) {
+  for (std::int64_t half = 1; half < block_size; half *= 2) {
+    for (std::int64_t base = 0; base < block_size; base += 2 * half) {
+      std::int64_t offset = 0;
+      for (; offset + 8 <= half; offset += 8) {
+        const __m256 left = _mm256_loadu_ps(values + base + offset);
+        const __m256 right =
+            _mm256_loadu_ps(values + base + half + offset);
+        _mm256_storeu_ps(values + base + offset, _mm256_add_ps(left, right));
+        _mm256_storeu_ps(
+            values + base + half + offset,
+            _mm256_sub_ps(left, right));
+      }
+      for (; offset < half; ++offset) {
+        const float left = values[base + offset];
+        const float right = values[base + half + offset];
+        values[base + offset] = left + right;
+        values[base + half + offset] = left - right;
+      }
+    }
+  }
+}
+
+ORBITQUANT_TARGET_AVX512 void fwht_block_avx512(
+    float *values,
+    std::int64_t block_size) {
+  for (std::int64_t half = 1; half < block_size; half *= 2) {
+    for (std::int64_t base = 0; base < block_size; base += 2 * half) {
+      std::int64_t offset = 0;
+      for (; offset + 16 <= half; offset += 16) {
+        const __m512 left = _mm512_loadu_ps(values + base + offset);
+        const __m512 right =
+            _mm512_loadu_ps(values + base + half + offset);
+        _mm512_storeu_ps(values + base + offset, _mm512_add_ps(left, right));
+        _mm512_storeu_ps(
+            values + base + half + offset,
+            _mm512_sub_ps(left, right));
+      }
+      for (; offset < half; ++offset) {
+        const float left = values[base + offset];
+        const float right = values[base + half + offset];
+        values[base + offset] = left + right;
+        values[base + half + offset] = left - right;
+      }
+    }
+  }
+}
+#endif
+
+inline void fwht_block(
+    float *values,
+    std::int64_t block_size,
+    ActivationIsa isa) {
+#if defined(__x86_64__) || defined(_M_X64)
+  if (isa == ActivationIsa::Avx512) {
+#if defined(_MSC_VER)
+    orbitquant::cpu::activation_fwht_msvc_avx2(values, block_size);
+#else
+    fwht_block_avx512(values, block_size);
+#endif
+    return;
+  }
+  if (isa == ActivationIsa::Avx2) {
+#if defined(_MSC_VER)
+    orbitquant::cpu::activation_fwht_msvc_avx2(values, block_size);
+#else
+    fwht_block_avx2(values, block_size);
+#endif
+    return;
+  }
+#endif
+#if defined(__aarch64__) || defined(_M_ARM64)
+  if (isa == ActivationIsa::Neon) {
+    fwht_block_neon(values, block_size);
+    return;
+  }
+#endif
+  fwht_block_portable(values, block_size);
+}
+
+template <typename scalar_t>
+float squared_norm_scalar(void const *data, std::int64_t offset, std::int64_t dim) {
+  float result = 0.0f;
+  for (std::int64_t index = 0; index < dim; ++index) {
+    const float value = load_scalar<scalar_t>(data, offset + index);
+    result += value * value;
+  }
+  return result;
+}
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+template <typename scalar_t>
+float squared_norm_neon(void const *data, std::int64_t offset, std::int64_t dim) {
+  float32x4_t accumulator = vdupq_n_f32(0.0f);
+  std::int64_t index = 0;
+  for (; index + 4 <= dim; index += 4) {
+    float32x4_t values;
+    if constexpr (std::is_same_v<scalar_t, float>) {
+      values = vld1q_f32(static_cast<float const *>(data) + offset + index);
+    } else if constexpr (std::is_same_v<scalar_t, c10::Half>) {
+      const auto *source = reinterpret_cast<float16_t const *>(
+          static_cast<std::uint16_t const *>(data) + offset + index);
+      values = vcvt_f32_f16(vld1_f16(source));
+    } else {
+      const uint16x4_t raw = vld1_u16(
+          static_cast<std::uint16_t const *>(data) + offset + index);
+      values = vreinterpretq_f32_u32(vshlq_n_u32(vmovl_u16(raw), 16));
+    }
+    accumulator = vfmaq_f32(accumulator, values, values);
+  }
+  float result = vaddvq_f32(accumulator);
+  for (; index < dim; ++index) {
+    const float value = load_scalar<scalar_t>(data, offset + index);
+    result += value * value;
+  }
+  return result;
+}
+#endif
+
+#if (defined(__x86_64__) || defined(_M_X64)) && !defined(_MSC_VER)
+template <typename scalar_t>
+ORBITQUANT_TARGET_AVX2 float squared_norm_avx2(
+    void const *data,
+    std::int64_t offset,
+    std::int64_t dim) {
+  __m256 accumulator = _mm256_setzero_ps();
+  std::int64_t index = 0;
+  for (; index + 8 <= dim; index += 8) {
+    __m256 values;
+    if constexpr (std::is_same_v<scalar_t, float>) {
+      values = _mm256_loadu_ps(
+          static_cast<float const *>(data) + offset + index);
+    } else if constexpr (std::is_same_v<scalar_t, c10::Half>) {
+      const auto *source =
+          static_cast<std::uint16_t const *>(data) + offset + index;
+      values = _mm256_cvtph_ps(
+          _mm_loadu_si128(reinterpret_cast<__m128i const *>(source)));
+    } else {
+      const auto *source =
+          static_cast<std::uint16_t const *>(data) + offset + index;
+      const __m128i packed =
+          _mm_loadu_si128(reinterpret_cast<__m128i const *>(source));
+      values = _mm256_castsi256_ps(
+          _mm256_slli_epi32(_mm256_cvtepu16_epi32(packed), 16));
+    }
+    accumulator = _mm256_fmadd_ps(values, values, accumulator);
+  }
+  const __m128 halves = _mm_add_ps(
+      _mm256_castps256_ps128(accumulator),
+      _mm256_extractf128_ps(accumulator, 1));
+  const __m128 pairs = _mm_hadd_ps(halves, halves);
+  float result = _mm_cvtss_f32(_mm_hadd_ps(pairs, pairs));
+  for (; index < dim; ++index) {
+    const float value = load_scalar<scalar_t>(data, offset + index);
+    result += value * value;
+  }
+  return result;
+}
+
+template <typename scalar_t>
+ORBITQUANT_TARGET_AVX512 float squared_norm_avx512(
+    void const *data,
+    std::int64_t offset,
+    std::int64_t dim) {
+  __m512 accumulator = _mm512_setzero_ps();
+  std::int64_t index = 0;
+  for (; index + 16 <= dim; index += 16) {
+    __m512 values;
+    if constexpr (std::is_same_v<scalar_t, float>) {
+      values = _mm512_loadu_ps(
+          static_cast<float const *>(data) + offset + index);
+    } else if constexpr (std::is_same_v<scalar_t, c10::Half>) {
+      const auto *source =
+          static_cast<std::uint16_t const *>(data) + offset + index;
+      values = _mm512_cvtph_ps(
+          _mm256_loadu_si256(reinterpret_cast<__m256i const *>(source)));
+    } else {
+      const auto *source =
+          static_cast<std::uint16_t const *>(data) + offset + index;
+      const __m256i packed =
+          _mm256_loadu_si256(reinterpret_cast<__m256i const *>(source));
+      values = _mm512_castsi512_ps(
+          _mm512_slli_epi32(_mm512_cvtepu16_epi32(packed), 16));
+    }
+    accumulator = _mm512_fmadd_ps(values, values, accumulator);
+  }
+  float result = _mm512_reduce_add_ps(accumulator);
+  for (; index < dim; ++index) {
+    const float value = load_scalar<scalar_t>(data, offset + index);
+    result += value * value;
+  }
+  return result;
+}
+#endif
+
+template <typename scalar_t>
+float squared_norm(
+    void const *data,
+    std::int64_t offset,
+    std::int64_t dim,
+    ActivationIsa isa) {
+#if defined(__x86_64__) || defined(_M_X64)
+  if (isa == ActivationIsa::Avx512) {
+#if defined(_MSC_VER)
+    constexpr auto scalar_kind = std::is_same_v<scalar_t, float>
+        ? orbitquant::cpu::ScalarKind::Float32
+        : std::is_same_v<scalar_t, c10::Half>
+        ? orbitquant::cpu::ScalarKind::Float16
+        : orbitquant::cpu::ScalarKind::BFloat16;
+    return orbitquant::cpu::activation_squared_norm_msvc_avx2(
+        data, scalar_kind, offset, dim);
+#else
+    return squared_norm_avx512<scalar_t>(data, offset, dim);
+#endif
+  }
+  if (isa == ActivationIsa::Avx2) {
+#if defined(_MSC_VER)
+    constexpr auto scalar_kind = std::is_same_v<scalar_t, float>
+        ? orbitquant::cpu::ScalarKind::Float32
+        : std::is_same_v<scalar_t, c10::Half>
+        ? orbitquant::cpu::ScalarKind::Float16
+        : orbitquant::cpu::ScalarKind::BFloat16;
+    return orbitquant::cpu::activation_squared_norm_msvc_avx2(
+        data, scalar_kind, offset, dim);
+#else
+    return squared_norm_avx2<scalar_t>(data, offset, dim);
+#endif
+  }
+#endif
+#if defined(__aarch64__) || defined(_M_ARM64)
+  if (isa == ActivationIsa::Neon) {
+    return squared_norm_neon<scalar_t>(data, offset, dim);
+  }
+#endif
+  return squared_norm_scalar<scalar_t>(data, offset, dim);
+}
+
+inline std::int64_t nearest_centroid(
+    float value,
+    float const *boundaries,
+    std::int64_t boundary_count) {
+  std::int64_t low = 0;
+  std::int64_t high = boundary_count;
+  while (low < high) {
+    const std::int64_t middle = low + (high - low) / 2;
+    if (value <= boundaries[middle]) {
+      high = middle;
+    } else {
+      low = middle + 1;
+    }
+  }
+  return low;
+}
+
+template <typename scalar_t>
+void quantize_lookup_scalar(
+    ActivationArgs const &args,
+    float const *scratch,
+    std::int64_t output_offset,
+    float norm,
+    std::int64_t start = 0) {
+  for (std::int64_t index = start; index < args.dim; ++index) {
+    const float direction = scratch[index] * args.inv_sqrt_block;
+    const std::int64_t centroid_index =
+        nearest_centroid(direction, args.boundaries, args.boundary_count);
+    store_scalar<scalar_t>(
+        args.out,
+        output_offset + index,
+        args.centroids[centroid_index] * norm);
+  }
+}
+
+#if (defined(__x86_64__) || defined(_M_X64)) && !defined(_MSC_VER)
+ORBITQUANT_TARGET_AVX2 inline __m128i float8_to_bfloat8(__m256 values) {
+  const __m256i bits = _mm256_castps_si256(values);
+  const __m256i absolute_bits =
+      _mm256_and_si256(bits, _mm256_set1_epi32(0x7fffffff));
+  const __m256i nan_mask =
+      _mm256_cmpgt_epi32(absolute_bits, _mm256_set1_epi32(0x7f800000));
+  const __m256i rounding = _mm256_add_epi32(
+      _mm256_set1_epi32(0x7fff),
+      _mm256_and_si256(_mm256_srli_epi32(bits, 16), _mm256_set1_epi32(1)));
+  const __m256i upper = _mm256_srli_epi32(
+      _mm256_add_epi32(bits, rounding),
+      16);
+  __m128i packed = _mm_packus_epi32(
+      _mm256_castsi256_si128(upper),
+      _mm256_extracti128_si256(upper, 1));
+  const __m128i packed_nan_mask = _mm_packs_epi32(
+      _mm256_castsi256_si128(nan_mask),
+      _mm256_extracti128_si256(nan_mask, 1));
+  packed = _mm_blendv_epi8(
+      packed,
+      _mm_set1_epi16(0x7fc0),
+      packed_nan_mask);
+  return packed;
+}
+
+ORBITQUANT_TARGET_AVX512 inline __m256i float16_to_bfloat16(__m512 values) {
+  const __m512i bits = _mm512_castps_si512(values);
+  const __m512i absolute_bits =
+      _mm512_and_si512(bits, _mm512_set1_epi32(0x7fffffff));
+  const __mmask16 nan_mask = _mm512_cmp_epu32_mask(
+      absolute_bits,
+      _mm512_set1_epi32(0x7f800000),
+      _MM_CMPINT_GT);
+  const __m512i rounding = _mm512_add_epi32(
+      _mm512_set1_epi32(0x7fff),
+      _mm512_and_si512(_mm512_srli_epi32(bits, 16), _mm512_set1_epi32(1)));
+  const __m512i upper = _mm512_srli_epi32(
+      _mm512_add_epi32(bits, rounding),
+      16);
+  return _mm256_mask_mov_epi16(
+      _mm512_cvtepi32_epi16(upper),
+      nan_mask,
+      _mm256_set1_epi16(0x7fc0));
+}
+
+template <typename scalar_t>
+ORBITQUANT_TARGET_AVX2 void quantize_lookup_avx2(
+    ActivationArgs const &args,
+    float const *scratch,
+    std::int64_t output_offset,
+    float norm) {
+  const __m256 inverse_sqrt_block = _mm256_set1_ps(args.inv_sqrt_block);
+  const __m256 output_norm = _mm256_set1_ps(norm);
+  const __m256i ones = _mm256_set1_epi32(1);
+  std::int64_t index = 0;
+  for (; index + 8 <= args.dim; index += 8) {
+    const __m256 direction = _mm256_mul_ps(
+        _mm256_loadu_ps(scratch + index), inverse_sqrt_block);
+    __m256i centroid_indices = _mm256_setzero_si256();
+    for (std::int64_t boundary = 0; boundary < args.boundary_count; ++boundary) {
+      const __m256 comparison = _mm256_cmp_ps(
+          direction,
+          _mm256_set1_ps(args.boundaries[boundary]),
+          _CMP_NLE_UQ);
+      centroid_indices = _mm256_add_epi32(
+          centroid_indices,
+          _mm256_and_si256(_mm256_castps_si256(comparison), ones));
+    }
+    const __m256 output = _mm256_mul_ps(
+        _mm256_i32gather_ps(args.centroids, centroid_indices, 4), output_norm);
+    if constexpr (std::is_same_v<scalar_t, float>) {
+      _mm256_storeu_ps(
+          static_cast<float *>(args.out) + output_offset + index,
+          output);
+    } else if constexpr (std::is_same_v<scalar_t, c10::Half>) {
+      _mm_storeu_si128(
+          reinterpret_cast<__m128i *>(
+              static_cast<std::uint16_t *>(args.out) + output_offset + index),
+          _mm256_cvtps_ph(output, _MM_FROUND_TO_NEAREST_INT));
+    } else {
+      _mm_storeu_si128(
+          reinterpret_cast<__m128i *>(
+              static_cast<std::uint16_t *>(args.out) + output_offset + index),
+          float8_to_bfloat8(output));
+    }
+  }
+  quantize_lookup_scalar<scalar_t>(args, scratch, output_offset, norm, index);
+}
+
+template <typename scalar_t>
+ORBITQUANT_TARGET_AVX512 void quantize_lookup_avx512(
+    ActivationArgs const &args,
+    float const *scratch,
+    std::int64_t output_offset,
+    float norm) {
+  const __m512 inverse_sqrt_block = _mm512_set1_ps(args.inv_sqrt_block);
+  const __m512 output_norm = _mm512_set1_ps(norm);
+  const __m512i ones = _mm512_set1_epi32(1);
+  std::int64_t index = 0;
+  for (; index + 16 <= args.dim; index += 16) {
+    const __m512 direction = _mm512_mul_ps(
+        _mm512_loadu_ps(scratch + index), inverse_sqrt_block);
+    __m512i centroid_indices = _mm512_setzero_si512();
+    for (std::int64_t boundary = 0; boundary < args.boundary_count; ++boundary) {
+      const __mmask16 comparison = _mm512_cmp_ps_mask(
+          direction,
+          _mm512_set1_ps(args.boundaries[boundary]),
+          _CMP_NLE_UQ);
+      centroid_indices = _mm512_mask_add_epi32(
+          centroid_indices,
+          comparison,
+          centroid_indices,
+          ones);
+    }
+    const __m512 output = _mm512_mul_ps(
+        _mm512_i32gather_ps(centroid_indices, args.centroids, 4),
+        output_norm);
+    if constexpr (std::is_same_v<scalar_t, float>) {
+      _mm512_storeu_ps(
+          static_cast<float *>(args.out) + output_offset + index,
+          output);
+    } else if constexpr (std::is_same_v<scalar_t, c10::Half>) {
+      _mm256_storeu_si256(
+          reinterpret_cast<__m256i *>(
+              static_cast<std::uint16_t *>(args.out) + output_offset + index),
+          _mm512_cvtps_ph(output, _MM_FROUND_TO_NEAREST_INT));
+    } else {
+      _mm256_storeu_si256(
+          reinterpret_cast<__m256i *>(
+              static_cast<std::uint16_t *>(args.out) + output_offset + index),
+          float16_to_bfloat16(output));
+    }
+  }
+  quantize_lookup_scalar<scalar_t>(args, scratch, output_offset, norm, index);
+}
+#endif
+
+template <typename scalar_t>
+void quantize_lookup(
+    ActivationArgs const &args,
+    float const *scratch,
+    std::int64_t output_offset,
+    float norm,
+    ActivationIsa isa) {
+#if defined(__x86_64__) || defined(_M_X64)
+  if (isa == ActivationIsa::Avx512) {
+#if defined(_MSC_VER)
+    orbitquant::cpu::activation_quantize_lookup_msvc_avx2(
+        args, scratch, output_offset, norm);
+#else
+    quantize_lookup_avx512<scalar_t>(args, scratch, output_offset, norm);
+#endif
+    return;
+  }
+  if (isa == ActivationIsa::Avx2) {
+#if defined(_MSC_VER)
+    orbitquant::cpu::activation_quantize_lookup_msvc_avx2(
+        args, scratch, output_offset, norm);
+#else
+    quantize_lookup_avx2<scalar_t>(args, scratch, output_offset, norm);
+#endif
+    return;
+  }
+#endif
+  quantize_lookup_scalar<scalar_t>(args, scratch, output_offset, norm);
+}
+
+template <typename scalar_t>
+void quantize_activation_range(
+    ActivationArgs const &args,
+    std::int64_t row_start,
+    std::int64_t row_end) {
+  std::vector<float> scratch(static_cast<std::size_t>(args.dim));
+  for (std::int64_t row = row_start; row < row_end; ++row) {
+    const std::int64_t input_offset = row * args.dim;
+    const float norm_squared =
+        squared_norm<scalar_t>(args.x, input_offset, args.dim, args.isa);
+    const float norm = std::sqrt(norm_squared);
+    const float inverse_norm = 1.0f / (norm + args.eps);
+    for (std::int64_t index = 0; index < args.dim; ++index) {
+      const float value = load_scalar<scalar_t>(
+          args.x,
+          input_offset + args.permutation[index]);
+      scratch[index] = value * static_cast<float>(args.signs[index]) * inverse_norm;
+    }
+    for (std::int64_t block = 0; block < args.dim; block += args.block_size) {
+      fwht_block(scratch.data() + block, args.block_size, args.isa);
+    }
+    quantize_lookup<scalar_t>(
+        args,
+        scratch.data(),
+        input_offset,
+        norm,
+        args.isa);
+  }
+}
+
+void quantize_activation_dispatch(
+    ActivationArgs const &args,
+    std::int64_t row_start,
+    std::int64_t row_end) {
+  switch (args.scalar_kind) {
+    case orbitquant::cpu::ScalarKind::Float32:
+      quantize_activation_range<float>(args, row_start, row_end);
+      return;
+    case orbitquant::cpu::ScalarKind::Float16:
+      quantize_activation_range<c10::Half>(args, row_start, row_end);
+      return;
+    case orbitquant::cpu::ScalarKind::BFloat16:
+      quantize_activation_range<c10::BFloat16>(args, row_start, row_end);
+      return;
+  }
+}
+
+void parallel_quantize_activations(ActivationArgs const &args) {
+  const std::int64_t values = args.rows * args.dim;
+  const int threads = values < 16'384
+      ? 1
+      : std::max<int>(
+            1,
+            std::min<std::int64_t>(
+                orbitquant::cpu::requested_threads(),
+                args.rows));
+  if (threads == 1) {
+    quantize_activation_dispatch(args, 0, args.rows);
+    return;
+  }
+
+  std::vector<std::thread> workers;
+  workers.reserve(threads);
+  const std::int64_t rows_per_thread = (args.rows + threads - 1) / threads;
+  for (int thread = 0; thread < threads; ++thread) {
+    const std::int64_t start = thread * rows_per_thread;
+    const std::int64_t end = std::min(args.rows, start + rows_per_thread);
+    if (start >= end) {
+      break;
+    }
+    workers.emplace_back([&args, start, end] {
+      quantize_activation_dispatch(args, start, end);
+    });
+  }
+  for (auto &worker : workers) {
+    worker.join();
+  }
+}
+
+}  // namespace
+
+void quantize_activations_cpu(
+    OrbitQuantTensor &out,
+    OrbitQuantTensor const &x,
+    OrbitQuantTensor const &permutation,
+    OrbitQuantTensor const &signs,
+    OrbitQuantTensor const &centroids,
+    OrbitQuantTensor const &boundaries,
+    double eps,
+    double inv_sqrt_block,
+    int64_t block_size) {
+  using torch::headeronly::DeviceType;
+  using torch::headeronly::ScalarType;
+
+  STD_TORCH_CHECK(x.device().type() == DeviceType::CPU, "x must be a CPU tensor");
+  STD_TORCH_CHECK(out.device().type() == DeviceType::CPU, "out must be a CPU tensor");
+  STD_TORCH_CHECK(
+      permutation.device().type() == DeviceType::CPU,
+      "permutation must be a CPU tensor");
+  STD_TORCH_CHECK(signs.device().type() == DeviceType::CPU, "signs must be a CPU tensor");
+  STD_TORCH_CHECK(
+      centroids.device().type() == DeviceType::CPU,
+      "centroids must be a CPU tensor");
+  STD_TORCH_CHECK(
+      boundaries.device().type() == DeviceType::CPU,
+      "boundaries must be a CPU tensor");
+  STD_TORCH_CHECK(x.is_contiguous(), "x must be contiguous");
+  STD_TORCH_CHECK(out.is_contiguous(), "out must be contiguous");
+  STD_TORCH_CHECK(permutation.is_contiguous(), "permutation must be contiguous");
+  STD_TORCH_CHECK(signs.is_contiguous(), "signs must be contiguous");
+  STD_TORCH_CHECK(centroids.is_contiguous(), "centroids must be contiguous");
+  STD_TORCH_CHECK(boundaries.is_contiguous(), "boundaries must be contiguous");
+  STD_TORCH_CHECK(out.scalar_type() == x.scalar_type(), "out dtype must match x dtype");
+  STD_TORCH_CHECK(
+      permutation.scalar_type() == ScalarType::Long,
+      "permutation must be int64");
+  STD_TORCH_CHECK(signs.scalar_type() == ScalarType::Char, "signs must be int8");
+  STD_TORCH_CHECK(centroids.scalar_type() == ScalarType::Float, "centroids must be float32");
+  STD_TORCH_CHECK(boundaries.scalar_type() == ScalarType::Float, "boundaries must be float32");
+  STD_TORCH_CHECK(x.dim() == 2, "x must be rank 2");
+  STD_TORCH_CHECK(out.dim() == 2, "out must be rank 2");
+  STD_TORCH_CHECK(out.size(0) == x.size(0), "out row count must match x");
+  STD_TORCH_CHECK(out.size(1) == x.size(1), "out dimension must match x");
+  const int64_t dim = x.size(1);
+  STD_TORCH_CHECK(permutation.numel() == dim, "permutation must match the input dimension");
+  STD_TORCH_CHECK(signs.numel() == dim, "signs must match the input dimension");
+  STD_TORCH_CHECK(
+      centroids.numel() == boundaries.numel() + 1,
+      "centroids must contain exactly one more value than boundaries");
+  STD_TORCH_CHECK(centroids.numel() >= 2, "at least two centroids are required");
+  STD_TORCH_CHECK(block_size > 0, "block_size must be positive");
+  STD_TORCH_CHECK(
+      (block_size & (block_size - 1)) == 0,
+      "block_size must be a power of two");
+  STD_TORCH_CHECK(dim % block_size == 0, "block_size must divide the input dimension");
+  STD_TORCH_CHECK(eps >= 0.0, "eps must be non-negative");
+  STD_TORCH_CHECK(inv_sqrt_block > 0.0, "inv_sqrt_block must be positive");
+
+  const auto *permutation_values = permutation.const_data_ptr<std::int64_t>();
+  const auto *sign_values = signs.const_data_ptr<std::int8_t>();
+  for (int64_t index = 0; index < dim; ++index) {
+    STD_TORCH_CHECK(
+        permutation_values[index] >= 0 && permutation_values[index] < dim,
+        "permutation contains an out-of-range index");
+    STD_TORCH_CHECK(
+        sign_values[index] == -1 || sign_values[index] == 1,
+        "signs must contain only -1 and 1");
+  }
+  if (x.numel() == 0) {
+    return;
+  }
+
+  const ActivationArgs args{
+      out.mutable_data_ptr(),
+      x.const_data_ptr(),
+      permutation_values,
+      sign_values,
+      centroids.const_data_ptr<float>(),
+      boundaries.const_data_ptr<float>(),
+      activation_scalar_kind(x),
+      select_activation_isa(),
+      x.size(0),
+      dim,
+      boundaries.numel(),
+      block_size,
+      static_cast<float>(eps),
+      static_cast<float>(inv_sqrt_block),
+  };
+  parallel_quantize_activations(args);
+}

--- a/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
+++ b/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
@@ -32,6 +32,16 @@ def main() -> None:
 
     setup = args.project / "setup.py"
     setup_text = setup.read_text(encoding="utf-8")
+
+    shutil_import = "from shutil import which, move\n"
+    if setup_text.count(shutil_import) != 1:
+        raise RuntimeError("generated setup must contain one shutil import")
+    setup_text = setup_text.replace(
+        shutil_import,
+        "from shutil import copy2, move, which\n",
+        1,
+    )
+
     cmake_args = '    if "CMAKE_ARGS" in os.environ:\n'
     if setup_text.count(cmake_args) != 1:
         raise RuntimeError("generated setup must contain one CMake arguments block")
@@ -64,6 +74,24 @@ def main() -> None:
         "        build_temp = (Path(build_temp_root) / ext.name).resolve()\n",
         1,
     )
+
+    build_call = (
+        "        subprocess.run(\n"
+        '            ["cmake", "--build", str(build_temp), *build_args], '
+        "cwd=build_temp, check=True\n"
+        "        )\n"
+    )
+    if setup_text.count(build_call) != 1:
+        raise RuntimeError("generated setup must contain one wheel CMake build call")
+    wheel_build_call = build_call + (
+        "\n"
+        '        package_name = ext.name.split(".", 1)[0]\n'
+        "        generated_ops = (\n"
+        '            Path(ext.sourcedir) / "torch-ext" / package_name / "_ops.py"\n'
+        "        )\n"
+        '        copy2(generated_ops, extdir / "_ops.py")\n'
+    )
+    setup_text = setup_text.replace(build_call, wheel_build_call, 1)
     setup.write_text(setup_text, encoding="utf-8")
 
 

--- a/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
+++ b/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
@@ -30,6 +30,19 @@ def main() -> None:
     )
     pyproject.write_text(text, encoding="utf-8")
 
+    setup = args.project / "setup.py"
+    setup_text = setup.read_text(encoding="utf-8")
+    ninja_path = 'ninja_executable_path = Path(ninja.BIN_DIR) / "ninja"'
+    if setup_text.count(ninja_path) != 1:
+        raise RuntimeError("generated setup must contain one Ninja executable path")
+    setup_text = setup_text.replace(
+        ninja_path,
+        "ninja_executable_path = Path(ninja.BIN_DIR) / "
+        '("ninja.exe" if os.name == "nt" else "ninja")',
+        1,
+    )
+    setup.write_text(setup_text, encoding="utf-8")
+
 
 if __name__ == "__main__":
     main()

--- a/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
+++ b/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
@@ -92,6 +92,15 @@ def main() -> None:
         '        copy2(generated_ops, extdir / "_ops.py")\n'
     )
     setup_text = setup_text.replace(build_call, wheel_build_call, 1)
+
+    zip_safe = "    zip_safe=False,\n"
+    if setup_text.count(zip_safe) != 1:
+        raise RuntimeError("generated setup must contain one zip-safe option")
+    setup_text = setup_text.replace(
+        zip_safe,
+        '    options={"bdist_wheel": {"py_limited_api": "cp39"}},\n' + zip_safe,
+        1,
+    )
     setup.write_text(setup_text, encoding="utf-8")
 
 

--- a/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
+++ b/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
@@ -32,6 +32,29 @@ def main() -> None:
 
     setup = args.project / "setup.py"
     setup_text = setup.read_text(encoding="utf-8")
+
+    cmake_args = '    if "CMAKE_ARGS" in os.environ:\n'
+    if setup_text.count(cmake_args) != 1:
+        raise RuntimeError("generated setup must contain one CMake arguments block")
+    setup_text = setup_text.replace(
+        cmake_args,
+        '    if "CMAKE_MAKE_PROGRAM" in os.environ:\n'
+        "        cmake_args.append(\n"
+        '            f"-DCMAKE_MAKE_PROGRAM:FILEPATH='
+        "{os.environ['CMAKE_MAKE_PROGRAM']}" + '"\n'
+        "        )\n\n" + cmake_args,
+        1,
+    )
+
+    ccache_condition = "    elif is_ccache_available():\n"
+    if setup_text.count(ccache_condition) != 1:
+        raise RuntimeError("generated setup must contain one ccache condition")
+    setup_text = setup_text.replace(
+        ccache_condition,
+        '    elif is_ccache_available() and sys.platform != "win32":\n',
+        1,
+    )
+
     windows_move = '        if sys.platform == "win32":\n'
     if setup_text.count(windows_move) != 1:
         raise RuntimeError("generated setup must contain one Windows output move")

--- a/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
+++ b/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
@@ -30,41 +30,6 @@ def main() -> None:
     )
     pyproject.write_text(text, encoding="utf-8")
 
-    setup = args.project / "setup.py"
-    setup_text = setup.read_text(encoding="utf-8")
-
-    cmake_args = '    if "CMAKE_ARGS" in os.environ:\n'
-    if setup_text.count(cmake_args) != 1:
-        raise RuntimeError("generated setup must contain one CMake arguments block")
-    setup_text = setup_text.replace(
-        cmake_args,
-        '    if "CMAKE_MAKE_PROGRAM" in os.environ:\n'
-        "        cmake_args.append(\n"
-        '            f"-DCMAKE_MAKE_PROGRAM:FILEPATH='
-        "{os.environ['CMAKE_MAKE_PROGRAM']}" + '"\n'
-        "        )\n\n" + cmake_args,
-        1,
-    )
-
-    ccache_condition = "    elif is_ccache_available():\n"
-    if setup_text.count(ccache_condition) != 1:
-        raise RuntimeError("generated setup must contain one ccache condition")
-    setup_text = setup_text.replace(
-        ccache_condition,
-        '    elif is_ccache_available() and sys.platform != "win32":\n',
-        1,
-    )
-
-    windows_move = '        if sys.platform == "win32":\n'
-    if setup_text.count(windows_move) != 1:
-        raise RuntimeError("generated setup must contain one Windows output move")
-    setup_text = setup_text.replace(
-        windows_move,
-        '        if sys.platform == "win32" and (extdir / cfg).is_dir():\n',
-        1,
-    )
-    setup.write_text(setup_text, encoding="utf-8")
-
 
 if __name__ == "__main__":
     main()

--- a/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
+++ b/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
@@ -44,6 +44,15 @@ def main() -> None:
         "        )\n\n" + cmake_args,
         1,
     )
+
+    ccache_condition = "    elif is_ccache_available():\n"
+    if setup_text.count(ccache_condition) != 1:
+        raise RuntimeError("generated setup must contain one ccache condition")
+    setup_text = setup_text.replace(
+        ccache_condition,
+        '    elif is_ccache_available() and sys.platform != "win32":\n',
+        1,
+    )
     setup.write_text(setup_text, encoding="utf-8")
 
 

--- a/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
+++ b/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
@@ -53,6 +53,17 @@ def main() -> None:
         '    elif is_ccache_available() and sys.platform != "win32":\n',
         1,
     )
+
+    build_temp = "        build_temp = Path(self.build_temp) / ext.name\n"
+    if setup_text.count(build_temp) != 1:
+        raise RuntimeError("generated setup must contain one extension build path")
+    setup_text = setup_text.replace(
+        build_temp,
+        '        build_temp_root = os.environ.get("ORBITQUANT_BUILD_TEMP", '
+        "self.build_temp)\n"
+        "        build_temp = (Path(build_temp_root) / ext.name).resolve()\n",
+        1,
+    )
     setup.write_text(setup_text, encoding="utf-8")
 
 

--- a/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
+++ b/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
@@ -30,6 +30,22 @@ def main() -> None:
     )
     pyproject.write_text(text, encoding="utf-8")
 
+    setup = args.project / "setup.py"
+    setup_text = setup.read_text(encoding="utf-8")
+    cmake_args = '    if "CMAKE_ARGS" in os.environ:\n'
+    if setup_text.count(cmake_args) != 1:
+        raise RuntimeError("generated setup must contain one CMake arguments block")
+    setup_text = setup_text.replace(
+        cmake_args,
+        '    if "CMAKE_MAKE_PROGRAM" in os.environ:\n'
+        "        cmake_args.append(\n"
+        '            f"-DCMAKE_MAKE_PROGRAM:FILEPATH='
+        "{os.environ['CMAKE_MAKE_PROGRAM']}" + '"\n'
+        "        )\n\n" + cmake_args,
+        1,
+    )
+    setup.write_text(setup_text, encoding="utf-8")
+
 
 if __name__ == "__main__":
     main()

--- a/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
+++ b/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
@@ -37,7 +37,7 @@ def main() -> None:
         raise RuntimeError("generated setup must contain one Ninja executable path")
     setup_text = setup_text.replace(
         ninja_path,
-        "ninja_executable_path = Path(ninja.BIN_DIR) / "
+        'ninja_executable_path = which("ninja") or Path(ninja.BIN_DIR) / '
         '("ninja.exe" if os.name == "nt" else "ninja")',
         1,
     )

--- a/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
+++ b/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
@@ -32,13 +32,12 @@ def main() -> None:
 
     setup = args.project / "setup.py"
     setup_text = setup.read_text(encoding="utf-8")
-    ninja_path = 'ninja_executable_path = Path(ninja.BIN_DIR) / "ninja"'
-    if setup_text.count(ninja_path) != 1:
-        raise RuntimeError("generated setup must contain one Ninja executable path")
+    windows_move = '        if sys.platform == "win32":\n'
+    if setup_text.count(windows_move) != 1:
+        raise RuntimeError("generated setup must contain one Windows output move")
     setup_text = setup_text.replace(
-        ninja_path,
-        'ninja_executable_path = which("ninja") or Path(ninja.BIN_DIR) / '
-        '("ninja.exe" if os.name == "nt" else "ninja")',
+        windows_move,
+        '        if sys.platform == "win32" and (extdir / cfg).is_dir():\n',
         1,
     )
     setup.write_text(setup_text, encoding="utf-8")

--- a/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
+++ b/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Prepare kernel-builder output for a platform wheel build."
+    )
+    parser.add_argument("project", type=Path)
+    parser.add_argument("--version", required=True)
+    args = parser.parse_args()
+
+    pyproject = args.project / "pyproject.toml"
+    text = pyproject.read_text(encoding="utf-8")
+
+    old_version = 'version = "0.1.0"'
+    if text.count(old_version) != 1:
+        raise RuntimeError("generated pyproject must contain one stub version")
+    text = text.replace(old_version, f'version = "{args.version}"', 1)
+
+    requires_python = 'requires-python = ">=3.9"'
+    if text.count(requires_python) != 1:
+        raise RuntimeError("generated pyproject must contain one Python requirement")
+    text = text.replace(
+        requires_python,
+        f'{requires_python}\ndependencies = ["torch>=2.11"]',
+        1,
+    )
+    pyproject.write_text(text, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/native-kernels/orbitquant-packed-matmul/tests/test_packed_matmul.py
+++ b/native-kernels/orbitquant-packed-matmul/tests/test_packed_matmul.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
+import platform
+
 import pytest
 import torch
 from orbitquant_packed_matmul import (
+    matmul_packed_adaln_int4_cpu,
     matmul_packed_w4a4_int8,
     matmul_packed_weight,
+    quantize_activations_cpu,
     quantize_activations_int8,
     quantize_activations_packed_w4,
+    supports_cpu_activation,
+    supports_cpu_adaln,
+    supports_device,
 )
 
 
@@ -24,15 +31,17 @@ def _pack(values: torch.Tensor, bits: int) -> torch.Tensor:
 
 
 def _device() -> str:
-    if torch.cuda.is_available():
+    if supports_device("cuda") and torch.cuda.is_available():
         return "cuda"
-    if torch.backends.mps.is_available():
+    if supports_device("mps") and torch.backends.mps.is_available():
         return "mps"
-    pytest.skip("CUDA or MPS is required")
+    if supports_device("cpu"):
+        return "cpu"
+    pytest.skip("the built variant has no runnable backend")
 
 
 def _mps_device() -> str:
-    if not torch.backends.mps.is_available():
+    if not supports_device("mps") or not torch.backends.mps.is_available():
         pytest.skip("MPS is required")
     return "mps"
 
@@ -47,14 +56,215 @@ def _mps_bfloat16_device() -> str:
 
 
 def _cuda_device() -> str:
-    if not torch.cuda.is_available():
+    if not supports_device("cuda") or not torch.cuda.is_available():
         pytest.skip("CUDA is required")
     return "cuda"
+
+
+def _runnable_cpu_isas() -> list[str]:
+    machine = platform.machine().lower()
+    capability = torch.backends.cpu.get_cpu_capability().upper()
+    isas = ["scalar"]
+    if machine in {"x86_64", "amd64"} and capability in {"AVX2", "AVX512"}:
+        isas.append("avx2")
+    if machine in {"x86_64", "amd64"} and capability == "AVX512":
+        isas.append("avx512")
+    if machine in {"aarch64", "arm64"}:
+        isas.append("neon")
+    return isas
 
 
 def _row_norms(device: str, out_features: int) -> torch.Tensor:
     dtype = torch.bfloat16 if device == "cuda" else torch.float32
     return torch.linspace(0.5, 1.5, out_features, device=device, dtype=dtype)
+
+
+def _fwht_reference(values: torch.Tensor) -> torch.Tensor:
+    output = values.clone()
+    half = 1
+    while half < output.shape[-1]:
+        blocks = output.reshape(*output.shape[:-1], -1, 2 * half)
+        left = blocks[..., :half].clone()
+        right = blocks[..., half:].clone()
+        blocks[..., :half] = left + right
+        blocks[..., half:] = left - right
+        half *= 2
+    return output
+
+
+@pytest.mark.kernels_ci
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_quantize_activations_cpu_matches_independent_reference(dtype: torch.dtype) -> None:
+    if not supports_cpu_activation():
+        pytest.skip("the built variant has no native CPU activation pipeline")
+    torch.manual_seed(41)
+    dim = 24
+    block_size = 8
+    x = torch.randn(2, 3, dim, dtype=dtype)
+    x[0, 0].zero_()
+    permutation = torch.randperm(dim)
+    signs = torch.randint(0, 2, (dim,), dtype=torch.int8).mul(2).sub(1)
+    centroids = torch.tanh(torch.linspace(-1.7, 1.7, 16))
+    boundaries = (centroids[:-1] + centroids[1:]) / 2
+    eps = 1e-10
+
+    work = x.float()
+    norms = work.norm(dim=-1, keepdim=True)
+    unit = work / (norms + eps)
+    gathered = unit.index_select(-1, permutation) * signs.float()
+    rotated = _fwht_reference(gathered.reshape(2, 3, 3, block_size)) / block_size**0.5
+    rotated = rotated.reshape_as(work)
+    indices = (rotated.unsqueeze(-1) - centroids).abs().argmin(dim=-1)
+    expected = (centroids[indices] * norms).to(dtype)
+
+    actual = quantize_activations_cpu(
+        x,
+        permutation,
+        signs,
+        centroids,
+        boundaries,
+        eps=eps,
+        inv_sqrt_block=block_size**-0.5,
+        block_size=block_size,
+    )
+
+    torch.testing.assert_close(actual, expected, atol=2e-3, rtol=2e-3)
+    assert torch.equal(actual[0, 0], torch.zeros(dim, dtype=dtype))
+
+
+@pytest.mark.kernels_ci
+def test_cpu_runtime_isa_dispatch_matches_scalar_reference(monkeypatch) -> None:
+    if not supports_device("cpu") or not supports_cpu_activation():
+        pytest.skip("the built variant has no complete native CPU pipeline")
+    torch.manual_seed(43)
+    rows = 8
+    in_features = 64
+    out_features = 11
+    x = torch.randn(rows, in_features)
+    indices = torch.randint(0, 16, (out_features, in_features), dtype=torch.uint8)
+    packed = _pack(indices, 4)
+    row_norms = torch.linspace(0.5, 1.5, out_features)
+    centroids = torch.tanh(torch.linspace(-1.7, 1.7, 16))
+    boundaries = (centroids[:-1] + centroids[1:]) / 2
+    bias = torch.randn(out_features)
+    permutation = torch.randperm(in_features)
+    signs = torch.randint(0, 2, (in_features,), dtype=torch.int8).mul(2).sub(1)
+
+    outputs = {}
+    activations = {}
+    for isa in _runnable_cpu_isas():
+        monkeypatch.setenv("ORBITQUANT_CPU_ISA", isa)
+        activations[isa] = quantize_activations_cpu(
+            x,
+            permutation,
+            signs,
+            centroids,
+            boundaries,
+            eps=1e-10,
+            inv_sqrt_block=in_features**-0.5,
+            block_size=in_features,
+        )
+        outputs[isa] = matmul_packed_weight(
+            activations[isa],
+            packed,
+            row_norms,
+            centroids,
+            bits=4,
+            out_features=out_features,
+            in_features=in_features,
+            bias=bias,
+        )
+
+    for isa in _runnable_cpu_isas()[1:]:
+        torch.testing.assert_close(
+            activations[isa], activations["scalar"], atol=2e-6, rtol=2e-6
+        )
+        torch.testing.assert_close(outputs[isa], outputs["scalar"], atol=2e-5, rtol=2e-5)
+
+
+@pytest.mark.kernels_ci
+@pytest.mark.parametrize("group_size", [8, 64])
+@pytest.mark.parametrize("with_bias", [False, True])
+def test_matmul_packed_adaln_cpu_matches_independent_bf16_reference(
+    group_size: int,
+    with_bias: bool,
+) -> None:
+    if not supports_cpu_adaln():
+        pytest.skip("the built variant has no native CPU AdaLN kernel")
+    torch.manual_seed(47)
+    in_features = 65
+    out_features = 9
+    num_groups = (in_features + group_size - 1) // group_size
+    padded_in_features = num_groups * group_size
+    indices = torch.randint(
+        0,
+        16,
+        (out_features, num_groups, group_size),
+        dtype=torch.uint8,
+    )
+    indices.reshape(out_features, padded_in_features)[:, in_features:] = 8
+    packed = _pack(indices, 4)
+    scales = torch.rand(out_features, num_groups, dtype=torch.bfloat16).mul(0.1)
+    x = torch.randn(2, 3, in_features, dtype=torch.bfloat16)
+    bias = torch.randn(out_features, dtype=torch.bfloat16) if with_bias else None
+
+    signed = indices.to(torch.int16).sub(8).float()
+    weight = (signed * scales.float()[..., None]).reshape(
+        out_features, padded_in_features
+    )[:, :in_features]
+    expected = torch.nn.functional.linear(x, weight.to(torch.bfloat16), bias)
+    actual = matmul_packed_adaln_int4_cpu(
+        x,
+        packed,
+        scales,
+        out_features=out_features,
+        in_features=in_features,
+        group_size=group_size,
+        bias=bias,
+    )
+
+    assert actual.dtype == torch.bfloat16
+    assert actual.shape == (2, 3, out_features)
+    torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.kernels_ci
+def test_cpu_adaln_runtime_isa_dispatch_matches_scalar_reference(monkeypatch) -> None:
+    if not supports_cpu_adaln():
+        pytest.skip("the built variant has no native CPU AdaLN kernel")
+    torch.manual_seed(53)
+    rows = 8
+    in_features = 64
+    out_features = 11
+    group_size = 64
+    indices = torch.randint(
+        0,
+        16,
+        (out_features, 1, group_size),
+        dtype=torch.uint8,
+    )
+    packed = _pack(indices, 4)
+    scales = torch.rand(out_features, 1, dtype=torch.bfloat16).mul(0.1)
+    x = torch.randn(rows, in_features, dtype=torch.bfloat16)
+    bias = torch.randn(out_features, dtype=torch.bfloat16)
+
+    outputs = {}
+    for isa in _runnable_cpu_isas():
+        monkeypatch.setenv("ORBITQUANT_CPU_ISA", isa)
+        outputs[isa] = matmul_packed_adaln_int4_cpu(
+            x,
+            packed,
+            scales,
+            out_features=out_features,
+            in_features=in_features,
+            group_size=group_size,
+            bias=bias,
+        )
+
+    for isa in _runnable_cpu_isas()[1:]:
+        torch.testing.assert_close(
+            outputs[isa], outputs["scalar"], atol=3e-2, rtol=3e-2
+        )
 
 
 @pytest.mark.kernels_ci
@@ -113,6 +323,7 @@ def test_matmul_packed_weight_short_sequence_matches_reference(
     in_features: int,
     out_features: int,
 ) -> None:
+    torch.manual_seed(1000 + bits * 100 + rows * 10 + in_features + out_features)
     device = _device()
     dtype = torch.float16 if device == "mps" else torch.bfloat16
     x = torch.randn(rows, in_features, device=device, dtype=dtype)
@@ -123,7 +334,16 @@ def test_matmul_packed_weight_short_sequence_matches_reference(
     bias = torch.randn(out_features, device=device, dtype=dtype)
 
     expected_weight = row_norms.cpu()[:, None] * centroids.cpu()[indices.long()]
-    expected = torch.nn.functional.linear(x.float().cpu(), expected_weight, bias.float().cpu())
+    if device == "cpu":
+        expected = torch.nn.functional.linear(
+            x.cpu(),
+            expected_weight.to(torch.bfloat16),
+            bias.cpu(),
+        ).float()
+    else:
+        expected = torch.nn.functional.linear(
+            x.float().cpu(), expected_weight, bias.float().cpu()
+        )
     actual = matmul_packed_weight(
         x,
         packed,

--- a/native-kernels/orbitquant-packed-matmul/torch-ext/orbitquant_packed_matmul/__init__.py
+++ b/native-kernels/orbitquant-packed-matmul/torch-ext/orbitquant_packed_matmul/__init__.py
@@ -6,10 +6,103 @@ from ._ops import ops
 
 __all__ = [
     "matmul_packed_w4a4_int8",
+    "matmul_packed_adaln_int4_cpu",
     "matmul_packed_weight",
+    "quantize_activations_cpu",
     "quantize_activations_int8",
     "quantize_activations_packed_w4",
+    "supports_cpu_activation",
+    "supports_cpu_adaln",
+    "supports_device",
 ]
+
+
+def supports_device(device_type: str) -> bool:
+    dispatch_keys = {
+        "cpu": "CPU",
+        "cuda": "CUDA",
+        "mps": "MPS",
+    }
+    try:
+        dispatch_key = dispatch_keys[device_type]
+    except KeyError as exc:
+        raise ValueError(f"unknown device type {device_type!r}") from exc
+    return bool(
+        torch._C._dispatch_has_kernel_for_dispatch_key(  # noqa: SLF001
+            ops.matmul_packed_weight._qualified_op_name,  # noqa: SLF001
+            dispatch_key,
+        )
+    )
+
+
+def supports_cpu_activation() -> bool:
+    try:
+        operation = ops.quantize_activations_cpu
+        qualified_name = operation._qualified_op_name  # noqa: SLF001
+    except (AttributeError, RuntimeError):
+        return False
+    return bool(
+        torch._C._dispatch_has_kernel_for_dispatch_key(  # noqa: SLF001
+            qualified_name,
+            "CPU",
+        )
+    )
+
+
+def supports_cpu_adaln() -> bool:
+    try:
+        operation = ops.matmul_packed_adaln_int4_cpu
+        qualified_name = operation._qualified_op_name  # noqa: SLF001
+    except (AttributeError, RuntimeError):
+        return False
+    return bool(
+        torch._C._dispatch_has_kernel_for_dispatch_key(  # noqa: SLF001
+            qualified_name,
+            "CPU",
+        )
+    )
+
+
+def quantize_activations_cpu(
+    x: torch.Tensor,
+    permutation: torch.Tensor,
+    signs: torch.Tensor,
+    centroids: torch.Tensor,
+    boundaries: torch.Tensor,
+    *,
+    eps: float,
+    inv_sqrt_block: float,
+    block_size: int,
+) -> torch.Tensor:
+    if x.device.type != "cpu":
+        raise RuntimeError("native CPU activation quantization requires CPU tensors")
+    if x.dtype not in {torch.float32, torch.float16, torch.bfloat16}:
+        raise ValueError("x must be float32, float16, or bfloat16")
+    if block_size <= 0 or block_size & (block_size - 1):
+        raise ValueError("block_size must be a positive power of two")
+    dim = x.shape[-1]
+    if dim % block_size != 0:
+        raise ValueError("block_size must divide the input dimension")
+
+    original_shape = x.shape
+    values = x.contiguous().reshape(-1, dim)
+    out = torch.empty_like(values)
+    permutation_values = permutation.to(device="cpu", dtype=torch.int64).contiguous()
+    sign_values = signs.to(device="cpu", dtype=torch.int8).contiguous()
+    centroid_values = centroids.to(device="cpu", dtype=torch.float32).contiguous()
+    boundary_values = boundaries.to(device="cpu", dtype=torch.float32).contiguous()
+    ops.quantize_activations_cpu(
+        out,
+        values,
+        permutation_values,
+        sign_values,
+        centroid_values,
+        boundary_values,
+        eps,
+        inv_sqrt_block,
+        block_size,
+    )
+    return out.reshape(original_shape)
 
 
 def matmul_packed_weight(
@@ -62,6 +155,50 @@ def matmul_packed_weight(
         block_m,
         block_n,
         block_k,
+    )
+    return out.reshape(*original_shape[:-1], out_features)
+
+
+def matmul_packed_adaln_int4_cpu(
+    x: torch.Tensor,
+    packed_weight: torch.Tensor,
+    scales: torch.Tensor,
+    *,
+    out_features: int,
+    in_features: int,
+    group_size: int,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if x.device.type != "cpu":
+        raise RuntimeError("native packed AdaLN requires CPU tensors")
+    if x.shape[-1] != in_features:
+        raise ValueError(f"expected input last dimension {in_features}, got {x.shape[-1]}")
+    if group_size <= 0:
+        raise ValueError("group_size must be positive")
+
+    original_shape = x.shape
+    x_2d = x.to(dtype=torch.bfloat16).contiguous().reshape(-1, in_features)
+    out = torch.empty((x_2d.shape[0], out_features), dtype=torch.bfloat16)
+    packed = packed_weight.to(device="cpu", dtype=torch.uint8).contiguous()
+    scale_values = scales.to(device="cpu", dtype=torch.float32).contiguous()
+    if bias is None:
+        bias_values = torch.empty((1,), dtype=torch.float32)
+        has_bias = False
+    else:
+        bias_values = (
+            bias.to(device="cpu", dtype=torch.bfloat16).to(dtype=torch.float32).contiguous()
+        )
+        has_bias = True
+    ops.matmul_packed_adaln_int4_cpu(
+        out,
+        x_2d,
+        packed,
+        scale_values,
+        bias_values,
+        has_bias,
+        out_features,
+        in_features,
+        group_size,
     )
     return out.reshape(*original_shape[:-1], out_features)
 

--- a/native-kernels/orbitquant-packed-matmul/torch-ext/torch_binding.cpp
+++ b/native-kernels/orbitquant-packed-matmul/torch-ext/torch_binding.cpp
@@ -1,7 +1,33 @@
-#include <torch/library.h>
-
 #include "registration.h"
 #include "torch_binding.h"
+
+#if defined(CPU_KERNEL)
+#include <torch/csrc/stable/library.h>
+
+STABLE_TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
+  ops.def(
+      "matmul_packed_weight(Tensor! out, Tensor x, Tensor packed_weight_indices, "
+      "Tensor row_norms, Tensor centroids, Tensor bias, bool has_bias, int bits, "
+      "int out_features, int in_features, int block_m, int block_n, int block_k) -> ()");
+  ops.def(
+      "quantize_activations_cpu(Tensor! out, Tensor x, Tensor permutation, "
+      "Tensor signs, Tensor centroids, Tensor boundaries, float eps, "
+      "float inv_sqrt_block, int block_size) -> ()");
+  ops.def(
+      "matmul_packed_adaln_int4_cpu(Tensor! out, Tensor x, Tensor packed_weight, "
+      "Tensor scales, Tensor bias, bool has_bias, int out_features, "
+      "int in_features, int group_size) -> ()");
+}
+
+STABLE_TORCH_LIBRARY_IMPL_EXPAND(TORCH_EXTENSION_NAME, CPU, ops) {
+  ops.impl("matmul_packed_weight", TORCH_BOX(&matmul_packed_weight));
+  ops.impl("quantize_activations_cpu", TORCH_BOX(&quantize_activations_cpu));
+  ops.impl(
+      "matmul_packed_adaln_int4_cpu",
+      TORCH_BOX(&matmul_packed_adaln_int4_cpu));
+}
+#else
+#include <torch/library.h>
 
 TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.def(
@@ -38,5 +64,6 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.impl("matmul_packed_weight", torch::kMPS, &matmul_packed_weight);
 #endif
 }
+#endif
 
 REGISTER_EXTENSION(TORCH_EXTENSION_NAME)

--- a/native-kernels/orbitquant-packed-matmul/torch-ext/torch_binding.h
+++ b/native-kernels/orbitquant-packed-matmul/torch-ext/torch_binding.h
@@ -1,14 +1,20 @@
 #pragma once
 
+#if defined(CPU_KERNEL)
+#include <torch/csrc/stable/tensor.h>
+using OrbitQuantTensor = torch::stable::Tensor;
+#else
 #include <torch/torch.h>
+using OrbitQuantTensor = torch::Tensor;
+#endif
 
 void matmul_packed_weight(
-    torch::Tensor &out,
-    torch::Tensor const &x,
-    torch::Tensor const &packed_weight_indices,
-    torch::Tensor const &row_norms,
-    torch::Tensor const &centroids,
-    torch::Tensor const &bias,
+    OrbitQuantTensor &out,
+    OrbitQuantTensor const &x,
+    OrbitQuantTensor const &packed_weight_indices,
+    OrbitQuantTensor const &row_norms,
+    OrbitQuantTensor const &centroids,
+    OrbitQuantTensor const &bias,
     bool has_bias,
     int64_t bits,
     int64_t out_features,
@@ -16,6 +22,30 @@ void matmul_packed_weight(
     int64_t block_m,
     int64_t block_n,
     int64_t block_k);
+
+#if defined(CPU_KERNEL)
+void quantize_activations_cpu(
+    OrbitQuantTensor &out,
+    OrbitQuantTensor const &x,
+    OrbitQuantTensor const &permutation,
+    OrbitQuantTensor const &signs,
+    OrbitQuantTensor const &centroids,
+    OrbitQuantTensor const &boundaries,
+    double eps,
+    double inv_sqrt_block,
+    int64_t block_size);
+
+void matmul_packed_adaln_int4_cpu(
+    OrbitQuantTensor &out,
+    OrbitQuantTensor const &x,
+    OrbitQuantTensor const &packed_weight,
+    OrbitQuantTensor const &scales,
+    OrbitQuantTensor const &bias,
+    bool has_bias,
+    int64_t out_features,
+    int64_t in_features,
+    int64_t group_size);
+#endif
 
 #if defined(CUDA_KERNEL)
 void matmul_packed_w4a4_int8(

--- a/src/orbitquant/adaln.py
+++ b/src/orbitquant/adaln.py
@@ -58,6 +58,7 @@ class RTNInt4Linear(nn.Module):
         in_features: int,
         out_features: int,
         group_size: int,
+        runtime_mode: str,
         module_name: str,
         source_weight_layout: str,
         packed_weight: torch.Tensor,
@@ -68,6 +69,7 @@ class RTNInt4Linear(nn.Module):
         self.in_features = in_features
         self.out_features = out_features
         self.group_size = group_size
+        self.runtime_mode = runtime_mode
         self.module_name = module_name
         self.source_weight_layout = source_weight_layout
         self.num_groups = (in_features + group_size - 1) // group_size
@@ -79,6 +81,7 @@ class RTNInt4Linear(nn.Module):
             self.bias = nn.Parameter(bias.detach().clone(), requires_grad=False)
         self._dequantized_weight_cache: torch.Tensor | None = None
         self._dequantized_weight_cache_key: tuple[str, torch.dtype] | None = None
+        self.last_effective_runtime_mode: str | None = None
 
     def clear_dequantized_cache(self) -> None:
         self._dequantized_weight_cache = None
@@ -100,6 +103,7 @@ class RTNInt4Linear(nn.Module):
             in_features=spec.in_features,
             out_features=spec.out_features,
             group_size=group_size,
+            runtime_mode=config.runtime_mode,
             module_name=module_name,
             source_weight_layout=spec.weight_layout,
             packed_weight=packed,
@@ -134,6 +138,7 @@ class RTNInt4Linear(nn.Module):
             in_features=spec.in_features,
             out_features=spec.out_features,
             group_size=group_size,
+            runtime_mode=config.runtime_mode,
             module_name=module_name,
             source_weight_layout=spec.weight_layout,
             packed_weight=packed,
@@ -184,6 +189,44 @@ class RTNInt4Linear(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         activation = x.to(torch.bfloat16)
+        if x.device.type == "cpu" and self.runtime_mode in {
+            "auto_fused",
+            "native_packed_matmul",
+        }:
+            try:
+                from orbitquant.kernels.native_packed_matmul import (
+                    matmul_packed_adaln_int4_with_native_cpu_kernel,
+                    native_cpu_adaln_available,
+                )
+
+                native_available = native_cpu_adaln_available()
+            except Exception as exc:
+                if self.runtime_mode == "native_packed_matmul":
+                    raise RuntimeError(
+                        "native_packed_matmul AdaLN on CPU requires a current "
+                        "orbitquant_packed_matmul CPU package with the INT4 group "
+                        "kernel; install/build it or use runtime_mode='dequant_bf16'."
+                    ) from exc
+                native_available = False
+            if native_available:
+                self.last_effective_runtime_mode = "native_packed_adaln_int4"
+                return matmul_packed_adaln_int4_with_native_cpu_kernel(
+                    activation,
+                    self.packed_weight,
+                    self.scales,
+                    out_features=self.out_features,
+                    in_features=self.in_features,
+                    group_size=self.group_size,
+                    bias=self.bias,
+                )
+            if self.runtime_mode == "native_packed_matmul":
+                raise RuntimeError(
+                    "the loaded orbitquant_packed_matmul CPU package has no packed "
+                    "AdaLN INT4 kernel; build a current variant or use "
+                    "runtime_mode='dequant_bf16'."
+                )
+
+        self.last_effective_runtime_mode = "dequant_bf16"
         weight = self._dequantize_weight(device=x.device, dtype=torch.bfloat16)
         bias = None if self.bias is None else self.bias.to(device=x.device, dtype=torch.bfloat16)
         return F.linear(activation, weight, bias)

--- a/src/orbitquant/kernels/dispatch.py
+++ b/src/orbitquant/kernels/dispatch.py
@@ -12,6 +12,10 @@ BackendCapabilities = dict[str, dict[str, object]]
 _MPS_SHADER_STAGE = "activation_norm_rpbh_quant_rescale,packed_weight_dequant"
 _MPS_NATIVE_STAGE = "packed_weight_matmul"
 _MPS_IMPLEMENTED_STAGE = f"{_MPS_SHADER_STAGE},{_MPS_NATIVE_STAGE}"
+_CPU_IMPLEMENTED_STAGE = (
+    "activation_norm_rpbh_quant_rescale,packed_weight_matmul,"
+    "adaln_rtn_packed_matmul"
+)
 _TRITON_CUDA_IMPLEMENTED_STAGE = (
     "activation_norm_rpbh_quant_rescale,packed_weight_dequant,"
     "packed_weight_matmul,lowbit_pack,lowbit_unpack,weight_rotation_fwht_quant_pack,"
@@ -46,6 +50,39 @@ def _native_packed_matmul_available() -> bool:
     return True
 
 
+def _native_cpu_packed_matmul_available() -> bool:
+    try:
+        from orbitquant.kernels.native_packed_matmul import (
+            native_packed_matmul_device_available,
+        )
+
+        return native_packed_matmul_device_available("cpu")
+    except Exception:
+        return False
+
+
+def _native_cpu_activation_available() -> bool:
+    try:
+        from orbitquant.kernels.native_packed_matmul import (
+            native_cpu_activation_available,
+        )
+
+        return native_cpu_activation_available()
+    except Exception:
+        return False
+
+
+def _native_cpu_adaln_available() -> bool:
+    try:
+        from orbitquant.kernels.native_packed_matmul import (
+            native_cpu_adaln_available,
+        )
+
+        return native_cpu_adaln_available()
+    except Exception:
+        return False
+
+
 def _join_stages(stages: list[str]) -> str | None:
     return ",".join(stages) if stages else None
 
@@ -60,6 +97,63 @@ def available_backends() -> BackendAvailability:
 
 def backend_capabilities(backends: BackendAvailability | None = None) -> BackendCapabilities:
     available = available_backends() if backends is None else backends
+    cpu_native_matmul_optimized = bool(
+        available["cpu"] and _native_cpu_packed_matmul_available()
+    )
+    cpu_native_activation_optimized = bool(
+        available["cpu"] and _native_cpu_activation_available()
+    )
+    cpu_native_adaln_optimized = bool(
+        available["cpu"] and _native_cpu_adaln_available()
+    )
+    cpu_optimized_stages = _join_stages(
+        [
+            *(
+                ["activation_norm_rpbh_quant_rescale"]
+                if cpu_native_activation_optimized
+                else []
+            ),
+            *(["packed_weight_matmul"] if cpu_native_matmul_optimized else []),
+            *(
+                ["adaln_rtn_packed_matmul"]
+                if cpu_native_adaln_optimized
+                else []
+            ),
+        ]
+    )
+    cpu_implementation = (
+        "native_exact_activation+native_exact_packed_matmul"
+        if cpu_native_activation_optimized and cpu_native_matmul_optimized
+        else "native_exact_packed_matmul+torch_activation_reference"
+        if cpu_native_matmul_optimized
+        else "native_exact_activation+reference_weight_matmul"
+        if cpu_native_activation_optimized
+        else "torch_reference"
+    )
+    if cpu_native_adaln_optimized:
+        cpu_implementation += "+native_packed_adaln_int4"
+    cpu_notes = []
+    if cpu_native_activation_optimized:
+        cpu_notes.append(
+            "The native exact activation pipeline performs FP32 token norm, "
+            "RPBH/FWHT, codebook assignment, and rescale."
+        )
+    else:
+        cpu_notes.append("Activation quantization uses the reference PyTorch CPU path.")
+    if cpu_native_matmul_optimized:
+        cpu_notes.append(
+            "Native exact packed matmul consumes low-bit weights without a full "
+            "floating-point cache."
+        )
+    else:
+        cpu_notes.append("The main linear matmul uses the reference PyTorch CPU path.")
+    if cpu_native_adaln_optimized:
+        cpu_notes.append(
+            "Native packed INT4 AdaLN matmul consumes group-64 weights without a "
+            "full floating-point cache."
+        )
+    else:
+        cpu_notes.append("AdaLN uses the explicit BF16 dequantization path.")
     mps_shader_optimized = bool(available["mps"] and _mps_metal_available())
     mps_native_matmul_optimized = bool(
         available["mps"] and _native_packed_matmul_available()
@@ -98,22 +192,26 @@ def backend_capabilities(backends: BackendAvailability | None = None) -> Backend
     return {
         "cpu": {
             "available": bool(available["cpu"]),
-            "claim_status": "reference_only",
-            "optimized": False,
+            "claim_status": "partial_optimized"
+            if cpu_optimized_stages is not None
+            else "reference_only",
+            "optimized": cpu_optimized_stages is not None,
             "full_fusion": False,
-            "implemented_stage": None,
-            "optimized_stage": None,
+            "implemented_stage": _CPU_IMPLEMENTED_STAGE,
+            "optimized_stage": cpu_optimized_stages,
             "weight_dequant_optimized": False,
             "weight_pack_optimized": False,
             "lowbit_unpack_optimized": False,
             "weight_quant_optimized": False,
             "adaln_quant_optimized": False,
-            "adaln_dequant_optimized": False,
+            "adaln_dequant_optimized": cpu_native_adaln_optimized,
             "device_types": ["cpu"],
-            "implementation": "torch_reference",
-            "package_format": "torch_reference",
-            "hf_kernel_builder_compliant": False,
-            "notes": "Correctness baseline using the reference PyTorch path.",
+            "implementation": cpu_implementation,
+            "package_format": "native_kernel_package_torch_stable_abi"
+            if cpu_optimized_stages is not None
+            else "torch_reference",
+            "hf_kernel_builder_compliant": cpu_optimized_stages is not None,
+            "notes": " ".join(cpu_notes),
         },
         "mps": {
             "available": bool(available["mps"]),

--- a/src/orbitquant/kernels/native_packed_matmul.py
+++ b/src/orbitquant/kernels/native_packed_matmul.py
@@ -85,6 +85,94 @@ def load_native_packed_matmul_kernel() -> Any:
     return _load_native_packed_matmul_kernel()
 
 
+def native_packed_matmul_device_available(device_type: str) -> bool:
+    if device_type not in {"cpu", "cuda", "mps"}:
+        raise ValueError(f"unknown device type {device_type!r}")
+    kernel = _load_native_packed_matmul_kernel()
+    supports_device = getattr(kernel, "supports_device", None)
+    if callable(supports_device):
+        return bool(supports_device(device_type))
+    # Kernel variants built before CPU support did not expose capability
+    # introspection. They were CUDA- or Metal-only, never CPU variants.
+    return device_type in {"cuda", "mps"}
+
+
+def native_cpu_activation_available() -> bool:
+    kernel = _load_native_packed_matmul_kernel()
+    supports_cpu_activation = getattr(kernel, "supports_cpu_activation", None)
+    return callable(supports_cpu_activation) and bool(supports_cpu_activation())
+
+
+def native_cpu_adaln_available() -> bool:
+    kernel = _load_native_packed_matmul_kernel()
+    supports_cpu_adaln = getattr(kernel, "supports_cpu_adaln", None)
+    return callable(supports_cpu_adaln) and bool(supports_cpu_adaln())
+
+
+def quantize_activations_with_native_cpu_kernel(
+    x: torch.Tensor,
+    permutation: torch.Tensor,
+    signs: torch.Tensor,
+    centroids: torch.Tensor,
+    boundaries: torch.Tensor,
+    *,
+    eps: float,
+    inv_sqrt_block: float,
+    block_size: int,
+) -> torch.Tensor:
+    if x.device.type != "cpu":
+        raise RuntimeError("native CPU activation quantization requires CPU tensors")
+    kernel = _load_native_packed_matmul_kernel()
+    operation = getattr(kernel, "quantize_activations_cpu", None)
+    if not callable(operation) or not native_cpu_activation_available():
+        raise RuntimeError(
+            "the loaded native packed matmul package does not provide the CPU "
+            "activation pipeline. Build a current CPU variant or use the reference "
+            "activation backend."
+        )
+    return operation(
+        x,
+        permutation,
+        signs,
+        centroids,
+        boundaries,
+        eps=eps,
+        inv_sqrt_block=inv_sqrt_block,
+        block_size=block_size,
+    )
+
+
+def matmul_packed_adaln_int4_with_native_cpu_kernel(
+    x: torch.Tensor,
+    packed_weight: torch.Tensor,
+    scales: torch.Tensor,
+    *,
+    out_features: int,
+    in_features: int,
+    group_size: int,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if x.device.type != "cpu":
+        raise RuntimeError("native packed AdaLN requires CPU tensors")
+    kernel = _load_native_packed_matmul_kernel()
+    operation = getattr(kernel, "matmul_packed_adaln_int4_cpu", None)
+    if not callable(operation) or not native_cpu_adaln_available():
+        raise RuntimeError(
+            "the loaded native packed matmul package does not provide the CPU "
+            "AdaLN INT4 group kernel. Build a current CPU variant or use "
+            "runtime_mode='dequant_bf16'."
+        )
+    return operation(
+        x,
+        packed_weight,
+        scales,
+        out_features=out_features,
+        in_features=in_features,
+        group_size=group_size,
+        bias=bias,
+    )
+
+
 def native_packed_w4a4_available() -> bool:
     kernel = _load_native_packed_matmul_kernel()
     return callable(getattr(kernel, "matmul_packed_w4a4_int8", None))
@@ -114,14 +202,22 @@ def matmul_packed_weight_with_native_kernel(
     block_n: int = 64,
     block_k: int = 128,
 ) -> torch.Tensor:
-    if x.device.type not in {"cuda", "mps"}:
+    if x.device.type not in {"cpu", "cuda", "mps"}:
         raise RuntimeError(
-            f"native_packed_matmul runtime requires CUDA or MPS input tensors; got {x.device.type}."
+            "native_packed_matmul runtime requires CPU, CUDA, or MPS input tensors; "
+            f"got {x.device.type}."
         )
     if x.shape[-1] != in_features:
         raise ValueError(f"expected input last dimension {in_features}, got {x.shape[-1]}")
 
     kernel = _load_native_packed_matmul_kernel()
+    if not native_packed_matmul_device_available(x.device.type):
+        raise RuntimeError(
+            "the loaded native packed matmul package does not contain a "
+            f"{x.device.type.upper()} backend. Install or build a compatible variant, "
+            "or use runtime_mode='dequant_bf16'. "
+            f"{_runtime_variant_hint()}"
+        )
     centroids = codebook if isinstance(codebook, torch.Tensor) else codebook.centroids
     return kernel.matmul_packed_weight(
         x,

--- a/src/orbitquant/layers.py
+++ b/src/orbitquant/layers.py
@@ -13,6 +13,9 @@ from orbitquant.rotations import RPBHRotation, get_rpbh_rotation
 
 _PACKED_MATMUL_PROBE_MISSING = object()
 _NATIVE_PACKED_MATMUL_LOAD_ERROR: object | Exception | None = _PACKED_MATMUL_PROBE_MISSING
+_NATIVE_CPU_PACKED_MATMUL_LOAD_ERROR: object | Exception | None = (
+    _PACKED_MATMUL_PROBE_MISSING
+)
 _TRITON_PACKED_MATMUL_IMPORT_ERROR: object | Exception | None = _PACKED_MATMUL_PROBE_MISSING
 
 
@@ -119,18 +122,38 @@ def _triton_packed_matmul_import_error() -> Exception | None:
     return None
 
 
+def _native_cpu_packed_matmul_load_error() -> Exception | None:
+    global _NATIVE_CPU_PACKED_MATMUL_LOAD_ERROR
+    if _NATIVE_CPU_PACKED_MATMUL_LOAD_ERROR is not _PACKED_MATMUL_PROBE_MISSING:
+        return _NATIVE_CPU_PACKED_MATMUL_LOAD_ERROR
+    try:
+        from orbitquant.kernels.native_packed_matmul import (
+            native_packed_matmul_device_available,
+        )
+
+        if not native_packed_matmul_device_available("cpu"):
+            raise RuntimeError("the loaded native package has no CPU backend")
+    except Exception as exc:
+        _NATIVE_CPU_PACKED_MATMUL_LOAD_ERROR = exc
+        return exc
+    _NATIVE_CPU_PACKED_MATMUL_LOAD_ERROR = None
+    return None
+
+
 def _clear_packed_matmul_probe_cache() -> None:
+    global _NATIVE_CPU_PACKED_MATMUL_LOAD_ERROR
     global _NATIVE_PACKED_MATMUL_LOAD_ERROR, _TRITON_PACKED_MATMUL_IMPORT_ERROR
     _NATIVE_PACKED_MATMUL_LOAD_ERROR = _PACKED_MATMUL_PROBE_MISSING
+    _NATIVE_CPU_PACKED_MATMUL_LOAD_ERROR = _PACKED_MATMUL_PROBE_MISSING
     _TRITON_PACKED_MATMUL_IMPORT_ERROR = _PACKED_MATMUL_PROBE_MISSING
 
 
 class OrbitQuantLinear(nn.Module):
     """Linear layer with OrbitQuant-packed rotated weights.
 
-    The default runtime uses packed low-bit matmul on CUDA/MPS when the native
-    or Triton kernels are available. The explicit ``dequant_bf16`` mode keeps
-    the compatibility/debug reference path.
+    The default runtime uses packed low-bit matmul on CPU/CUDA/MPS when the
+    native or Triton kernels are available. The explicit ``dequant_bf16`` mode
+    keeps the compatibility/debug reference path.
     """
 
     def __init__(
@@ -330,7 +353,7 @@ class OrbitQuantLinear(nn.Module):
             row_norms = torch.empty(
                 spec.out_features, dtype=torch.bfloat16, device=layer.weight.device
             )
-        return cls(
+        empty = cls(
             in_features=spec.in_features,
             out_features=spec.out_features,
             config=config,
@@ -341,6 +364,11 @@ class OrbitQuantLinear(nn.Module):
             row_norms=row_norms,
             debug_weight=debug_weight,
         )
+        # Hugging Face streaming loaders may replace non-persistent buffers while
+        # moving an empty module skeleton out of meta initialization. Rebuild these
+        # deterministic RPBH/codebook constants on the first real forward.
+        empty._derived_constants_valid = False
+        return empty
 
     def clear_dequantized_cache(self) -> None:
         self._dequantized_weight_cache = None
@@ -414,9 +442,9 @@ class OrbitQuantLinear(nn.Module):
             )
 
     def _validate_native_packed_matmul_input(self, x: torch.Tensor) -> None:
-        if x.device.type not in {"cuda", "mps"}:
+        if x.device.type not in {"cpu", "cuda", "mps"}:
             raise RuntimeError(
-                "native_packed_matmul runtime requires CUDA or MPS input tensors; "
+                "native_packed_matmul runtime requires CPU, CUDA, or MPS input tensors; "
                 f"got {x.device.type}."
             )
 
@@ -442,6 +470,18 @@ class OrbitQuantLinear(nn.Module):
         except (ImportError, RuntimeError):
             return False
         return True
+
+    def _native_cpu_activation_available(self, x: torch.Tensor) -> bool:
+        if x.device.type != "cpu":
+            return False
+        try:
+            from orbitquant.kernels.native_packed_matmul import (
+                native_cpu_activation_available,
+            )
+
+            return native_cpu_activation_available()
+        except (ImportError, RuntimeError):
+            return False
 
     def _native_w4_activation_available(self, x: torch.Tensor) -> bool:
         if (
@@ -550,6 +590,8 @@ class OrbitQuantLinear(nn.Module):
     def _resolve_auto_fused_runtime(self, x: torch.Tensor) -> str:
         device_type = x.device.type
         if device_type == "cpu":
+            if _native_cpu_packed_matmul_load_error() is None:
+                return "native_packed_matmul"
             return "dequant_bf16"
         if device_type == "cuda":
             native_error = _native_packed_matmul_load_error()
@@ -810,6 +852,23 @@ class OrbitQuantLinear(nn.Module):
             rotated_x = (
                 self.rotation.apply_to_activations(work / (norms + self.activation_eps)) * norms
             ).to(x.dtype)
+        elif runtime_mode == "native_packed_matmul" and self._native_cpu_activation_available(x):
+            from orbitquant.kernels.native_packed_matmul import (
+                quantize_activations_with_native_cpu_kernel,
+            )
+
+            activation_constants = self._activation_kernel_constant_tensors(x.device)
+            self.last_activation_kernel_backend = "native_cpu"
+            rotated_x = quantize_activations_with_native_cpu_kernel(
+                x,
+                activation_constants["permutation"],
+                activation_constants["signs"],
+                activation_constants["centroids"],
+                activation_constants["boundaries"],
+                eps=self.activation_eps,
+                inv_sqrt_block=self.rotation.normalization,
+                block_size=self.rotation.block_size,
+            )
         else:
             self.last_activation_kernel_backend = select_backend(
                 x.device, requested=self.activation_kernel_backend

--- a/tests/test_adaln_rtn.py
+++ b/tests/test_adaln_rtn.py
@@ -1,5 +1,6 @@
 import pytest
 import torch
+from torch.nn import functional as F
 
 from orbitquant.adaln import (
     RTNInt4Linear,
@@ -7,6 +8,27 @@ from orbitquant.adaln import (
 )
 from orbitquant.config import OrbitQuantConfig
 from orbitquant.kernels import available_backends
+
+
+def _independent_packed_adaln_weight(layer: RTNInt4Linear) -> torch.Tensor:
+    count = layer.out_features * layer.num_groups * layer.group_size
+    packed = layer.packed_weight.detach().cpu()
+    unsigned = torch.tensor(
+        [
+            int(packed[index // 2]) & 15
+            if index % 2 == 0
+            else (int(packed[index // 2]) >> 4) & 15
+            for index in range(count)
+        ],
+        dtype=torch.int16,
+    )
+    signed = unsigned.sub(8).float().reshape(
+        layer.out_features,
+        layer.num_groups,
+        layer.group_size,
+    )
+    weight = signed * layer.scales.detach().cpu().float()[..., None]
+    return weight.reshape(layer.out_features, -1)[:, : layer.in_features].to(torch.bfloat16)
 
 
 def test_int4_rtn_linear_preserves_shape_and_freezes_parameters():
@@ -52,6 +74,79 @@ def test_int4_rtn_casts_fp32_inputs_to_paper_bf16_activation_path():
     assert actual.dtype == torch.bfloat16
     assert actual.shape == (2, 3, 9)
     assert torch.isfinite(actual).all()
+
+
+def test_int4_rtn_explicit_reference_mode_materializes_debug_cache():
+    torch.manual_seed(3)
+    source = torch.nn.Linear(65, 9)
+    x = torch.randn(2, 3, 65, dtype=torch.bfloat16)
+    config = OrbitQuantConfig(runtime_mode="dequant_bf16")
+    quantized = RTNInt4Linear.from_linear(
+        source,
+        config=config,
+        module_name="block.modulation",
+    )
+
+    expected = F.linear(
+        x,
+        _independent_packed_adaln_weight(quantized),
+        source.bias.detach().to(torch.bfloat16),
+    )
+    actual = quantized(x)
+
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+    assert quantized.last_effective_runtime_mode == "dequant_bf16"
+    assert quantized._dequantized_weight_cache is not None
+
+
+def test_int4_rtn_native_cpu_matches_independent_reference_without_dense_cache():
+    try:
+        import orbitquant_packed_matmul
+    except Exception:
+        pytest.skip("native packed matmul kernel package is not importable")
+    if not orbitquant_packed_matmul.supports_cpu_adaln():
+        pytest.skip("the importable native package has no CPU AdaLN kernel")
+
+    torch.manual_seed(5)
+    source = torch.nn.Linear(65, 9)
+    x = torch.randn(2, 3, 65, dtype=torch.bfloat16)
+    config = OrbitQuantConfig(runtime_mode="native_packed_matmul")
+    quantized = RTNInt4Linear.from_linear(
+        source,
+        config=config,
+        module_name="block.modulation",
+    )
+    expected = F.linear(
+        x,
+        _independent_packed_adaln_weight(quantized),
+        source.bias.detach().to(torch.bfloat16),
+    )
+
+    actual = quantized(x)
+
+    torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
+    assert quantized.last_effective_runtime_mode == "native_packed_adaln_int4"
+    assert quantized._dequantized_weight_cache is None
+    assert quantized._dequantized_weight_cache_key is None
+
+
+def test_int4_rtn_explicit_native_mode_fails_loud_without_current_package(monkeypatch):
+    import orbitquant.kernels.native_packed_matmul as native_module
+
+    monkeypatch.setattr(native_module, "native_cpu_adaln_available", lambda: False)
+    source = torch.nn.Linear(16, 8)
+    config = OrbitQuantConfig(
+        adaln_group_size=8,
+        runtime_mode="native_packed_matmul",
+    )
+    quantized = RTNInt4Linear.from_linear(
+        source,
+        config=config,
+        module_name="block.modulation",
+    )
+
+    with pytest.raises(RuntimeError, match="has no packed AdaLN INT4 kernel"):
+        quantized(torch.randn(2, 16))
 
 
 def test_int4_rtn_rejects_non_positive_group_size():

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -39,7 +39,10 @@ def test_github_actions_cpu_unit_workflow_exists():
     assert "windows-native-cpu:" in text
     assert "runs-on: windows-2025" in text
     assert "--rev d43de01d0b43285d8e5061ca4380c2bd1c40ae3b" in text
+    assert "--debug" in text
     assert "prepare_wheel_project.py" in text
+    assert 'CMAKE_GENERATOR = "Visual Studio 17 2022"' in text
+    assert "Get-CimInstance Win32_Processor" in text
     assert "bdist_wheel --py-limited-api=cp39" in text
     assert '"-cp39-abi3-win_amd64\\.whl$"' in text
     assert "torch==2.12.1 pytest" in text

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -41,8 +41,12 @@ def test_github_actions_cpu_unit_workflow_exists():
     assert "--rev d43de01d0b43285d8e5061ca4380c2bd1c40ae3b" in text
     assert "--debug" in text
     assert "prepare_wheel_project.py" in text
-    assert "uses: actions/cache@v6.1.0" in text
-    assert 'CMAKE_GENERATOR = "Visual Studio 18 2026"' in text
+    assert "uses: actions/cache/restore@v6.1.0" in text
+    assert "uses: actions/cache/save@v6.1.0" in text
+    assert "vswhere.exe" in text
+    assert "VsDevCmd.bat" in text
+    assert "ninja --version" in text
+    assert 'CMAKE_GENERATOR = "Ninja"' in text
     assert "Get-CimInstance Win32_Processor" in text
     assert "bdist_wheel --py-limited-api=cp39" in text
     assert '"-cp39-abi3-win_amd64\\.whl$"' in text

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -44,6 +44,7 @@ def test_github_actions_cpu_unit_workflow_exists():
     assert "uses: actions/cache/restore@v6.1.0" in text
     assert "uses: actions/cache/save@v6.1.0" in text
     assert 'CMAKE_GENERATOR = "Visual Studio 17 2022"' in text
+    assert 'CMAKE_GENERATOR_TOOLSET = "host=x86"' in text
     assert "Get-CimInstance Win32_Processor" in text
     assert "bdist_wheel --py-limited-api=cp39" in text
     assert '"-cp39-abi3-win_amd64\\.whl$"' in text

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -36,6 +36,14 @@ def test_github_actions_cpu_unit_workflow_exists():
     assert "dist/*.whl" in text
     assert "orbitquant-0.1.0-py3-none-any.whl" not in text
     assert "orbitquant --version" in text
+    assert "windows-native-cpu:" in text
+    assert "runs-on: windows-2025" in text
+    assert "--rev d43de01d0b43285d8e5061ca4380c2bd1c40ae3b" in text
+    assert "prepare_wheel_project.py" in text
+    assert "bdist_wheel --py-limited-api=cp39" in text
+    assert '"-cp39-abi3-win_amd64\\.whl$"' in text
+    assert "torch==2.12.1 pytest" in text
+    assert "-m kernels_ci" in text
 
 
 def test_package_version_matches_import_version():
@@ -272,7 +280,8 @@ def test_native_packed_matmul_kernel_package_stays_kernel_builder_abi3_compliant
         "pybind11": re.compile(r"pybind11|PYBIND11|py::"),
         "torch extension header": re.compile(r"torch/extension\.h"),
         "hardcoded torch op namespace": re.compile(
-            r"TORCH_LIBRARY\(|TORCH_LIBRARY_FRAGMENT|TORCH_LIBRARY_IMPL|PyInit"
+            r"TORCH_LIBRARY\(|TORCH_LIBRARY_FRAGMENT|"
+            r"(?<!STABLE_)TORCH_LIBRARY_IMPL|PyInit"
         ),
         "setuptools extension build": re.compile(
             r"CUDAExtension|BuildExtension|cpp_extension\.load|load_inline"
@@ -296,7 +305,8 @@ def test_native_packed_matmul_kernel_package_stays_kernel_builder_abi3_compliant
     assert build_config["general"]["name"] == "orbitquant-packed-matmul"
     assert "_" not in build_config["general"]["name"]
     assert build_config["general"]["license"] == "Apache-2.0"
-    assert build_config["general"]["backends"] == ["cuda", "metal"]
+    assert build_config["general"]["backends"] == ["cpu", "cuda", "metal"]
+    assert build_config["torch"]["stable-abi"] == {"cpu": "2.11"}
     assert build_config["general"]["upstream"] == "https://github.com/iamwavecut/OrbitQuant"
     assert (
         build_config["general"]["source"]

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -41,7 +41,8 @@ def test_github_actions_cpu_unit_workflow_exists():
     assert "--rev d43de01d0b43285d8e5061ca4380c2bd1c40ae3b" in text
     assert "--debug" in text
     assert "prepare_wheel_project.py" in text
-    assert 'CMAKE_GENERATOR = "Visual Studio 17 2022"' in text
+    assert "uses: actions/cache@v6.1.0" in text
+    assert 'CMAKE_GENERATOR = "Visual Studio 18 2026"' in text
     assert "Get-CimInstance Win32_Processor" in text
     assert "bdist_wheel --py-limited-api=cp39" in text
     assert '"-cp39-abi3-win_amd64\\.whl$"' in text

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -37,17 +37,13 @@ def test_github_actions_cpu_unit_workflow_exists():
     assert "orbitquant-0.1.0-py3-none-any.whl" not in text
     assert "orbitquant --version" in text
     assert "windows-native-cpu:" in text
-    assert "runs-on: windows-2025" in text
+    assert "runs-on: windows-2022" in text
     assert "--rev d43de01d0b43285d8e5061ca4380c2bd1c40ae3b" in text
     assert "--debug" in text
     assert "prepare_wheel_project.py" in text
     assert "uses: actions/cache/restore@v6.1.0" in text
     assert "uses: actions/cache/save@v6.1.0" in text
-    assert "vswhere.exe" in text
-    assert "VsDevCmd.bat" in text
-    assert "(Get-Command nmake.exe).Source" in text
-    assert 'CMAKE_GENERATOR = "NMake Makefiles"' in text
-    assert "CMAKE_MAKE_PROGRAM" in text
+    assert 'CMAKE_GENERATOR = "Visual Studio 17 2022"' in text
     assert "Get-CimInstance Win32_Processor" in text
     assert "bdist_wheel --py-limited-api=cp39" in text
     assert '"-cp39-abi3-win_amd64\\.whl$"' in text

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -46,6 +46,7 @@ def test_github_actions_cpu_unit_workflow_exists():
     assert "VsDevCmd.bat" in text
     assert 'CMAKE_GENERATOR = "Ninja Multi-Config"' in text
     assert "CMAKE_MAKE_PROGRAM" in text
+    assert "ORBITQUANT_BUILD_TEMP" in text
     assert "Get-CimInstance Win32_Processor" in text
     assert "bdist_wheel --py-limited-api=cp39" in text
     assert '"-cp39-abi3-win_amd64\\.whl$"' in text

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -44,7 +44,8 @@ def test_github_actions_cpu_unit_workflow_exists():
     assert "uses: actions/cache/restore@v6.1.0" in text
     assert "uses: actions/cache/save@v6.1.0" in text
     assert 'CMAKE_GENERATOR = "Visual Studio 17 2022"' in text
-    assert 'CMAKE_ARGS = "-DGPU_LANG=CPU -T host=x86"' in text
+    assert "Microsoft.Component.MSBuild" in text
+    assert "CMAKE_MAKE_PROGRAM" in text
     assert "Get-CimInstance Win32_Processor" in text
     assert "bdist_wheel --py-limited-api=cp39" in text
     assert '"-cp39-abi3-win_amd64\\.whl$"' in text

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -45,8 +45,8 @@ def test_github_actions_cpu_unit_workflow_exists():
     assert "uses: actions/cache/save@v6.1.0" in text
     assert "vswhere.exe" in text
     assert "VsDevCmd.bat" in text
-    assert "ninja --version" in text
-    assert 'CMAKE_GENERATOR = "Ninja"' in text
+    assert "Get-Command nmake.exe" in text
+    assert 'CMAKE_GENERATOR = "NMake Makefiles"' in text
     assert "Get-CimInstance Win32_Processor" in text
     assert "bdist_wheel --py-limited-api=cp39" in text
     assert '"-cp39-abi3-win_amd64\\.whl$"' in text

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -43,8 +43,8 @@ def test_github_actions_cpu_unit_workflow_exists():
     assert "prepare_wheel_project.py" in text
     assert "uses: actions/cache/restore@v6.1.0" in text
     assert "uses: actions/cache/save@v6.1.0" in text
-    assert 'CMAKE_GENERATOR = "Visual Studio 17 2022"' in text
-    assert "Microsoft.Component.MSBuild" in text
+    assert "VsDevCmd.bat" in text
+    assert 'CMAKE_GENERATOR = "Ninja Multi-Config"' in text
     assert "CMAKE_MAKE_PROGRAM" in text
     assert "Get-CimInstance Win32_Processor" in text
     assert "bdist_wheel --py-limited-api=cp39" in text

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -45,8 +45,9 @@ def test_github_actions_cpu_unit_workflow_exists():
     assert "uses: actions/cache/save@v6.1.0" in text
     assert "vswhere.exe" in text
     assert "VsDevCmd.bat" in text
-    assert "Get-Command nmake.exe" in text
+    assert "(Get-Command nmake.exe).Source" in text
     assert 'CMAKE_GENERATOR = "NMake Makefiles"' in text
+    assert "CMAKE_MAKE_PROGRAM" in text
     assert "Get-CimInstance Win32_Processor" in text
     assert "bdist_wheel --py-limited-api=cp39" in text
     assert '"-cp39-abi3-win_amd64\\.whl$"' in text

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -52,6 +52,13 @@ def test_github_actions_cpu_unit_workflow_exists():
     assert '"-cp39-abi3-win_amd64\\.whl$"' in text
     assert "torch==2.12.1 pytest" in text
     assert "-m kernels_ci" in text
+    assert "manylinux-native-cpu:" in text
+    assert "cibuildwheel==4.1.0" in text
+    assert "CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28" in text
+    assert "--exclude libc10.so" in text
+    assert "--exclude libtorch_cpu.so" in text
+    assert "--exclude libtorch.so" in text
+    assert "*-cp39-abi3-manylinux_2_28_x86_64.whl" in text
 
 
 def test_package_version_matches_import_version():

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -44,7 +44,7 @@ def test_github_actions_cpu_unit_workflow_exists():
     assert "uses: actions/cache/restore@v6.1.0" in text
     assert "uses: actions/cache/save@v6.1.0" in text
     assert 'CMAKE_GENERATOR = "Visual Studio 17 2022"' in text
-    assert 'CMAKE_GENERATOR_TOOLSET = "host=x86"' in text
+    assert 'CMAKE_ARGS = "-DGPU_LANG=CPU -T host=x86"' in text
     assert "Get-CimInstance Win32_Processor" in text
     assert "bdist_wheel --py-limited-api=cp39" in text
     assert '"-cp39-abi3-win_amd64\\.whl$"' in text

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -905,6 +905,11 @@ def test_cli_compare_native_runs_original_and_quantized_side_by_side(
     capsys,
     tmp_path,
 ):
+    monkeypatch.setattr(
+        "orbitquant.layers._native_cpu_packed_matmul_load_error",
+        lambda: RuntimeError("reference-path test"),
+    )
+
     class TinyPipeline:
         def __init__(self, color="red"):
             self.color = color

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -114,6 +114,9 @@ def test_backend_selection_is_explicit_and_fails_loud_for_unavailable_backends()
 def test_backend_capabilities_report_partial_and_fallback_kernel_status(monkeypatch):
     monkeypatch.setattr(dispatch_module, "_mps_metal_available", lambda: False)
     monkeypatch.setattr(dispatch_module, "_native_packed_matmul_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_packed_matmul_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_activation_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_adaln_available", lambda: False)
     capabilities = backend_capabilities(
         backends={"cpu": True, "mps": True, "triton_cuda": True}
     )
@@ -121,7 +124,10 @@ def test_backend_capabilities_report_partial_and_fallback_kernel_status(monkeypa
     assert capabilities["cpu"]["available"] is True
     assert capabilities["cpu"]["claim_status"] == "reference_only"
     assert capabilities["cpu"]["optimized"] is False
-    assert capabilities["cpu"]["implemented_stage"] is None
+    assert capabilities["cpu"]["implemented_stage"] == (
+        "activation_norm_rpbh_quant_rescale,packed_weight_matmul,"
+        "adaln_rtn_packed_matmul"
+    )
     assert capabilities["cpu"]["optimized_stage"] is None
     assert capabilities["cpu"]["weight_dequant_optimized"] is False
     assert capabilities["cpu"]["weight_pack_optimized"] is False
@@ -173,6 +179,9 @@ def test_backend_capabilities_report_partial_and_fallback_kernel_status(monkeypa
 def test_backend_capabilities_report_mps_metal_partial_kernel(monkeypatch):
     monkeypatch.setattr(dispatch_module, "_mps_metal_available", lambda: True)
     monkeypatch.setattr(dispatch_module, "_native_packed_matmul_available", lambda: True)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_packed_matmul_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_activation_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_adaln_available", lambda: False)
 
     capabilities = backend_capabilities(
         backends={"cpu": True, "mps": True, "triton_cuda": False}
@@ -227,6 +236,9 @@ def test_backend_capabilities_report_mps_metal_partial_kernel(monkeypatch):
 def test_backend_capabilities_report_mps_shader_without_native_matmul(monkeypatch):
     monkeypatch.setattr(dispatch_module, "_mps_metal_available", lambda: True)
     monkeypatch.setattr(dispatch_module, "_native_packed_matmul_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_packed_matmul_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_activation_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_adaln_available", lambda: False)
 
     capabilities = backend_capabilities(
         backends={"cpu": True, "mps": True, "triton_cuda": False}
@@ -253,6 +265,9 @@ def test_backend_capabilities_report_mps_shader_without_native_matmul(monkeypatc
 def test_backend_capabilities_report_mps_native_matmul_without_shader(monkeypatch):
     monkeypatch.setattr(dispatch_module, "_mps_metal_available", lambda: False)
     monkeypatch.setattr(dispatch_module, "_native_packed_matmul_available", lambda: True)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_packed_matmul_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_activation_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_adaln_available", lambda: False)
 
     capabilities = backend_capabilities(
         backends={"cpu": True, "mps": True, "triton_cuda": False}
@@ -264,6 +279,73 @@ def test_backend_capabilities_report_mps_native_matmul_without_shader(monkeypatc
     assert capabilities["mps"]["package_format"] == "native_kernel_package"
     assert capabilities["mps"]["optimized_stage"] == "packed_weight_matmul"
     assert capabilities["mps"]["weight_dequant_optimized"] is False
+
+
+def test_backend_capabilities_label_cpu_native_matmul_as_partial_not_fused(monkeypatch):
+    monkeypatch.setattr(dispatch_module, "_mps_metal_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_packed_matmul_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_packed_matmul_available", lambda: True)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_activation_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_adaln_available", lambda: False)
+
+    capabilities = backend_capabilities(
+        backends={"cpu": True, "mps": False, "triton_cuda": False}
+    )
+
+    assert capabilities["cpu"]["claim_status"] == "partial_optimized"
+    assert capabilities["cpu"]["optimized"] is True
+    assert capabilities["cpu"]["full_fusion"] is False
+    assert capabilities["cpu"]["optimized_stage"] == "packed_weight_matmul"
+    assert capabilities["cpu"]["implementation"] == (
+        "native_exact_packed_matmul+torch_activation_reference"
+    )
+    assert capabilities["cpu"]["hf_kernel_builder_compliant"] is True
+
+
+def test_backend_capabilities_report_native_cpu_activation_and_matmul(monkeypatch):
+    monkeypatch.setattr(dispatch_module, "_mps_metal_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_packed_matmul_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_packed_matmul_available", lambda: True)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_activation_available", lambda: True)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_adaln_available", lambda: False)
+
+    capabilities = backend_capabilities(
+        backends={"cpu": True, "mps": False, "triton_cuda": False}
+    )
+
+    assert capabilities["cpu"]["claim_status"] == "partial_optimized"
+    assert capabilities["cpu"]["optimized"] is True
+    assert capabilities["cpu"]["full_fusion"] is False
+    assert capabilities["cpu"]["optimized_stage"] == (
+        "activation_norm_rpbh_quant_rescale,packed_weight_matmul"
+    )
+    assert capabilities["cpu"]["implementation"] == (
+        "native_exact_activation+native_exact_packed_matmul"
+    )
+    assert capabilities["cpu"]["hf_kernel_builder_compliant"] is True
+
+
+def test_backend_capabilities_report_complete_native_cpu_kernel_surface(monkeypatch):
+    monkeypatch.setattr(dispatch_module, "_mps_metal_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_packed_matmul_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_packed_matmul_available", lambda: True)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_activation_available", lambda: True)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_adaln_available", lambda: True)
+
+    capabilities = backend_capabilities(
+        backends={"cpu": True, "mps": False, "triton_cuda": False}
+    )
+
+    assert capabilities["cpu"]["optimized_stage"] == (
+        "activation_norm_rpbh_quant_rescale,packed_weight_matmul,"
+        "adaln_rtn_packed_matmul"
+    )
+    assert capabilities["cpu"]["adaln_quant_optimized"] is False
+    assert capabilities["cpu"]["adaln_dequant_optimized"] is True
+    assert capabilities["cpu"]["implementation"] == (
+        "native_exact_activation+native_exact_packed_matmul+native_packed_adaln_int4"
+    )
+    assert "without a full floating-point cache" in capabilities["cpu"]["notes"]
 
 
 def test_backend_selection_accepts_injected_availability_for_gpu_paths():

--- a/tests/test_native_kernel_package.py
+++ b/tests/test_native_kernel_package.py
@@ -72,6 +72,7 @@ def test_wheel_project_preparation_adds_runtime_requirement() -> None:
     assert 'os.environ.get("ORBITQUANT_BUILD_TEMP", ' in script
     assert "build_temp = (Path(build_temp_root) / ext.name).resolve()" in script
     assert 'copy2(generated_ops, extdir / "_ops.py")' in script
+    assert 'options={"bdist_wheel": {"py_limited_api": "cp39"}}' in script
 
 
 def test_kernel_builder_binding_uses_abi3_safe_registration_pattern() -> None:

--- a/tests/test_native_kernel_package.py
+++ b/tests/test_native_kernel_package.py
@@ -67,6 +67,8 @@ def test_wheel_project_preparation_supports_windows_single_config_build() -> Non
     )
 
     assert 'dependencies = ["torch>=2.11"]' in script
+    assert 'if "CMAKE_MAKE_PROGRAM" in os.environ' in script
+    assert 'is_ccache_available() and sys.platform != "win32"' in script
     assert 'sys.platform == "win32" and (extdir / cfg).is_dir()' in script
 
 

--- a/tests/test_native_kernel_package.py
+++ b/tests/test_native_kernel_package.py
@@ -61,14 +61,13 @@ def test_kernel_builder_manifest_targets_cpu_cuda_and_metal() -> None:
     assert kernels["packed_matmul_metal"]["depends"] == ["torch"]
 
 
-def test_wheel_project_preparation_keeps_windows_ninja_executable() -> None:
+def test_wheel_project_preparation_supports_windows_single_config_build() -> None:
     script = (KERNEL_ROOT / "scripts/prepare_wheel_project.py").read_text(
         encoding="utf-8"
     )
 
     assert 'dependencies = ["torch>=2.11"]' in script
-    assert 'which("ninja") or Path(ninja.BIN_DIR)' in script
-    assert '"ninja.exe" if os.name == "nt" else "ninja"' in script
+    assert 'sys.platform == "win32" and (extdir / cfg).is_dir()' in script
 
 
 def test_kernel_builder_binding_uses_abi3_safe_registration_pattern() -> None:

--- a/tests/test_native_kernel_package.py
+++ b/tests/test_native_kernel_package.py
@@ -71,6 +71,7 @@ def test_wheel_project_preparation_adds_runtime_requirement() -> None:
     assert 'is_ccache_available() and sys.platform != "win32"' in script
     assert 'os.environ.get("ORBITQUANT_BUILD_TEMP", ' in script
     assert "build_temp = (Path(build_temp_root) / ext.name).resolve()" in script
+    assert 'copy2(generated_ops, extdir / "_ops.py")' in script
 
 
 def test_kernel_builder_binding_uses_abi3_safe_registration_pattern() -> None:

--- a/tests/test_native_kernel_package.py
+++ b/tests/test_native_kernel_package.py
@@ -68,6 +68,7 @@ def test_wheel_project_preparation_adds_runtime_requirement() -> None:
 
     assert 'dependencies = ["torch>=2.11"]' in script
     assert 'if "CMAKE_MAKE_PROGRAM" in os.environ' in script
+    assert 'is_ccache_available() and sys.platform != "win32"' in script
 
 
 def test_kernel_builder_binding_uses_abi3_safe_registration_pattern() -> None:

--- a/tests/test_native_kernel_package.py
+++ b/tests/test_native_kernel_package.py
@@ -17,19 +17,44 @@ def _kernel_source_files() -> list[Path]:
     ]
 
 
-def test_kernel_builder_manifest_targets_cuda_and_metal() -> None:
+def test_kernel_builder_manifest_targets_cpu_cuda_and_metal() -> None:
     config = tomllib.loads((KERNEL_ROOT / "build.toml").read_text(encoding="utf-8"))
 
     assert config["general"]["name"] == "orbitquant-packed-matmul"
     assert config["general"]["edition"] == 5
     assert config["general"]["license"] == "Apache-2.0"
-    assert config["general"]["backends"] == ["cuda", "metal"]
+    assert config["general"]["backends"] == ["cpu", "cuda", "metal"]
     assert config["general"]["hub"]["repo-id"] == "WaveCut/orbitquant-packed-matmul"
     assert config["torch"]["src"] == [
         "torch-ext/torch_binding.cpp",
         "torch-ext/torch_binding.h",
     ]
     kernels = config["kernel"]
+    assert config["torch"]["stable-abi"] == {"cpu": "2.11"}
+    assert kernels["packed_matmul_cpu"]["backend"] == "cpu"
+    assert kernels["packed_matmul_cpu"]["depends"] == ["torch"]
+    assert kernels["packed_matmul_cpu"]["src"] == [
+        "orbitquant_packed_matmul_cpu/cpu_isa.cpp",
+        "orbitquant_packed_matmul_cpu/cpu_kernel_args.h",
+        "orbitquant_packed_matmul_cpu/cpu_threads.cpp",
+        "orbitquant_packed_matmul_cpu/cpu_threads.h",
+        "orbitquant_packed_matmul_cpu/packed_adaln_cpu.cpp",
+        "orbitquant_packed_matmul_cpu/packed_matmul_cpu.cpp",
+        "orbitquant_packed_matmul_cpu/packed_matmul_cpu.h",
+        "orbitquant_packed_matmul_cpu/packed_matmul_scalar.cpp",
+        "orbitquant_packed_matmul_cpu/packed_matmul_neon.cpp",
+        "orbitquant_packed_matmul_cpu/packed_matmul_x86_avx512.cpp",
+        "orbitquant_packed_matmul_cpu/quantize_activations_cpu.cpp",
+    ]
+    assert kernels["packed_matmul_cpu_x86_avx2"]["backend"] == "cpu"
+    assert kernels["packed_matmul_cpu_x86_avx2"]["depends"] == ["torch"]
+    assert kernels["packed_matmul_cpu_x86_avx2"]["cxx-flags"] == [
+        "$<$<CXX_COMPILER_ID:MSVC>:/arch:AVX2>"
+    ]
+    assert kernels["packed_matmul_cpu_x86_avx2"]["src"] == [
+        "orbitquant_packed_matmul_cpu/cpu_msvc_avx2.cpp",
+        "orbitquant_packed_matmul_cpu/packed_matmul_x86.cpp",
+    ]
     assert kernels["packed_matmul_cuda"]["backend"] == "cuda"
     assert kernels["packed_matmul_cuda"]["depends"] == ["torch"]
     assert kernels["packed_matmul_metal"]["backend"] == "metal"
@@ -41,8 +66,13 @@ def test_kernel_builder_binding_uses_abi3_safe_registration_pattern() -> None:
     header = (KERNEL_ROOT / "torch-ext/torch_binding.h").read_text(encoding="utf-8")
 
     assert "TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops)" in binding
+    assert "STABLE_TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops)" in binding
+    assert "STABLE_TORCH_LIBRARY_IMPL_EXPAND" in binding
+    assert "TORCH_BOX(&matmul_packed_weight)" in binding
+    assert "TORCH_BOX(&matmul_packed_adaln_int4_cpu)" in binding
     assert "REGISTER_EXTENSION(TORCH_EXTENSION_NAME)" in binding
     assert "torch/torch.h" in header
+    assert "torch/csrc/stable/tensor.h" in header
 
     combined = "\n".join(
         path.read_text(encoding="utf-8")
@@ -57,7 +87,7 @@ def test_kernel_builder_binding_uses_abi3_safe_registration_pattern() -> None:
         "py::",
         "TORCH_LIBRARY(",
         "TORCH_LIBRARY_FRAGMENT",
-        "TORCH_LIBRARY_IMPL",
+        "TORCH_LIBRARY_IMPL(",
         "PyInit",
         "torch.ops.",
         "import orbitquant",
@@ -109,6 +139,33 @@ def test_kernel_sources_expose_the_current_runtime_contract() -> None:
     metal_source = (KERNEL_ROOT / "orbitquant_packed_matmul_metal/packed_matmul.metal").read_text(
         encoding="utf-8"
     )
+    cpu_source = (KERNEL_ROOT / "orbitquant_packed_matmul_cpu/packed_matmul_cpu.cpp").read_text(
+        encoding="utf-8"
+    )
+    cpu_isa_source = (
+        KERNEL_ROOT / "orbitquant_packed_matmul_cpu/cpu_isa.cpp"
+    ).read_text(encoding="utf-8")
+    cpu_msvc_avx2_source = (
+        KERNEL_ROOT / "orbitquant_packed_matmul_cpu/cpu_msvc_avx2.cpp"
+    ).read_text(encoding="utf-8")
+    cpu_threads_source = (
+        KERNEL_ROOT / "orbitquant_packed_matmul_cpu/cpu_threads.cpp"
+    ).read_text(encoding="utf-8")
+    cpu_neon_source = (
+        KERNEL_ROOT / "orbitquant_packed_matmul_cpu/packed_matmul_neon.cpp"
+    ).read_text(encoding="utf-8")
+    cpu_avx2_source = (
+        KERNEL_ROOT / "orbitquant_packed_matmul_cpu/packed_matmul_x86.cpp"
+    ).read_text(encoding="utf-8")
+    cpu_avx512_source = (
+        KERNEL_ROOT / "orbitquant_packed_matmul_cpu/packed_matmul_x86_avx512.cpp"
+    ).read_text(encoding="utf-8")
+    cpu_activation_source = (
+        KERNEL_ROOT / "orbitquant_packed_matmul_cpu/quantize_activations_cpu.cpp"
+    ).read_text(encoding="utf-8")
+    cpu_adaln_source = (
+        KERNEL_ROOT / "orbitquant_packed_matmul_cpu/packed_adaln_cpu.cpp"
+    ).read_text(encoding="utf-8")
 
     for token in (
         "packed_weight_indices",
@@ -137,6 +194,34 @@ def test_kernel_sources_expose_the_current_runtime_contract() -> None:
     assert "threadgroup float *shared" in metal_source
     assert "threadgroup_barrier(mem_flags::mem_threadgroup)" in metal_source
     assert "params.block_k" in metal_source
+    assert "torch::headeronly::ScalarType" in cpu_source
+    assert "packed_matmul_neon_available" in cpu_source
+    assert "vfmaq_f32" in cpu_neon_source
+    assert "packed_matmul_scalar_range" in cpu_neon_source
+    assert "ORBITQUANT_CPU_ISA" in cpu_source
+    assert "packed_matmul_x86_avx2_available" in cpu_source
+    assert "_mm256_permutevar8x32_ps" in cpu_avx2_source
+    assert "runtime_has_avx2_fma_f16c" in cpu_isa_source
+    assert "__cpuidex" in cpu_isa_source
+    assert "activation_fwht_msvc_avx2" in cpu_msvc_avx2_source
+    assert "packed_adaln_msvc_avx2_range" in cpu_msvc_avx2_source
+    assert "_mm512_permutexvar_ps" in cpu_avx512_source
+    assert "_mm512_permutexvar_epi16" in cpu_avx512_source
+    assert "_mm512_dpbf16_ps" in cpu_avx512_source
+    assert '__builtin_cpu_supports("avx512bf16")' in cpu_avx512_source
+    assert "kPrimaryRowTile = 8" in cpu_avx512_source
+    assert "quantize_lookup_avx2" in cpu_activation_source
+    assert "quantize_lookup_avx512" in cpu_activation_source
+    assert "_mm512_mask_add_epi32" in cpu_activation_source
+    assert "select_activation_isa" in cpu_activation_source
+    assert "packed_adaln_scalar_range" in cpu_adaln_source
+    assert "packed_adaln_neon_range" in cpu_adaln_source
+    assert "packed_adaln_avx2_range" in cpu_adaln_source
+    assert "packed_adaln_avx512_range" in cpu_adaln_source
+    assert "_mm512_dpbf16_ps" in cpu_adaln_source
+    assert "sched_getaffinity" in cpu_threads_source
+    assert "physical_package_id" in cpu_threads_source
+    assert "hw.perflevel0.physicalcpu" in cpu_threads_source
 
 
 def test_cuda_kernel_uses_wmma_for_supported_bf16_and_fp16_low_bit_modes() -> None:
@@ -183,8 +268,16 @@ def test_kernel_benchmark_reports_reference_comparison() -> None:
     assert "reference_weight" in benchmark_source
     assert "materialize_reference_weight" in benchmark_source
     assert "packed_seconds_per_iter" in benchmark_source
+    assert 'choices=["cpu", "cuda", "mps"]' in benchmark_source
+    assert "packed_first_call_seconds" in benchmark_source
+    assert "packed_hot_median_seconds" in benchmark_source
+    assert "packed_hot_p95_seconds" in benchmark_source
     assert "predequantized_f_linear_seconds_per_iter" in benchmark_source
+    assert "predequantized_hot_median_seconds" in benchmark_source
+    assert "predequantized_hot_p95_seconds" in benchmark_source
     assert "dequantize_then_f_linear_seconds_per_iter" in benchmark_source
+    assert "dequantize_then_hot_median_seconds" in benchmark_source
+    assert "dequantize_then_hot_p95_seconds" in benchmark_source
     assert "packed_weight_indices_bytes" in benchmark_source
     assert "row_norms_bytes" in benchmark_source
     assert "centroid_bytes" in benchmark_source
@@ -196,3 +289,4 @@ def test_kernel_benchmark_reports_reference_comparison() -> None:
     assert "reference_seconds_per_iter" in benchmark_source
     assert "packed_vs_reference_speedup" in benchmark_source
     assert "max_abs_error" in benchmark_source
+    assert "relative_rmse" in benchmark_source

--- a/tests/test_native_kernel_package.py
+++ b/tests/test_native_kernel_package.py
@@ -67,6 +67,7 @@ def test_wheel_project_preparation_adds_runtime_requirement() -> None:
     )
 
     assert 'dependencies = ["torch>=2.11"]' in script
+    assert 'if "CMAKE_MAKE_PROGRAM" in os.environ' in script
 
 
 def test_kernel_builder_binding_uses_abi3_safe_registration_pattern() -> None:

--- a/tests/test_native_kernel_package.py
+++ b/tests/test_native_kernel_package.py
@@ -61,6 +61,16 @@ def test_kernel_builder_manifest_targets_cpu_cuda_and_metal() -> None:
     assert kernels["packed_matmul_metal"]["depends"] == ["torch"]
 
 
+def test_wheel_project_preparation_keeps_windows_ninja_executable() -> None:
+    script = (KERNEL_ROOT / "scripts/prepare_wheel_project.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'dependencies = ["torch>=2.11"]' in script
+    assert 'which("ninja") or Path(ninja.BIN_DIR)' in script
+    assert '"ninja.exe" if os.name == "nt" else "ninja"' in script
+
+
 def test_kernel_builder_binding_uses_abi3_safe_registration_pattern() -> None:
     binding = (KERNEL_ROOT / "torch-ext/torch_binding.cpp").read_text(encoding="utf-8")
     header = (KERNEL_ROOT / "torch-ext/torch_binding.h").read_text(encoding="utf-8")

--- a/tests/test_native_kernel_package.py
+++ b/tests/test_native_kernel_package.py
@@ -69,6 +69,8 @@ def test_wheel_project_preparation_adds_runtime_requirement() -> None:
     assert 'dependencies = ["torch>=2.11"]' in script
     assert 'if "CMAKE_MAKE_PROGRAM" in os.environ' in script
     assert 'is_ccache_available() and sys.platform != "win32"' in script
+    assert 'os.environ.get("ORBITQUANT_BUILD_TEMP", ' in script
+    assert "build_temp = (Path(build_temp_root) / ext.name).resolve()" in script
 
 
 def test_kernel_builder_binding_uses_abi3_safe_registration_pattern() -> None:

--- a/tests/test_native_kernel_package.py
+++ b/tests/test_native_kernel_package.py
@@ -61,15 +61,12 @@ def test_kernel_builder_manifest_targets_cpu_cuda_and_metal() -> None:
     assert kernels["packed_matmul_metal"]["depends"] == ["torch"]
 
 
-def test_wheel_project_preparation_supports_windows_single_config_build() -> None:
+def test_wheel_project_preparation_adds_runtime_requirement() -> None:
     script = (KERNEL_ROOT / "scripts/prepare_wheel_project.py").read_text(
         encoding="utf-8"
     )
 
     assert 'dependencies = ["torch>=2.11"]' in script
-    assert 'if "CMAKE_MAKE_PROGRAM" in os.environ' in script
-    assert 'is_ccache_available() and sys.platform != "win32"' in script
-    assert 'sys.platform == "win32" and (extdir / cfg).is_dir()' in script
 
 
 def test_kernel_builder_binding_uses_abi3_safe_registration_pattern() -> None:

--- a/tests/test_native_packed_matmul.py
+++ b/tests/test_native_packed_matmul.py
@@ -9,10 +9,17 @@ import orbitquant.kernels.native_packed_matmul as native_module
 from orbitquant.codebooks import get_codebook
 
 
-def test_native_packed_matmul_rejects_cpu_before_loading_kernel():
+def test_native_packed_matmul_rejects_variant_without_cpu_backend(monkeypatch):
     codebook = get_codebook(dim=16, bits=4)
+    fake_kernel = SimpleNamespace(
+        matmul_packed_weight=lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("unsupported CPU variant must not be invoked")
+        ),
+        supports_device=lambda device_type: device_type == "mps",
+    )
+    monkeypatch.setattr(native_module, "_NATIVE_KERNEL", fake_kernel)
 
-    with pytest.raises(RuntimeError, match="requires CUDA or MPS input tensors"):
+    with pytest.raises(RuntimeError, match="does not contain a CPU backend"):
         native_module.matmul_packed_weight_with_native_kernel(
             torch.randn(2, 16),
             torch.empty(56, dtype=torch.uint8),
@@ -21,6 +28,39 @@ def test_native_packed_matmul_rejects_cpu_before_loading_kernel():
             bits=4,
             out_features=7,
             in_features=16,
+        )
+
+
+def test_native_device_capability_treats_legacy_variants_as_accelerator_only(monkeypatch):
+    fake_legacy_kernel = SimpleNamespace(matmul_packed_weight=lambda *args, **kwargs: None)
+    monkeypatch.setattr(native_module, "_NATIVE_KERNEL", fake_legacy_kernel)
+
+    assert native_module.native_packed_matmul_device_available("cpu") is False
+    assert native_module.native_packed_matmul_device_available("mps") is True
+
+
+def test_native_cpu_adaln_availability_requires_capability_operation(monkeypatch):
+    fake_kernel = SimpleNamespace(
+        supports_cpu_adaln=lambda: True,
+        matmul_packed_adaln_int4_cpu=lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(native_module, "_NATIVE_KERNEL", fake_kernel)
+
+    assert native_module.native_cpu_adaln_available() is True
+
+
+def test_native_cpu_adaln_bridge_rejects_legacy_variant(monkeypatch):
+    fake_kernel = SimpleNamespace(matmul_packed_adaln_int4_cpu=lambda *args, **kwargs: None)
+    monkeypatch.setattr(native_module, "_NATIVE_KERNEL", fake_kernel)
+
+    with pytest.raises(RuntimeError, match="does not provide the CPU AdaLN"):
+        native_module.matmul_packed_adaln_int4_with_native_cpu_kernel(
+            torch.randn(2, 8, dtype=torch.bfloat16),
+            torch.empty(32, dtype=torch.uint8),
+            torch.ones(4, 1, dtype=torch.bfloat16),
+            out_features=4,
+            in_features=8,
+            group_size=8,
         )
 
 

--- a/tests/test_orbit_linear.py
+++ b/tests/test_orbit_linear.py
@@ -226,8 +226,19 @@ def test_orbit_linear_records_last_effective_runtime_and_activation_backend():
 
     quantized(x)
 
-    assert quantized.last_effective_runtime_mode == "dequant_bf16"
-    assert quantized.last_activation_kernel_backend == "cpu"
+    expected_runtime = (
+        "native_packed_matmul"
+        if layers_module._native_cpu_packed_matmul_load_error() is None
+        else "dequant_bf16"
+    )
+    assert quantized.last_effective_runtime_mode == expected_runtime
+    expected_activation_backend = (
+        "native_cpu"
+        if expected_runtime == "native_packed_matmul"
+        and quantized._native_cpu_activation_available(x)
+        else "cpu"
+    )
+    assert quantized.last_activation_kernel_backend == expected_activation_backend
     assert quantized.last_forward_device_type == "cpu"
 
 
@@ -267,7 +278,13 @@ def test_orbit_linear_caches_dequantized_weight(monkeypatch):
     torch.manual_seed(2)
     source = torch.nn.Linear(16, 7)
     x = torch.randn(2, 5, 16)
-    config = OrbitQuantConfig(weight_bits=4, activation_bits=4, rotation_seed=11, block_size=8)
+    config = OrbitQuantConfig(
+        weight_bits=4,
+        activation_bits=4,
+        rotation_seed=11,
+        block_size=8,
+        runtime_mode="dequant_bf16",
+    )
     quantized = OrbitQuantLinear.from_linear(source, config=config, module_name="block.ff.linear")
     calls = 0
     original_unpack = layers_module.unpack_lowbit
@@ -489,9 +506,7 @@ def test_orbit_linear_triton_packed_matmul_runtime_avoids_weight_dequant_cache(m
     ]
 
 
-def test_orbit_linear_native_packed_matmul_runtime_rejects_cpu_before_quantization(
-    monkeypatch,
-):
+def test_orbit_linear_native_packed_matmul_runtime_accepts_cpu_input():
     torch.manual_seed(5)
     source = torch.nn.Linear(16, 7)
     config = OrbitQuantConfig(
@@ -505,17 +520,7 @@ def test_orbit_linear_native_packed_matmul_runtime_rejects_cpu_before_quantizati
     quantized = OrbitQuantLinear.from_linear(source, config=config, module_name="block.ff.linear")
     x = torch.randn(2, 5, 16)
 
-    def fail_activation_quantization(*args, **kwargs):
-        raise AssertionError("device validation should run before activation quantization")
-
-    monkeypatch.setattr(
-        layers_module,
-        "quantize_activations_kernel",
-        fail_activation_quantization,
-    )
-
-    with pytest.raises(RuntimeError, match="requires CUDA or MPS input tensors"):
-        quantized(x)
+    quantized._validate_native_packed_matmul_input(x)
 
 
 def test_orbit_linear_native_packed_matmul_runtime_avoids_weight_dequant_cache(monkeypatch):
@@ -862,9 +867,11 @@ def test_orbit_linear_native_packed_matmul_mps_matches_dequant_bf16(monkeypatch)
     if not torch.backends.mps.is_available():
         pytest.skip("MPS backend is not available")
     try:
-        import orbitquant_packed_matmul  # noqa: F401
+        import orbitquant_packed_matmul
     except Exception:
         pytest.skip("native packed matmul kernel package is not importable")
+    if not orbitquant_packed_matmul.supports_device("mps"):
+        pytest.skip("the importable native packed matmul variant has no MPS backend")
 
     import orbitquant.kernels.native_packed_matmul as native_module
 
@@ -901,18 +908,22 @@ def test_orbit_linear_native_packed_matmul_mps_matches_dequant_bf16(monkeypatch)
 def test_orbit_linear_auto_fused_native_packed_matmul_matches_reference_without_dequant(
     monkeypatch,
 ):
-    if torch.cuda.is_available():
-        device = torch.device("cuda")
-        dtype = torch.bfloat16
-    elif torch.backends.mps.is_available():
-        device = torch.device("mps")
-        dtype = torch.float32
-    else:
-        pytest.skip("CUDA or MPS backend is required")
     try:
-        import orbitquant_packed_matmul  # noqa: F401
+        import orbitquant_packed_matmul
     except Exception:
         pytest.skip("native packed matmul kernel package is not importable")
+
+    if torch.cuda.is_available() and orbitquant_packed_matmul.supports_device("cuda"):
+        device = torch.device("cuda")
+        dtype = torch.bfloat16
+    elif torch.backends.mps.is_available() and orbitquant_packed_matmul.supports_device("mps"):
+        device = torch.device("mps")
+        dtype = torch.float32
+    elif orbitquant_packed_matmul.supports_device("cpu"):
+        device = torch.device("cpu")
+        dtype = torch.float32
+    else:
+        pytest.skip("the importable native packed matmul variant has no runnable backend")
 
     import orbitquant.kernels.native_packed_matmul as native_module
 
@@ -935,6 +946,7 @@ def test_orbit_linear_auto_fused_native_packed_matmul_matches_reference_without_
     packed = copy.deepcopy(reference).to(device)
     packed.runtime_mode = "auto_fused"
     monkeypatch.setattr(native_module, "_NATIVE_KERNEL", None)
+    layers_module._clear_packed_matmul_probe_cache()
 
     def fail_dequantize_weight(*args, **kwargs):
         raise AssertionError("auto_fused native runtime materialized dequantized weights")

--- a/tests/test_paper_reference_oracle.py
+++ b/tests/test_paper_reference_oracle.py
@@ -119,20 +119,30 @@ def test_rpbh_matches_independent_dense_equation_9_oracle():
 
 
 @pytest.mark.parametrize(
-    ("weight_bits", "activation_bits", "with_bias"),
+    ("weight_bits", "activation_bits", "with_bias", "runtime_mode"),
     [
-        (4, 4, True),
-        (3, 3, False),
-        (2, 4, True),
-        (2, 3, False),
-        (4, 6, True),
+        (4, 4, True, "dequant_bf16"),
+        (3, 3, False, "dequant_bf16"),
+        (2, 4, True, "dequant_bf16"),
+        (2, 3, False, "dequant_bf16"),
+        (4, 6, True, "dequant_bf16"),
+        (4, 4, True, "native_packed_matmul"),
     ],
 )
 def test_reference_runtime_matches_independent_algorithm_1_oracle(
     weight_bits: int,
     activation_bits: int,
     with_bias: bool,
+    runtime_mode: str,
 ):
+    if runtime_mode == "native_packed_matmul":
+        try:
+            import orbitquant_packed_matmul
+        except Exception:
+            pytest.skip("native packed matmul kernel package is not importable")
+        if not orbitquant_packed_matmul.supports_device("cpu"):
+            pytest.skip("the importable native packed matmul variant has no CPU backend")
+
     torch.manual_seed(202)
     source = torch.nn.Linear(24, 5, bias=with_bias)
     with torch.no_grad():
@@ -144,7 +154,7 @@ def test_reference_runtime_matches_independent_algorithm_1_oracle(
         activation_bits=activation_bits,
         rotation_seed=29,
         block_size="paper",
-        runtime_mode="dequant_bf16",
+        runtime_mode=runtime_mode,
         activation_kernel_backend="cpu",
     )
     layer = OrbitQuantLinear.from_linear(
@@ -229,7 +239,7 @@ def test_adaln_group64_rtn_matches_independent_weight_only_contract():
         source.bias.copy_(torch.tensor([-0.25, 0.0, 0.5]))
     layer = RTNInt4Linear.from_linear(
         source,
-        config=OrbitQuantConfig(),
+        config=OrbitQuantConfig(runtime_mode="dequant_bf16"),
         module_name="transformer_blocks.0.norm1.linear",
     )
 

--- a/tests/test_transformers_pretrained_integration.py
+++ b/tests/test_transformers_pretrained_integration.py
@@ -62,8 +62,15 @@ def test_transformers_pretrained_from_pretrained_quantizes_on_load(tmp_path):
     assert isinstance(loaded.transformer_blocks[0]["attn"]["to_q"], OrbitQuantLinear)
     assert isinstance(loaded.transformer_blocks[0]["modulation"], RTNInt4Linear)
     assert isinstance(loaded.proj_out, torch.nn.Linear)
+    quantized = loaded.transformer_blocks[0]["attn"]["to_q"]
+    assert not quantized._derived_constants_valid
     x = torch.randn(2, 3, 16)
     assert torch.isfinite(loaded(x)).all()
+    assert quantized._derived_constants_valid
+    assert torch.equal(
+        torch.unique(quantized._rotation_signs),
+        torch.tensor([-1, 1], dtype=torch.int8),
+    )
 
 
 def test_transformers_pretrained_streams_full_precision_weight_into_packed_tensors(
@@ -98,8 +105,14 @@ def test_transformers_pretrained_streams_full_precision_weight_into_packed_tenso
     assert quantized.row_norms is not None
     assert modulation.packed_weight is not None
     assert modulation.scales is not None
+    assert not quantized._derived_constants_valid
     x = torch.randn(2, 3, 16)
     assert torch.isfinite(loaded(x)).all()
+    assert quantized._derived_constants_valid
+    assert torch.equal(
+        torch.unique(quantized._rotation_signs),
+        torch.tensor([-1, 1], dtype=torch.int8),
+    )
 
 
 def test_transformers_pretrained_save_pretrained_round_trips_pre_quantized_model(


### PR DESCRIPTION
## Summary

- add exact packed CPU activation, low-bit matmul, and INT4 group-64 AdaLN without full weight materialization
- add runtime scalar, ARM64 NEON, x86 AVX2, AVX-512, and AVX-512 BF16 dispatch
- use the native CPU path from `auto_fused` when the optional package is available
- add ABI3/stable-LibTorch wheel preparation and an actual Windows MSVC build/install/forward CI gate

## Verification

- local full suite: 485 passed, 39 accelerator-only skips
- native package: 73 passed, 33 CUDA/MPS skips on both ARM64 and x86_64
- x86 EPYC 9654: scalar/AVX2/AVX-512 correctness plus `vpermw`/`vdpbf16ps` disassembly evidence
- W4A4 32x1536x1536: 1.496 ms packed median vs 6.714 ms explicit dequant+linear, 25.1% of BF16 weight bytes
- package build and metadata checks pass

## Claim boundary

Only source-built ARM64/macOS and x86_64/Linux CPU paths are hardware-verified at this point. The Windows job in this PR must pass before Windows is marked supported. Raw Ubuntu 24.04 wheels are not release artifacts because auditwheel constrains them to manylinux_2_38; a manylinux_2_28 build remains required. No PyPI or GitHub release is performed by this PR.