### PR TITLE
Add bounded checkpoint streaming quantization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
             --git https://github.com/huggingface/kernels `
             --rev d43de01d0b43285d8e5061ca4380c2bd1c40ae3b `
             --locked `
+            --debug `
             --root "$env:RUNNER_TEMP\kernel-builder" `
             hf-kernel-builder
 
@@ -98,6 +99,12 @@ jobs:
         shell: pwsh
         working-directory: native-kernels/orbitquant-packed-matmul
         run: |
+          Get-CimInstance Win32_Processor | `
+            Select-Object Name, NumberOfCores, NumberOfLogicalProcessors | `
+            Format-List
+          cmake --version
+          $env:CMAKE_GENERATOR = "Visual Studio 17 2022"
+          $env:CMAKE_GENERATOR_PLATFORM = "x64"
           $env:CMAKE_ARGS = "-DGPU_LANG=CPU"
           $env:MAX_JOBS = "2"
           $python = "$env:GITHUB_WORKSPACE\.venv\Scripts\python.exe"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,15 @@ jobs:
           uv sync --extra dev
           uv pip install --python .venv\Scripts\python.exe cmake ninja setuptools wheel
 
+      - name: Cache pinned kernel-builder
+        id: kernel-builder-cache
+        uses: actions/cache@v6.1.0
+        with:
+          path: ${{ runner.temp }}\kernel-builder
+          key: kernel-builder-windows-d43de01d0b43285d8e5061ca4380c2bd1c40ae3b
+
       - name: Install pinned kernel-builder
+        if: steps.kernel-builder-cache.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
           cargo install `
@@ -103,7 +111,7 @@ jobs:
             Select-Object Name, NumberOfCores, NumberOfLogicalProcessors | `
             Format-List
           cmake --version
-          $env:CMAKE_GENERATOR = "Visual Studio 17 2022"
+          $env:CMAKE_GENERATOR = "Visual Studio 18 2026"
           $env:CMAKE_GENERATOR_PLATFORM = "x64"
           $env:CMAKE_ARGS = "-DGPU_LANG=CPU"
           $env:MAX_JOBS = "2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,105 @@ jobs:
           source "$tmpdir/.venv/bin/activate"
           "$tmpdir/.venv/bin/python" -c "import orbitquant; print(orbitquant.__version__)"
           orbitquant --version
+
+  windows-native-cpu:
+    name: Windows native CPU
+    runs-on: windows-2025
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.0
+
+      - name: Install Python dependencies
+        shell: pwsh
+        run: |
+          uv sync --extra dev
+          uv pip install --python .venv\Scripts\python.exe cmake ninja setuptools wheel
+
+      - name: Install pinned kernel-builder
+        shell: pwsh
+        run: |
+          cargo install `
+            --git https://github.com/huggingface/kernels `
+            --rev d43de01d0b43285d8e5061ca4380c2bd1c40ae3b `
+            --locked `
+            --root "$env:RUNNER_TEMP\kernel-builder" `
+            hf-kernel-builder
+
+      - name: Generate native build project
+        shell: pwsh
+        run: |
+          $kernelRoot = "native-kernels\orbitquant-packed-matmul"
+          $builder = "$env:RUNNER_TEMP\kernel-builder\bin\kernel-builder.exe"
+          & $builder check-config $kernelRoot
+          & $builder create-pyproject --unique-id windows_ci -f $kernelRoot
+          & .venv\Scripts\python.exe `
+            "$kernelRoot\scripts\prepare_wheel_project.py" `
+            $kernelRoot `
+            --version 0.1.0
+
+      - name: Build ABI3 CPU wheel with MSVC
+        shell: pwsh
+        working-directory: native-kernels/orbitquant-packed-matmul
+        run: |
+          $env:CMAKE_ARGS = "-DGPU_LANG=CPU"
+          $env:MAX_JOBS = "2"
+          $python = "$env:GITHUB_WORKSPACE\.venv\Scripts\python.exe"
+          & $python setup.py bdist_wheel --py-limited-api=cp39
+
+      - name: Verify wheel tag and metadata
+        shell: pwsh
+        working-directory: native-kernels/orbitquant-packed-matmul
+        run: |
+          $wheel = Get-ChildItem dist\*.whl | Select-Object -First 1
+          if ($null -eq $wheel) {
+            throw "native CPU wheel was not produced"
+          }
+          if ($wheel.Name -notmatch "-cp39-abi3-win_amd64\.whl$") {
+            throw "unexpected native CPU wheel tag: $($wheel.Name)"
+          }
+          $python = "$env:GITHUB_WORKSPACE\.venv\Scripts\python.exe"
+          & $python -c "import pathlib, zipfile; p=next(pathlib.Path('dist').glob('*.whl')); z=zipfile.ZipFile(p); m=z.read(next(n for n in z.namelist() if n.endswith('.dist-info/METADATA'))).decode(); assert 'Requires-Dist: torch>=2.11' in m; print(p.name); print(m)"
+
+      - name: Smoke install and native package tests
+        shell: pwsh
+        run: |
+          $smoke = "$env:RUNNER_TEMP\orbitquant-native-smoke"
+          uv venv $smoke --python 3.12
+          $python = "$smoke\Scripts\python.exe"
+          uv pip install --python $python torch==2.12.1 pytest
+          $wheel = Get-ChildItem `
+            native-kernels\orbitquant-packed-matmul\dist\*.whl | `
+            Select-Object -First 1
+          uv pip install --python $python $wheel.FullName --no-deps
+          & $python -m pytest `
+            native-kernels\orbitquant-packed-matmul\tests\test_packed_matmul.py `
+            -m kernels_ci `
+            -ra
+
+      - name: OrbitQuant native integration tests
+        shell: pwsh
+        run: |
+          $python = ".venv\Scripts\python.exe"
+          $wheel = Get-ChildItem `
+            native-kernels\orbitquant-packed-matmul\dist\*.whl | `
+            Select-Object -First 1
+          uv pip install --python $python $wheel.FullName --no-deps
+          & $python -m pytest `
+            tests\test_native_packed_matmul.py `
+            tests\test_adaln_rtn.py `
+            tests\test_paper_reference_oracle.py `
+            -ra
+
+      - name: Upload Windows native CPU wheel
+        uses: actions/upload-artifact@v6.0.0
+        with:
+          name: orbitquant-packed-matmul-windows-cpu
+          path: native-kernels/orbitquant-packed-matmul/dist/*.whl

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: Version to publish
         required: true
-        default: "0.2.2"
+        default: "0.4.0"
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -46,37 +46,52 @@ Diffusers versions. The default `target_policy="auto"` selects a known
 paper policy where applicable and otherwise uses the universal policy.
 
 ```python
-import torch
 import orbitquant
-from transformers import AutoModelForCausalLM
+from transformers import AutoModel
+from orbitquant import OrbitQuantConfig
 
-config = orbitquant.recipe(
-    "w4a4",
-    runtime_mode="auto_fused",
+model_id = "google/vit-base-patch16-224"
+model = AutoModel.from_pretrained(
+    model_id,
+    quantization_config=OrbitQuantConfig(target_policy="auto"),
+    low_cpu_mem_usage=True,
 )
-
-model = AutoModelForCausalLM.from_pretrained(
-    "your-org/your-transformer",
-    dtype=torch.bfloat16,
-    quantization_config=config,
-)
-model.save_pretrained("./your-transformer-orbitquant-w4a4")
 ```
 
-Load the packed model after importing the backend:
+This is checkpoint-level conversion, not post-load module replacement. For each
+target weight OrbitQuant reads aligned row tiles from safetensors, closes that
+source mapping, and feeds a temporary packed shard back to the normal
+Transformers loader. Peak model-side memory is bounded by packed resident state,
+one source row tile, quantization workspace, intentionally skipped state, and
+runtime overhead. The full source transformer is never resident at once.
+
+Save an offline packed artifact without loading the source model again:
+
+```python
+model.save_pretrained("./model-orbitquant-w4a4", max_shard_size="2GB")
+```
+
+Load the packed artifact after importing the backend:
 
 ```python
 import orbitquant
-from transformers import AutoModelForCausalLM
+from transformers import AutoModel
 
-model = AutoModelForCausalLM.from_pretrained(
-    "./your-transformer-orbitquant-w4a4",
+model = AutoModel.from_pretrained(
+    "./model-orbitquant-w4a4",
     device_map="auto",
 )
 ```
 
 Named recipes are `w4a4`, `w3a3`, `w2a4`, `w2a3`, and `w4a6`. They create a
 normal `OrbitQuantConfig`, so every field can be overridden.
+
+Bounded on-the-fly conversion requires safetensors and the Transformers 5
+weight-conversion APIs. Local paths and Hub model IDs use the normal
+`revision`, `variant`, token/auth, `device_map`, `max_memory`, CPU, and disk
+offload arguments. Pickle/`.bin` checkpoints fail with an actionable error;
+use the explicit post-load helper only when accepting that it has no
+checkpoint-level memory guarantee.
 
 ## Inspect Coverage
 
@@ -118,7 +133,7 @@ Explicit dtype overrides remain available through `modules_dtype_dict`.
 ## Quantize An Instantiated Module
 
 For ordinary PyTorch models or frameworks that do not use Hugging Face loading
-hooks:
+hooks, or as an explicit compatibility fallback:
 
 ```python
 from orbitquant import quantize_model, recipe
@@ -130,6 +145,10 @@ summary = quantize_model(
 )
 print(summary.quantized_modules)
 ```
+
+Here `staging_mode="streaming"` limits device staging per module only. The
+source model is already loaded, so this helper does not make a bounded host-RAM
+claim.
 
 The replacement supports arbitrary leading dimensions and treats the final
 dimension as `in_features`, including sequence, image-token, and video-token
@@ -159,38 +178,56 @@ silently replacing them.
 
 ## Diffusers
 
-Quantize the denoiser component of a pipeline:
+Quantize the denoiser while loading an arbitrary compatible pipeline:
 
 ```python
 import torch
+import orbitquant
 from diffusers import DiffusionPipeline
-from orbitquant import quantize_pipeline, recipe, save_quantized_pipeline_component
+from orbitquant import (
+    OrbitQuantConfig,
+    build_diffusers_pipeline_quantization_config,
+)
 
+model_id = "black-forest-labs/FLUX.1-schnell"
+qconfig = build_diffusers_pipeline_quantization_config(
+    OrbitQuantConfig(target_policy="auto"),
+    components="transformer",
+)
 pipe = DiffusionPipeline.from_pretrained(
-    "black-forest-labs/FLUX.2-klein-4B",
+    model_id,
+    quantization_config=qconfig,
     torch_dtype=torch.bfloat16,
 )
-config = recipe("w4a4", target_policy="flux2")
-summary = quantize_pipeline(
-    pipe,
-    config,
-    component="transformer",
-    quantization_device="cuda",
-)
-save_quantized_pipeline_component(
-    pipe,
-    "./flux2-klein-orbitquant-w4a4",
-    config=config,
-    component="transformer",
-    source_model_id="black-forest-labs/FLUX.2-klein-4B",
-    summary=summary,
-)
+pipe.enable_model_cpu_offload()
 ```
 
+Use sequential offload without an OrbitQuant-specific hook or preparation step:
+
+```python
+pipe = DiffusionPipeline.from_pretrained(
+    model_id,
+    quantization_config=qconfig,
+    torch_dtype=torch.bfloat16,
+)
+pipe.enable_sequential_cpu_offload()
+```
+
+Save the packed pipeline for later prequantized loading:
+
+```python
+pipe.save_pretrained("./pipeline-orbitquant", safe_serialization=True)
+```
+
+The default component is only `transformer`; text encoders require an explicit
+component opt-in. Diffusers uses the same safetensors row-sliced conversion and
+normal `PipelineQuantizationConfig` loading path. Unknown architectures receive
+structural `target_policy="auto"` coverage, not a quality guarantee; inspect the
+policy and validate output quality before publishing an artifact.
+
 Published FLUX, Z-Image, and Wan repositories are compact Diffusers component
-artifacts. Image model cards contain the matching pipeline code, native
-generation settings, and a ten-prompt full-resolution BF16-vs-OrbitQuant
-comparison matrix.
+artifacts. Their model cards contain the matching pipeline code and validation
+evidence.
 
 Load a published component artifact together with its recorded source pipeline:
 
@@ -209,6 +246,33 @@ pipe = load_quantized_pipeline_from_artifact(
     runtime_mode="auto_fused",
 )
 ```
+
+## Reproduce Load Memory
+
+The memory harness runs ordinary, on-the-fly, and prequantized loads in separate
+processes and reports RSS separately from mmap virtual size:
+
+```bash
+python scripts/measure_streaming_load_memory.py \
+  --framework transformers \
+  --model-id google/vit-base-patch16-224 \
+  --prequantized-model-id ./vit-base-orbitquant \
+  --torch-dtype bfloat16 \
+  --output ./memory-results.json
+```
+
+One CPU/MPS host run with Torch 2.12.1 measured:
+
+| Load | Peak RSS | Virtual/mmap peak | Resident state | Disk artifact | Wall time |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| BF16 source | 705.7 MiB | 416.3 GiB | 164.8 MiB | 330.3 MiB | 1.57 s |
+| On-the-fly OrbitQuant | 436.6 MiB | 416.4 GiB | 43.4 MiB | 330.3 MiB source | 3.01 s |
+| Prequantized | 331.3 MiB | 415.9 GiB | 43.4 MiB | 43.5 MiB | 0.14 s |
+
+The streaming run processed 324.0 MiB of selected source tensors with a 9.0
+MiB largest source tensor, retained no full dequantized cache, and reported no
+source-release failure. CUDA allocated/reserved and NVML fields are emitted
+when CUDA and NVML are available; they were unavailable for this Mac run.
 
 ## Packed Runtime
 

--- a/README.md
+++ b/README.md
@@ -218,11 +218,12 @@ pipe = load_quantized_pipeline_from_artifact(
 | --- | --- |
 | CUDA | Native activation kernel plus packed W4A4 tensor-core path; native or Triton packed fallback |
 | MPS | Native packed Metal package |
-| CPU | PyTorch reference path |
+| CPU | Native exact activation, packed low-bit matmul, and packed INT4 AdaLN when the CPU package is importable; PyTorch reference fallback otherwise |
 
 CUDA and MPS do not silently materialize a full BF16/FP16 weight matrix in
 `auto_fused`. If no packed backend is available, the error includes the missing
-backend and installation guidance.
+backend and installation guidance. CPU retains a compatibility fallback when
+the optional native package is absent.
 
 Use the explicit reference path for compatibility or numerical debugging:
 
@@ -257,8 +258,9 @@ inference by setting the allocator before Python starts:
 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True python generate.py
 ```
 
-The variant must match the Torch minor version, CUDA or Metal backend, C++ ABI,
-architecture, and operating system. See
+CUDA and Metal variants must match the Torch/backend tuple. The CPU variant
+targets the LibTorch Stable ABI 2.11, but remains specific to its operating
+system, C++ runtime, and architecture. See
 [`docs/kernel-audit.md`](docs/kernel-audit.md) for tested shapes, benchmark
 methodology, and local package verification.
 

--- a/docs/kernel-audit.md
+++ b/docs/kernel-audit.md
@@ -4,9 +4,11 @@ OrbitQuant uses packed low-bit weights directly in optimized runtime modes. The
 reference path materializes a floating-point weight matrix and is available only
 when explicitly selected.
 
-The runtime contract below reflects OrbitQuant 0.3.1. Benchmark tables retain
-the exact software and hardware of each recorded run rather than implying that
-those versions are current installation requirements.
+The runtime contract below reflects the current source tree. Benchmark tables
+retain the exact software and hardware of each recorded run rather than
+implying that those versions are current installation requirements. Binary
+platform support is only marked verified where build, install, and forward
+evidence exists.
 
 ## Runtime Contract
 
@@ -16,10 +18,11 @@ those versions are current installation requirements.
 | --- | --- | --- |
 | CUDA | Native activation kernel plus packed W4A4 tensor-core path; native or Triton packed fallback | A matching native package for the fastest path; Triton for the CUTLASS epilogue and generic packed fallback |
 | MPS | Native packed matmul | An importable local Metal package |
-| CPU | Reference matmul | PyTorch |
+| CPU | Native exact activation, packed low-bit matmul, and packed INT4 AdaLN when the CPU variant is importable; reference fallback otherwise | A matching native CPU package for packed execution |
 
 CUDA and MPS raise an actionable error when no packed backend is available.
-They do not silently fall back to full weight dequantization. Use
+They do not silently fall back to full weight dequantization. CPU keeps a
+compatibility fallback when the optional native package is absent. Use
 `runtime_mode="dequant_bf16"` explicitly for compatibility, debugging, or
 numerical comparison.
 
@@ -32,7 +35,8 @@ Other explicit modes are `native_packed_matmul`, `triton_packed_matmul`,
 | --- | --- | --- |
 | CUDA | Optimized packed inference | Native RPBH/quantization, chunked packed-weight decode plus CUTLASS INT8 matmul, direct packed CUDA MMA fallback, and generic Triton packed fallback |
 | MPS/Metal | Optimized packed inference | Native Metal packed matmul and Metal activation quantization stages |
-| CPU | Reference | PyTorch activation quantization, weight dequantization, and linear matmul |
+| CPU | Hardware-verified native source build; platform wheels pending | Runtime ISA dispatch across scalar, AVX2/FMA, AVX-512/BF16, and ARM64 NEON; exact packed activation, packed low-bit matmul, and packed INT4 group-64 AdaLN |
+| Vulkan | Unverified | No runtime backend |
 | ROCm | Unsupported | No release backend |
 | XPU | Unsupported | No release backend |
 
@@ -103,6 +107,57 @@ The variant must match the active Torch, CUDA or Metal, platform, and C++ ABI
 tuple. OrbitQuant rejects incompatible packages instead of loading them.
 
 ## Verified Devices And Shapes
+
+The native CPU package was built and executed on an AMD EPYC 4564P (Zen 4)
+with GCC 13.3 and Torch 2.13.0+cpu. The hosted cpuset exposed logical CPUs
+`13,29`, which are the two SMT threads of one physical core. These results are
+single-physical-core ISA and latency evidence, not a multi-core scaling claim.
+Runtime dispatch exercised scalar, AVX2/FMA, and AVX-512 paths against the same
+independent BF16 reference. The AVX-512 group-64 path uses `vpermw` for INT4
+lookup and `vdpbf16ps` accumulation; annotated disassembly confirmed that the
+hot rows=4 and rows=8 loops retain accumulators in ZMM registers without a full
+weight decode buffer or stack-spilled accumulator tile.
+
+For an exact W4A4 projection with 32 activation rows and dimension 1536, the
+native activation stage measured 0.1484 ms median, packed matmul measured
+1.0528 ms, and the full native layer measured 1.2081 ms. Explicit
+`dequant_bf16` measured 1.5836 ms and source BF16 `F.linear` measured 0.5479 ms.
+The packed and explicit-reference outputs had relative RMSE `1.203e-7` and
+maximum error `1.526e-5`. Packed weights and row norms occupied 1,179,648 bytes
+versus 4,718,592 bytes for BF16 weights, and the native layer retained no
+dequantized-weight cache.
+
+AdaLN uses an exact signed INT4 group-64 lookup with BF16 scales and
+activations. The realistic modulation shape below is 3072 input channels and
+18432 output channels. Timings are 21 post-warmup calls with
+`ORBITQUANT_CPU_THREADS=1`; `auto_fused` selected the AVX-512/BF16 path.
+
+| Rows | Packed median | Packed p95 | Resident BF16 median | Packed vs resident BF16 | Relative RMSE | Max error |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 2.4828 ms | 2.7575 ms | 6.9140 ms | 2.78x | 1.01e-6 | 0.001953 |
+| 4 | 3.0471 ms | 3.0726 ms | 6.3742 ms | 2.09x | 2.50e-5 | 0.0625 |
+| 32 | 24.4159 ms | 24.4693 ms | 15.9194 ms | 0.65x | 2.32e-5 | 0.125 |
+
+The packed AdaLN weight is 28,311,552 bytes and its BF16 scales are 1,769,472
+bytes, compared with 113,246,208 bytes for the BF16 weight. A native-only
+process increased resident memory by 1.4 MB on its first call and by another
+4.3 MB across 500 calls; it did not allocate the 113 MB dense weight. The
+rows=32 result documents the crossover where oneDNN's resident BF16 GEMM is
+faster; AdaLN conditioning normally uses batch-sized row counts rather than
+spatial-token row counts.
+
+The same x86_64 stable-ABI 2.11 binary built against Torch 2.13 loaded and ran
+under Torch 2.12.1. This verifies the current LibTorch Stable ABI boundary for
+those two runtimes; it does not make the wheel independent of the platform
+GLIBC, C++ runtime, or CPU ISA. Linux and Windows wheel policy remains pending,
+and Windows CPU execution is not yet verified.
+
+The ARM64 native CPU path was separately built on an Apple M2 Max. At 32 rows
+and dimension 1536, the full native W4A4 layer measured about 1.20 ms versus
+1.84 ms for explicit BF16 dequantization; the packed matmul itself was about
+0.81 ms versus 0.79 ms for a resident dense matmul. Scalar and NEON paths were
+both exercised against the independent reference. These CPU measurements are
+separate from the preferred Metal GPU path on Apple Silicon.
 
 CUDA native-package verification passed on an NVIDIA RTX PRO 4500 Blackwell
 with Torch 2.13.0+cu130 using the

--- a/docs/paper-methodology-audit.md
+++ b/docs/paper-methodology-audit.md
@@ -1,7 +1,7 @@
 # OrbitQuant Paper Methodology Audit
 
 Paper revision: arXiv 2607.02461v1.
-Implementation baseline: OrbitQuant 0.3.1.
+Implementation baseline: OrbitQuant 0.4.0.
 
 This audit defines the method-conformance and claim boundaries for OrbitQuant.
 Run `scripts/run_paper_methodology_checks.sh` to verify the independent

--- a/native-kernels/orbitquant-packed-matmul/benchmarks/benchmark.py
+++ b/native-kernels/orbitquant-packed-matmul/benchmarks/benchmark.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import platform
+import statistics
 import time
 
 import torch
@@ -28,18 +31,29 @@ def _synchronize(device: str) -> None:
         torch.mps.synchronize()
 
 
-def _time_call(device: str, iters: int, fn) -> float:
+def _time_call(device: str, fn) -> float:
     _synchronize(device)
-    start = time.perf_counter()
+    start = time.perf_counter_ns()
+    fn()
+    _synchronize(device)
+    return (time.perf_counter_ns() - start) / 1_000_000_000
+
+
+def _time_distribution(device: str, iters: int, fn) -> dict[str, float]:
+    samples = []
     for _ in range(iters):
-        fn()
-    _synchronize(device)
-    return (time.perf_counter() - start) / iters
+        samples.append(_time_call(device, fn))
+    samples.sort()
+    return {
+        "mean": statistics.fmean(samples),
+        "median": statistics.median(samples),
+        "p95": samples[min(len(samples) - 1, int(len(samples) * 0.95))],
+    }
 
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--device", choices=["cuda", "mps"], default="cuda")
+    parser.add_argument("--device", choices=["cpu", "cuda", "mps"], default="cuda")
     parser.add_argument("--bits", type=int, default=4)
     parser.add_argument("--rows", type=int, default=4096)
     parser.add_argument("--in-features", type=int, default=3072)
@@ -47,8 +61,17 @@ def main() -> None:
     parser.add_argument("--iters", type=int, default=20)
     parser.add_argument("--warmup", type=int, default=3)
     parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--threads", type=int, default=0)
     parser.add_argument("--with-bias", action="store_true")
     args = parser.parse_args()
+
+    if args.threads < 0:
+        parser.error("--threads must be non-negative")
+    if args.iters <= 0 or args.warmup < 0:
+        parser.error("--iters must be positive and --warmup must be non-negative")
+    if args.device == "cpu" and args.threads > 0:
+        os.environ["ORBITQUANT_CPU_THREADS"] = str(args.threads)
+        torch.set_num_threads(args.threads)
 
     torch.manual_seed(args.seed)
     dtype = torch.float16 if args.device == "mps" else torch.bfloat16
@@ -98,30 +121,48 @@ def main() -> None:
     def dequantize_then_linear_call() -> torch.Tensor:
         return torch.nn.functional.linear(x, materialize_reference_weight(), bias)
 
+    packed_first_call_seconds = _time_call(args.device, packed_call)
+    predequantized_first_call_seconds = _time_call(args.device, predequantized_linear_call)
+    dequantize_then_first_call_seconds = _time_call(args.device, dequantize_then_linear_call)
+
     for _ in range(args.warmup):
         packed_call()
         predequantized_linear_call()
         dequantize_then_linear_call()
-    packed_seconds = _time_call(args.device, args.iters, packed_call)
-    predequantized_linear_seconds = _time_call(
+    packed_distribution = _time_distribution(args.device, args.iters, packed_call)
+    predequantized_distribution = _time_distribution(
         args.device,
         args.iters,
         predequantized_linear_call,
     )
-    dequantize_then_linear_seconds = _time_call(
+    dequantize_then_distribution = _time_distribution(
         args.device,
         args.iters,
         dequantize_then_linear_call,
     )
+    packed_seconds = packed_distribution["mean"]
+    predequantized_linear_seconds = predequantized_distribution["mean"]
+    dequantize_then_linear_seconds = dequantize_then_distribution["mean"]
 
     packed_output = packed_call()
     reference_output = predequantized_linear_call()
     _synchronize(args.device)
-    max_abs_error = (packed_output.float() - reference_output.float()).abs().max().item()
+    error = packed_output.float() - reference_output.float()
+    max_abs_error = error.abs().max().item()
+    rmse = error.square().mean().sqrt().item()
+    reference_rms = reference_output.float().square().mean().sqrt().item()
+    relative_rmse = rmse / max(reference_rms, 1e-12)
 
     payload = {
         "device": args.device,
-        "device_name": torch.cuda.get_device_name(0) if args.device == "cuda" else "mps",
+        "device_name": (
+            torch.cuda.get_device_name(0)
+            if args.device == "cuda"
+            else "mps"
+            if args.device == "mps"
+            else f"{platform.processor() or platform.machine()} "
+            f"({torch.backends.cpu.get_cpu_capability()})"
+        ),
         "dtype": str(dtype).replace("torch.", ""),
         "bits": args.bits,
         "rows": args.rows,
@@ -129,10 +170,25 @@ def main() -> None:
         "out_features": args.out_features,
         "iters": args.iters,
         "warmup": args.warmup,
+        "threads": (
+            os.environ.get("ORBITQUANT_CPU_THREADS", "runtime default")
+            if args.device == "cpu"
+            else None
+        ),
+        "torch_threads": torch.get_num_threads() if args.device == "cpu" else None,
         "with_bias": args.with_bias,
         "packed_seconds_per_iter": packed_seconds,
+        "packed_first_call_seconds": packed_first_call_seconds,
+        "packed_hot_median_seconds": packed_distribution["median"],
+        "packed_hot_p95_seconds": packed_distribution["p95"],
         "predequantized_f_linear_seconds_per_iter": predequantized_linear_seconds,
+        "predequantized_first_call_seconds": predequantized_first_call_seconds,
+        "predequantized_hot_median_seconds": predequantized_distribution["median"],
+        "predequantized_hot_p95_seconds": predequantized_distribution["p95"],
         "dequantize_then_f_linear_seconds_per_iter": dequantize_then_linear_seconds,
+        "dequantize_then_first_call_seconds": dequantize_then_first_call_seconds,
+        "dequantize_then_hot_median_seconds": dequantize_then_distribution["median"],
+        "dequantize_then_hot_p95_seconds": dequantize_then_distribution["p95"],
         "packed_weight_indices_bytes": packed_weight_indices_bytes,
         "row_norms_bytes": row_norms_bytes,
         "centroid_bytes": centroid_bytes,
@@ -155,6 +211,8 @@ def main() -> None:
         if packed_seconds > 0
         else None,
         "max_abs_error": max_abs_error,
+        "rmse": rmse,
+        "relative_rmse": relative_rmse,
         "reference": (
             "predequantized PyTorch F.linear over a materialized dequantized "
             "weight matrix"

--- a/native-kernels/orbitquant-packed-matmul/build.toml
+++ b/native-kernels/orbitquant-packed-matmul/build.toml
@@ -3,7 +3,7 @@ name = "orbitquant-packed-matmul"
 version = 1
 edition = 5
 license = "Apache-2.0"
-backends = ["cuda", "metal"]
+backends = ["cpu", "cuda", "metal"]
 upstream = "https://github.com/iamwavecut/OrbitQuant"
 source = "https://huggingface.co/WaveCut/orbitquant-packed-matmul"
 
@@ -14,6 +14,37 @@ repo-id = "WaveCut/orbitquant-packed-matmul"
 src = [
   "torch-ext/torch_binding.cpp",
   "torch-ext/torch_binding.h",
+]
+
+[torch.stable-abi]
+cpu = "2.11"
+
+[kernel.packed_matmul_cpu]
+backend = "cpu"
+depends = ["torch"]
+include = ["orbitquant_packed_matmul_cpu"]
+src = [
+  "orbitquant_packed_matmul_cpu/cpu_isa.cpp",
+  "orbitquant_packed_matmul_cpu/cpu_kernel_args.h",
+  "orbitquant_packed_matmul_cpu/cpu_threads.cpp",
+  "orbitquant_packed_matmul_cpu/cpu_threads.h",
+  "orbitquant_packed_matmul_cpu/packed_adaln_cpu.cpp",
+  "orbitquant_packed_matmul_cpu/packed_matmul_cpu.cpp",
+  "orbitquant_packed_matmul_cpu/packed_matmul_cpu.h",
+  "orbitquant_packed_matmul_cpu/packed_matmul_scalar.cpp",
+  "orbitquant_packed_matmul_cpu/packed_matmul_neon.cpp",
+  "orbitquant_packed_matmul_cpu/packed_matmul_x86_avx512.cpp",
+  "orbitquant_packed_matmul_cpu/quantize_activations_cpu.cpp",
+]
+
+[kernel.packed_matmul_cpu_x86_avx2]
+backend = "cpu"
+depends = ["torch"]
+include = ["orbitquant_packed_matmul_cpu"]
+cxx-flags = ["$<$<CXX_COMPILER_ID:MSVC>:/arch:AVX2>"]
+src = [
+  "orbitquant_packed_matmul_cpu/cpu_msvc_avx2.cpp",
+  "orbitquant_packed_matmul_cpu/packed_matmul_x86.cpp",
 ]
 
 [kernel.packed_matmul_cuda]

--- a/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/cpu_isa.cpp
+++ b/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/cpu_isa.cpp
@@ -1,0 +1,42 @@
+#include "packed_matmul_cpu.h"
+
+#if defined(__x86_64__) || defined(_M_X64)
+#if defined(_MSC_VER)
+#include <intrin.h>
+#pragma intrinsic(_xgetbv)
+#endif
+#endif
+
+namespace orbitquant::cpu {
+namespace {
+
+bool runtime_has_avx2_fma_f16c() {
+#if defined(_MSC_VER) && defined(_M_X64)
+  int registers[4]{};
+  __cpuid(registers, 1);
+  const bool osxsave = (registers[2] & (1 << 27)) != 0;
+  const bool avx = (registers[2] & (1 << 28)) != 0;
+  const bool fma = (registers[2] & (1 << 12)) != 0;
+  const bool f16c = (registers[2] & (1 << 29)) != 0;
+  if (!osxsave || !avx || !fma || !f16c || (_xgetbv(0) & 0x6) != 0x6) {
+    return false;
+  }
+  __cpuidex(registers, 7, 0);
+  return (registers[1] & (1 << 5)) != 0;
+#elif defined(__x86_64__)
+  __builtin_cpu_init();
+  return __builtin_cpu_supports("avx2") && __builtin_cpu_supports("fma") &&
+      __builtin_cpu_supports("f16c");
+#else
+  return false;
+#endif
+}
+
+}  // namespace
+
+bool packed_matmul_x86_avx2_available() {
+  static const bool available = runtime_has_avx2_fma_f16c();
+  return available;
+}
+
+}  // namespace orbitquant::cpu

--- a/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/cpu_kernel_args.h
+++ b/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/cpu_kernel_args.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "packed_matmul_cpu.h"
+
+#include <cstdint>
+
+namespace orbitquant::cpu {
+
+enum class ActivationIsa : std::uint8_t {
+  Portable,
+  Neon,
+  Avx2,
+  Avx512,
+};
+
+struct ActivationArgs {
+  void *out;
+  void const *x;
+  std::int64_t const *permutation;
+  std::int8_t const *signs;
+  float const *centroids;
+  float const *boundaries;
+  ScalarKind scalar_kind;
+  ActivationIsa isa;
+  std::int64_t rows;
+  std::int64_t dim;
+  std::int64_t boundary_count;
+  std::int64_t block_size;
+  float eps;
+  float inv_sqrt_block;
+};
+
+void activation_fwht_msvc_avx2(float *values, std::int64_t block_size);
+
+float activation_squared_norm_msvc_avx2(
+    void const *data,
+    ScalarKind scalar_kind,
+    std::int64_t offset,
+    std::int64_t dim);
+
+void activation_quantize_lookup_msvc_avx2(
+    ActivationArgs const &args,
+    float const *scratch,
+    std::int64_t output_offset,
+    float norm);
+
+struct AdalnArgs {
+  void *out;
+  void const *x;
+  std::uint8_t const *packed_weight;
+  float const *scales;
+  float const *bias;
+  bool has_bias;
+  std::int64_t rows;
+  std::int64_t out_features;
+  std::int64_t in_features;
+  std::int64_t group_size;
+  std::int64_t num_groups;
+  std::int64_t padded_in_features;
+};
+
+using AdalnRangeFn = void (*)(
+    AdalnArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end);
+
+void packed_adaln_msvc_avx2_range(
+    AdalnArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end);
+
+}  // namespace orbitquant::cpu

--- a/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/cpu_msvc_avx2.cpp
+++ b/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/cpu_msvc_avx2.cpp
@@ -1,0 +1,431 @@
+#include "cpu_kernel_args.h"
+
+#if defined(_MSC_VER) && defined(_M_X64)
+#include <immintrin.h>
+
+#include <torch/headeronly/util/BFloat16.h>
+#include <torch/headeronly/util/Half.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <type_traits>
+
+namespace orbitquant::cpu {
+namespace {
+
+template <typename scalar_t>
+inline float load_scalar(void const *data, std::int64_t offset) {
+  return static_cast<float>(static_cast<scalar_t const *>(data)[offset]);
+}
+
+template <>
+inline float load_scalar<float>(void const *data, std::int64_t offset) {
+  return static_cast<float const *>(data)[offset];
+}
+
+template <typename scalar_t>
+inline void store_scalar(void *data, std::int64_t offset, float value) {
+  static_cast<scalar_t *>(data)[offset] = scalar_t(value);
+}
+
+template <>
+inline void store_scalar<float>(void *data, std::int64_t offset, float value) {
+  static_cast<float *>(data)[offset] = value;
+}
+
+template <typename scalar_t>
+float squared_norm_avx2(
+    void const *data,
+    std::int64_t offset,
+    std::int64_t dim) {
+  __m256 accumulator = _mm256_setzero_ps();
+  std::int64_t index = 0;
+  for (; index + 8 <= dim; index += 8) {
+    __m256 values;
+    if constexpr (std::is_same_v<scalar_t, float>) {
+      values = _mm256_loadu_ps(
+          static_cast<float const *>(data) + offset + index);
+    } else if constexpr (std::is_same_v<scalar_t, c10::Half>) {
+      const auto *source =
+          static_cast<std::uint16_t const *>(data) + offset + index;
+      values = _mm256_cvtph_ps(
+          _mm_loadu_si128(reinterpret_cast<__m128i const *>(source)));
+    } else {
+      const auto *source =
+          static_cast<std::uint16_t const *>(data) + offset + index;
+      const __m128i packed =
+          _mm_loadu_si128(reinterpret_cast<__m128i const *>(source));
+      values = _mm256_castsi256_ps(
+          _mm256_slli_epi32(_mm256_cvtepu16_epi32(packed), 16));
+    }
+    accumulator = _mm256_fmadd_ps(values, values, accumulator);
+  }
+  const __m128 halves = _mm_add_ps(
+      _mm256_castps256_ps128(accumulator),
+      _mm256_extractf128_ps(accumulator, 1));
+  const __m128 pairs = _mm_hadd_ps(halves, halves);
+  float result = _mm_cvtss_f32(_mm_hadd_ps(pairs, pairs));
+  for (; index < dim; ++index) {
+    const float value = load_scalar<scalar_t>(data, offset + index);
+    result += value * value;
+  }
+  return result;
+}
+
+inline std::int64_t nearest_centroid(
+    float value,
+    float const *boundaries,
+    std::int64_t boundary_count) {
+  std::int64_t low = 0;
+  std::int64_t high = boundary_count;
+  while (low < high) {
+    const std::int64_t middle = low + (high - low) / 2;
+    if (value <= boundaries[middle]) {
+      high = middle;
+    } else {
+      low = middle + 1;
+    }
+  }
+  return low;
+}
+
+inline __m128i float8_to_bfloat8(__m256 values) {
+  const __m256i bits = _mm256_castps_si256(values);
+  const __m256i absolute_bits =
+      _mm256_and_si256(bits, _mm256_set1_epi32(0x7fffffff));
+  const __m256i nan_mask =
+      _mm256_cmpgt_epi32(absolute_bits, _mm256_set1_epi32(0x7f800000));
+  const __m256i rounding = _mm256_add_epi32(
+      _mm256_set1_epi32(0x7fff),
+      _mm256_and_si256(_mm256_srli_epi32(bits, 16), _mm256_set1_epi32(1)));
+  const __m256i upper = _mm256_srli_epi32(
+      _mm256_add_epi32(bits, rounding),
+      16);
+  __m128i packed = _mm_packus_epi32(
+      _mm256_castsi256_si128(upper),
+      _mm256_extracti128_si256(upper, 1));
+  const __m128i packed_nan_mask = _mm_packs_epi32(
+      _mm256_castsi256_si128(nan_mask),
+      _mm256_extracti128_si256(nan_mask, 1));
+  return _mm_blendv_epi8(
+      packed,
+      _mm_set1_epi16(0x7fc0),
+      packed_nan_mask);
+}
+
+template <typename scalar_t>
+void quantize_lookup_avx2(
+    ActivationArgs const &args,
+    float const *scratch,
+    std::int64_t output_offset,
+    float norm) {
+  const __m256 inverse_sqrt_block = _mm256_set1_ps(args.inv_sqrt_block);
+  const __m256 output_norm = _mm256_set1_ps(norm);
+  const __m256i ones = _mm256_set1_epi32(1);
+  std::int64_t index = 0;
+  for (; index + 8 <= args.dim; index += 8) {
+    const __m256 direction = _mm256_mul_ps(
+        _mm256_loadu_ps(scratch + index), inverse_sqrt_block);
+    __m256i centroid_indices = _mm256_setzero_si256();
+    for (std::int64_t boundary = 0; boundary < args.boundary_count; ++boundary) {
+      const __m256 comparison = _mm256_cmp_ps(
+          direction,
+          _mm256_set1_ps(args.boundaries[boundary]),
+          _CMP_NLE_UQ);
+      centroid_indices = _mm256_add_epi32(
+          centroid_indices,
+          _mm256_and_si256(_mm256_castps_si256(comparison), ones));
+    }
+    const __m256 output = _mm256_mul_ps(
+        _mm256_i32gather_ps(args.centroids, centroid_indices, 4),
+        output_norm);
+    if constexpr (std::is_same_v<scalar_t, float>) {
+      _mm256_storeu_ps(
+          static_cast<float *>(args.out) + output_offset + index,
+          output);
+    } else if constexpr (std::is_same_v<scalar_t, c10::Half>) {
+      _mm_storeu_si128(
+          reinterpret_cast<__m128i *>(
+              static_cast<std::uint16_t *>(args.out) + output_offset + index),
+          _mm256_cvtps_ph(output, _MM_FROUND_TO_NEAREST_INT));
+    } else {
+      _mm_storeu_si128(
+          reinterpret_cast<__m128i *>(
+              static_cast<std::uint16_t *>(args.out) + output_offset + index),
+          float8_to_bfloat8(output));
+    }
+  }
+  for (; index < args.dim; ++index) {
+    const float direction = scratch[index] * args.inv_sqrt_block;
+    const std::int64_t centroid_index = nearest_centroid(
+        direction, args.boundaries, args.boundary_count);
+    store_scalar<scalar_t>(
+        args.out,
+        output_offset + index,
+        args.centroids[centroid_index] * norm);
+  }
+}
+
+inline float load_bfloat(void const *data, std::int64_t offset) {
+  return static_cast<float>(
+      static_cast<c10::BFloat16 const *>(data)[offset]);
+}
+
+inline void store_bfloat(void *data, std::int64_t offset, float value) {
+  static_cast<c10::BFloat16 *>(data)[offset] = c10::BFloat16(value);
+}
+
+inline std::uint8_t unpack_adaln_index(
+    std::uint8_t const *packed,
+    std::int64_t flat_index) {
+  const std::uint8_t byte = packed[flat_index / 2];
+  return (flat_index & 1) == 0 ? byte & 15u : (byte >> 4) & 15u;
+}
+
+inline float dequantized_adaln_value(std::uint8_t index, float scale) {
+  return static_cast<float>(
+      c10::BFloat16((static_cast<int>(index) - 8) * scale));
+}
+
+inline void fill_group_lut(float *lut, float scale) {
+  for (int index = 0; index < 16; ++index) {
+    lut[index] = dequantized_adaln_value(
+        static_cast<std::uint8_t>(index), scale);
+  }
+}
+
+void packed_adaln_scalar_range(
+    AdalnArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  for (std::int64_t out_col = out_start; out_col < out_end; ++out_col) {
+    for (std::int64_t row = 0; row < args.rows; ++row) {
+      float accumulator = 0.0f;
+      const std::int64_t input_offset = row * args.in_features;
+      for (std::int64_t k = 0; k < args.in_features; ++k) {
+        const std::int64_t weight_offset =
+            out_col * args.padded_in_features + k;
+        const std::uint8_t index =
+            unpack_adaln_index(args.packed_weight, weight_offset);
+        const float scale =
+            args.scales[out_col * args.num_groups + k / args.group_size];
+        accumulator += load_bfloat(args.x, input_offset + k) *
+            dequantized_adaln_value(index, scale);
+      }
+      if (args.has_bias) {
+        accumulator += args.bias[out_col];
+      }
+      store_bfloat(
+          args.out,
+          row * args.out_features + out_col,
+          accumulator);
+    }
+  }
+}
+
+inline __m256 load_bfloat8(void const *data, std::int64_t offset) {
+  const auto *source =
+      static_cast<std::uint16_t const *>(data) + offset;
+  const __m128i packed =
+      _mm_loadu_si128(reinterpret_cast<__m128i const *>(source));
+  return _mm256_castsi256_ps(
+      _mm256_slli_epi32(_mm256_cvtepu16_epi32(packed), 16));
+}
+
+inline float horizontal_sum(__m256 value) {
+  const __m128 halves = _mm_add_ps(
+      _mm256_castps256_ps128(value),
+      _mm256_extractf128_ps(value, 1));
+  const __m128 pairs = _mm_hadd_ps(halves, halves);
+  return _mm_cvtss_f32(_mm_hadd_ps(pairs, pairs));
+}
+
+template <int row_tile>
+inline void packed_adaln_avx2_rows(
+    AdalnArgs const &args,
+    std::uint8_t const *packed_row,
+    float const *scale_row,
+    std::int64_t out_col,
+    std::int64_t row_start) {
+  __m256 accumulators[row_tile];
+  float tails[row_tile]{};
+  for (int row = 0; row < row_tile; ++row) {
+    accumulators[row] = _mm256_setzero_ps();
+  }
+  const __m128i nibble_mask = _mm_set1_epi8(15);
+  const __m256i low_table_limit = _mm256_set1_epi32(7);
+
+  for (std::int64_t group = 0; group < args.num_groups; ++group) {
+    float lut[16];
+    fill_group_lut(lut, scale_row[group]);
+    const __m256 lut_low = _mm256_loadu_ps(lut);
+    const __m256 lut_high = _mm256_loadu_ps(lut + 8);
+    const std::int64_t group_start = group * args.group_size;
+    const std::int64_t group_end = std::min(
+        args.in_features,
+        group_start + args.group_size);
+    std::int64_t k = group_start;
+    for (; k + 8 <= group_end; k += 8) {
+      std::int32_t packed;
+      std::memcpy(&packed, packed_row + k / 2, sizeof(packed));
+      const __m128i bytes = _mm_cvtsi32_si128(packed);
+      const __m128i low = _mm_and_si128(bytes, nibble_mask);
+      const __m128i high = _mm_and_si128(
+          _mm_srli_epi16(bytes, 4), nibble_mask);
+      const __m256i indices =
+          _mm256_cvtepu8_epi32(_mm_unpacklo_epi8(low, high));
+      const __m256 weight = _mm256_blendv_ps(
+          _mm256_permutevar8x32_ps(lut_low, indices),
+          _mm256_permutevar8x32_ps(lut_high, indices),
+          _mm256_castsi256_ps(
+              _mm256_cmpgt_epi32(indices, low_table_limit)));
+      for (int row = 0; row < row_tile; ++row) {
+        const std::int64_t input_offset =
+            (row_start + row) * args.in_features + k;
+        accumulators[row] = _mm256_fmadd_ps(
+            load_bfloat8(args.x, input_offset),
+            weight,
+            accumulators[row]);
+      }
+    }
+    for (; k < group_end; ++k) {
+      const float weight = lut[unpack_adaln_index(packed_row, k)];
+      for (int row = 0; row < row_tile; ++row) {
+        tails[row] += load_bfloat(
+            args.x,
+            (row_start + row) * args.in_features + k) * weight;
+      }
+    }
+  }
+
+  for (int row = 0; row < row_tile; ++row) {
+    float accumulator = horizontal_sum(accumulators[row]) + tails[row];
+    if (args.has_bias) {
+      accumulator += args.bias[out_col];
+    }
+    store_bfloat(
+        args.out,
+        (row_start + row) * args.out_features + out_col,
+        accumulator);
+  }
+}
+
+template <
+    void (*rows8)(AdalnArgs const &, std::uint8_t const *, float const *, std::int64_t, std::int64_t),
+    void (*rows4)(AdalnArgs const &, std::uint8_t const *, float const *, std::int64_t, std::int64_t),
+    void (*rows3)(AdalnArgs const &, std::uint8_t const *, float const *, std::int64_t, std::int64_t),
+    void (*rows2)(AdalnArgs const &, std::uint8_t const *, float const *, std::int64_t, std::int64_t),
+    void (*rows1)(AdalnArgs const &, std::uint8_t const *, float const *, std::int64_t, std::int64_t)>
+void packed_adaln_tiled_range(
+    AdalnArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  const std::int64_t packed_row_bytes = args.padded_in_features / 2;
+  for (std::int64_t out_col = out_start; out_col < out_end; ++out_col) {
+    const auto *packed_row =
+        args.packed_weight + out_col * packed_row_bytes;
+    const auto *scale_row =
+        args.scales + out_col * args.num_groups;
+    std::int64_t row = 0;
+    for (; row + 8 <= args.rows; row += 8) {
+      rows8(args, packed_row, scale_row, out_col, row);
+    }
+    if (row + 4 <= args.rows) {
+      rows4(args, packed_row, scale_row, out_col, row);
+      row += 4;
+    }
+    switch (args.rows - row) {
+      case 3:
+        rows3(args, packed_row, scale_row, out_col, row);
+        break;
+      case 2:
+        rows2(args, packed_row, scale_row, out_col, row);
+        break;
+      case 1:
+        rows1(args, packed_row, scale_row, out_col, row);
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+}  // namespace
+
+void activation_fwht_msvc_avx2(float *values, std::int64_t block_size) {
+  for (std::int64_t half = 1; half < block_size; half *= 2) {
+    for (std::int64_t base = 0; base < block_size; base += 2 * half) {
+      std::int64_t offset = 0;
+      for (; offset + 8 <= half; offset += 8) {
+        const __m256 left = _mm256_loadu_ps(values + base + offset);
+        const __m256 right =
+            _mm256_loadu_ps(values + base + half + offset);
+        _mm256_storeu_ps(values + base + offset, _mm256_add_ps(left, right));
+        _mm256_storeu_ps(
+            values + base + half + offset,
+            _mm256_sub_ps(left, right));
+      }
+      for (; offset < half; ++offset) {
+        const float left = values[base + offset];
+        const float right = values[base + half + offset];
+        values[base + offset] = left + right;
+        values[base + half + offset] = left - right;
+      }
+    }
+  }
+}
+
+float activation_squared_norm_msvc_avx2(
+    void const *data,
+    ScalarKind scalar_kind,
+    std::int64_t offset,
+    std::int64_t dim) {
+  switch (scalar_kind) {
+    case ScalarKind::Float32:
+      return squared_norm_avx2<float>(data, offset, dim);
+    case ScalarKind::Float16:
+      return squared_norm_avx2<c10::Half>(data, offset, dim);
+    case ScalarKind::BFloat16:
+      return squared_norm_avx2<c10::BFloat16>(data, offset, dim);
+  }
+  return 0.0f;
+}
+
+void activation_quantize_lookup_msvc_avx2(
+    ActivationArgs const &args,
+    float const *scratch,
+    std::int64_t output_offset,
+    float norm) {
+  switch (args.scalar_kind) {
+    case ScalarKind::Float32:
+      quantize_lookup_avx2<float>(args, scratch, output_offset, norm);
+      return;
+    case ScalarKind::Float16:
+      quantize_lookup_avx2<c10::Half>(args, scratch, output_offset, norm);
+      return;
+    case ScalarKind::BFloat16:
+      quantize_lookup_avx2<c10::BFloat16>(
+          args, scratch, output_offset, norm);
+      return;
+  }
+}
+
+void packed_adaln_msvc_avx2_range(
+    AdalnArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  if (args.group_size % 8 != 0 || args.padded_in_features % 2 != 0) {
+    packed_adaln_scalar_range(args, out_start, out_end);
+    return;
+  }
+  packed_adaln_tiled_range<
+      packed_adaln_avx2_rows<8>,
+      packed_adaln_avx2_rows<4>,
+      packed_adaln_avx2_rows<3>,
+      packed_adaln_avx2_rows<2>,
+      packed_adaln_avx2_rows<1>>(args, out_start, out_end);
+}
+
+}  // namespace orbitquant::cpu
+#endif

--- a/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/cpu_threads.cpp
+++ b/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/cpu_threads.cpp
@@ -1,0 +1,103 @@
+#include "cpu_threads.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <fstream>
+#include <set>
+#include <string>
+#include <thread>
+#include <utility>
+
+#if defined(__APPLE__)
+#include <sys/sysctl.h>
+#endif
+
+#if defined(__linux__)
+#include <sched.h>
+#endif
+
+namespace orbitquant::cpu {
+namespace {
+
+int environment_thread_count() {
+  char const *value = std::getenv("ORBITQUANT_CPU_THREADS");
+  if (value == nullptr) {
+    value = std::getenv("OMP_NUM_THREADS");
+  }
+  if (value == nullptr) {
+    return 0;
+  }
+  char *end = nullptr;
+  const long parsed = std::strtol(value, &end, 10);
+  if (end == value || parsed <= 0) {
+    return 0;
+  }
+  return static_cast<int>(std::min<long>(parsed, 64));
+}
+
+#if defined(__linux__)
+int affinity_physical_core_count() {
+  cpu_set_t affinity;
+  CPU_ZERO(&affinity);
+  if (sched_getaffinity(0, sizeof(affinity), &affinity) != 0) {
+    return 0;
+  }
+
+  int logical_cpus = 0;
+  std::set<std::pair<int, int>> physical_cores;
+  for (int cpu = 0; cpu < CPU_SETSIZE; ++cpu) {
+    if (!CPU_ISSET(cpu, &affinity)) {
+      continue;
+    }
+    ++logical_cpus;
+    int package = -1;
+    int core = -1;
+    std::ifstream package_file(
+        "/sys/devices/system/cpu/cpu" + std::to_string(cpu) +
+        "/topology/physical_package_id");
+    std::ifstream core_file(
+        "/sys/devices/system/cpu/cpu" + std::to_string(cpu) +
+        "/topology/core_id");
+    if (package_file >> package && core_file >> core) {
+      physical_cores.emplace(package, core);
+    }
+  }
+  return physical_cores.empty()
+      ? logical_cpus
+      : static_cast<int>(physical_cores.size());
+}
+#endif
+
+int default_thread_count() {
+#if defined(__APPLE__)
+  int performance_cores = 0;
+  std::size_t size = sizeof(performance_cores);
+  if (sysctlbyname(
+          "hw.perflevel0.physicalcpu",
+          &performance_cores,
+          &size,
+          nullptr,
+          0) == 0 &&
+      performance_cores > 0) {
+    return std::min(performance_cores, 64);
+  }
+#endif
+#if defined(__linux__)
+  const int affinity_cores = affinity_physical_core_count();
+  if (affinity_cores > 0) {
+    return std::min(affinity_cores, 64);
+  }
+#endif
+  const unsigned hardware = std::thread::hardware_concurrency();
+  return static_cast<int>(hardware == 0 ? 1 : std::min<unsigned>(hardware, 64));
+}
+
+}  // namespace
+
+int requested_threads() {
+  const int environment = environment_thread_count();
+  static const int default_threads = default_thread_count();
+  return environment > 0 ? environment : default_threads;
+}
+
+}  // namespace orbitquant::cpu

--- a/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/cpu_threads.h
+++ b/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/cpu_threads.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace orbitquant::cpu {
+
+int requested_threads();
+
+}  // namespace orbitquant::cpu

--- a/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_adaln_cpu.cpp
+++ b/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_adaln_cpu.cpp
@@ -1,0 +1,877 @@
+#include "cpu_threads.h"
+#include "cpu_kernel_args.h"
+#include "packed_matmul_cpu.h"
+#include "../torch-ext/torch_binding.h"
+
+#include <torch/headeronly/core/DeviceType.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/macros/Macros.h>
+#include <torch/headeronly/util/BFloat16.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstdint>
+#include <cstring>
+#include <thread>
+#include <vector>
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+#include <arm_neon.h>
+#endif
+
+#if (defined(__x86_64__) || defined(_M_X64)) && !defined(_MSC_VER)
+#include <immintrin.h>
+#define ORBITQUANT_TARGET_AVX2 __attribute__((target("avx2,fma,f16c")))
+#define ORBITQUANT_TARGET_AVX512 \
+  __attribute__((target("avx512f,avx512dq,avx512bw,avx512vl,fma,f16c")))
+#define ORBITQUANT_TARGET_AVX512_BF16 \
+  __attribute__((target( \
+      "avx512f,avx512dq,avx512bw,avx512vl,avx512bf16,fma,f16c")))
+#define ORBITQUANT_HAS_AVX512_BF16_INTRINSICS 1
+#define ORBITQUANT_NOINLINE __attribute__((noinline))
+#endif
+
+namespace {
+
+using orbitquant::cpu::AdalnArgs;
+using orbitquant::cpu::AdalnRangeFn;
+
+inline float load_bfloat(
+    void const *data,
+    std::int64_t offset) {
+  return static_cast<float>(
+      static_cast<c10::BFloat16 const *>(data)[offset]);
+}
+
+inline void store_bfloat(
+    void *data,
+    std::int64_t offset,
+    float value) {
+  static_cast<c10::BFloat16 *>(data)[offset] = c10::BFloat16(value);
+}
+
+inline std::uint8_t unpack_adaln_index(
+    std::uint8_t const *packed,
+    std::int64_t flat_index) {
+  const std::uint8_t byte = packed[flat_index / 2];
+  return (flat_index & 1) == 0 ? byte & 15u : (byte >> 4) & 15u;
+}
+
+inline float dequantized_adaln_value(
+    std::uint8_t index,
+    float scale) {
+  return static_cast<float>(
+      c10::BFloat16((static_cast<int>(index) - 8) * scale));
+}
+
+inline void fill_group_lut(float *lut, float scale) {
+  for (int index = 0; index < 16; ++index) {
+    lut[index] = dequantized_adaln_value(
+        static_cast<std::uint8_t>(index),
+        scale);
+  }
+}
+
+void packed_adaln_scalar_range(
+    AdalnArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  for (std::int64_t out_col = out_start; out_col < out_end; ++out_col) {
+    for (std::int64_t row = 0; row < args.rows; ++row) {
+      float accumulator = 0.0f;
+      const std::int64_t input_offset = row * args.in_features;
+      for (std::int64_t k = 0; k < args.in_features; ++k) {
+        const std::int64_t weight_offset =
+            out_col * args.padded_in_features + k;
+        const std::uint8_t index =
+            unpack_adaln_index(args.packed_weight, weight_offset);
+        const float scale =
+            args.scales[out_col * args.num_groups + k / args.group_size];
+        accumulator += load_bfloat(args.x, input_offset + k) *
+            dequantized_adaln_value(index, scale);
+      }
+      if (args.has_bias) {
+        accumulator += args.bias[out_col];
+      }
+      store_bfloat(
+          args.out,
+          row * args.out_features + out_col,
+          accumulator);
+    }
+  }
+}
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+inline float32x4_t load_bfloat4(
+    void const *data,
+    std::int64_t offset) {
+  const uint16x4_t raw = vld1_u16(
+      static_cast<std::uint16_t const *>(data) + offset);
+  return vreinterpretq_f32_u32(vshlq_n_u32(vmovl_u16(raw), 16));
+}
+
+template <int row_tile>
+inline void packed_adaln_neon_rows(
+    AdalnArgs const &args,
+    std::uint8_t const *packed_row,
+    float const *scale_row,
+    std::int64_t out_col,
+    std::int64_t row_start) {
+  float32x4_t accumulators[row_tile];
+  float tails[row_tile]{};
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    accumulators[row] = vdupq_n_f32(0.0f);
+  }
+
+  for (std::int64_t group = 0; group < args.num_groups; ++group) {
+    float lut[16];
+    fill_group_lut(lut, scale_row[group]);
+    const std::int64_t group_start = group * args.group_size;
+    const std::int64_t group_end = std::min(
+        args.in_features,
+        group_start + args.group_size);
+    std::int64_t k = group_start;
+    for (; k + 4 <= group_end; k += 4) {
+      float weights[4];
+#pragma clang loop unroll(full)
+      for (int lane = 0; lane < 4; ++lane) {
+        weights[lane] = lut[unpack_adaln_index(packed_row, k + lane)];
+      }
+      const float32x4_t weight = vld1q_f32(weights);
+#pragma clang loop unroll(full)
+      for (int row = 0; row < row_tile; ++row) {
+        const std::int64_t input_offset =
+            (row_start + row) * args.in_features + k;
+        accumulators[row] = vfmaq_f32(
+            accumulators[row],
+            load_bfloat4(args.x, input_offset),
+            weight);
+      }
+    }
+    for (; k < group_end; ++k) {
+      const float weight = lut[unpack_adaln_index(packed_row, k)];
+#pragma clang loop unroll(full)
+      for (int row = 0; row < row_tile; ++row) {
+        tails[row] += load_bfloat(
+            args.x,
+            (row_start + row) * args.in_features + k) * weight;
+      }
+    }
+  }
+
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    float accumulator = vaddvq_f32(accumulators[row]) + tails[row];
+    if (args.has_bias) {
+      accumulator += args.bias[out_col];
+    }
+    store_bfloat(
+        args.out,
+        (row_start + row) * args.out_features + out_col,
+        accumulator);
+  }
+}
+
+void packed_adaln_neon_range(
+    AdalnArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  if (args.group_size % 4 != 0 || args.padded_in_features % 2 != 0) {
+    packed_adaln_scalar_range(args, out_start, out_end);
+    return;
+  }
+  constexpr int kPrimaryRowTile = 8;
+  const std::int64_t packed_row_bytes = args.padded_in_features / 2;
+  for (std::int64_t out_col = out_start; out_col < out_end; ++out_col) {
+    const auto *packed_row =
+        args.packed_weight + out_col * packed_row_bytes;
+    const auto *scale_row =
+        args.scales + out_col * args.num_groups;
+    std::int64_t row = 0;
+    for (; row + kPrimaryRowTile <= args.rows; row += kPrimaryRowTile) {
+      packed_adaln_neon_rows<kPrimaryRowTile>(
+          args, packed_row, scale_row, out_col, row);
+    }
+    if (row + 4 <= args.rows) {
+      packed_adaln_neon_rows<4>(
+          args, packed_row, scale_row, out_col, row);
+      row += 4;
+    }
+    switch (args.rows - row) {
+      case 3:
+        packed_adaln_neon_rows<3>(
+            args, packed_row, scale_row, out_col, row);
+        break;
+      case 2:
+        packed_adaln_neon_rows<2>(
+            args, packed_row, scale_row, out_col, row);
+        break;
+      case 1:
+        packed_adaln_neon_rows<1>(
+            args, packed_row, scale_row, out_col, row);
+        break;
+      default:
+        break;
+    }
+  }
+}
+#else
+void packed_adaln_neon_range(
+    AdalnArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  packed_adaln_scalar_range(args, out_start, out_end);
+}
+#endif
+
+#if (defined(__x86_64__) || defined(_M_X64)) && !defined(_MSC_VER)
+ORBITQUANT_TARGET_AVX2 inline __m256 load_bfloat8(
+    void const *data,
+    std::int64_t offset) {
+  const auto *source =
+      static_cast<std::uint16_t const *>(data) + offset;
+  const __m128i packed =
+      _mm_loadu_si128(reinterpret_cast<__m128i const *>(source));
+  return _mm256_castsi256_ps(
+      _mm256_slli_epi32(_mm256_cvtepu16_epi32(packed), 16));
+}
+
+ORBITQUANT_TARGET_AVX512 inline __m512 load_bfloat16(
+    void const *data,
+    std::int64_t offset) {
+  const auto *source =
+      static_cast<std::uint16_t const *>(data) + offset;
+  const __m256i packed =
+      _mm256_loadu_si256(reinterpret_cast<__m256i const *>(source));
+  return _mm512_castsi512_ps(
+      _mm512_slli_epi32(_mm512_cvtepu16_epi32(packed), 16));
+}
+
+ORBITQUANT_TARGET_AVX2 inline float horizontal_sum(__m256 value) {
+  const __m128 halves = _mm_add_ps(
+      _mm256_castps256_ps128(value),
+      _mm256_extractf128_ps(value, 1));
+  const __m128 pairs = _mm_hadd_ps(halves, halves);
+  return _mm_cvtss_f32(_mm_hadd_ps(pairs, pairs));
+}
+
+ORBITQUANT_TARGET_AVX512 inline float horizontal_sum(__m512 value) {
+  return _mm512_reduce_add_ps(value);
+}
+
+template <int row_tile>
+ORBITQUANT_TARGET_AVX2 inline void packed_adaln_avx2_rows(
+    AdalnArgs const &args,
+    std::uint8_t const *packed_row,
+    float const *scale_row,
+    std::int64_t out_col,
+    std::int64_t row_start) {
+  __m256 accumulators[row_tile];
+  float tails[row_tile]{};
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    accumulators[row] = _mm256_setzero_ps();
+  }
+  const __m128i nibble_mask = _mm_set1_epi8(15);
+  const __m256i low_table_limit = _mm256_set1_epi32(7);
+
+  for (std::int64_t group = 0; group < args.num_groups; ++group) {
+    float lut[16];
+    fill_group_lut(lut, scale_row[group]);
+    const __m256 lut_low = _mm256_loadu_ps(lut);
+    const __m256 lut_high = _mm256_loadu_ps(lut + 8);
+    const std::int64_t group_start = group * args.group_size;
+    const std::int64_t group_end = std::min(
+        args.in_features,
+        group_start + args.group_size);
+    std::int64_t k = group_start;
+    for (; k + 8 <= group_end; k += 8) {
+      std::int32_t packed;
+      std::memcpy(&packed, packed_row + k / 2, sizeof(packed));
+      const __m128i bytes = _mm_cvtsi32_si128(packed);
+      const __m128i low = _mm_and_si128(bytes, nibble_mask);
+      const __m128i high = _mm_and_si128(
+          _mm_srli_epi16(bytes, 4),
+          nibble_mask);
+      const __m256i indices =
+          _mm256_cvtepu8_epi32(_mm_unpacklo_epi8(low, high));
+      const __m256 weight = _mm256_blendv_ps(
+          _mm256_permutevar8x32_ps(lut_low, indices),
+          _mm256_permutevar8x32_ps(lut_high, indices),
+          _mm256_castsi256_ps(
+              _mm256_cmpgt_epi32(indices, low_table_limit)));
+#pragma clang loop unroll(full)
+      for (int row = 0; row < row_tile; ++row) {
+        const std::int64_t input_offset =
+            (row_start + row) * args.in_features + k;
+        accumulators[row] = _mm256_fmadd_ps(
+            load_bfloat8(args.x, input_offset),
+            weight,
+            accumulators[row]);
+      }
+    }
+    for (; k < group_end; ++k) {
+      const float weight = lut[unpack_adaln_index(packed_row, k)];
+#pragma clang loop unroll(full)
+      for (int row = 0; row < row_tile; ++row) {
+        tails[row] += load_bfloat(
+            args.x,
+            (row_start + row) * args.in_features + k) * weight;
+      }
+    }
+  }
+
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    float accumulator = horizontal_sum(accumulators[row]) + tails[row];
+    if (args.has_bias) {
+      accumulator += args.bias[out_col];
+    }
+    store_bfloat(
+        args.out,
+        (row_start + row) * args.out_features + out_col,
+        accumulator);
+  }
+}
+
+template <int row_tile>
+ORBITQUANT_TARGET_AVX512 inline void packed_adaln_avx512_rows(
+    AdalnArgs const &args,
+    std::uint8_t const *packed_row,
+    float const *scale_row,
+    std::int64_t out_col,
+    std::int64_t row_start) {
+  __m512 accumulators[row_tile];
+  float tails[row_tile]{};
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    accumulators[row] = _mm512_setzero_ps();
+  }
+  const __m128i nibble_mask = _mm_set1_epi8(15);
+
+  for (std::int64_t group = 0; group < args.num_groups; ++group) {
+    float lut[16];
+    fill_group_lut(lut, scale_row[group]);
+    const __m512 centroid_lut = _mm512_loadu_ps(lut);
+    const std::int64_t group_start = group * args.group_size;
+    const std::int64_t group_end = std::min(
+        args.in_features,
+        group_start + args.group_size);
+    std::int64_t k = group_start;
+    for (; k + 16 <= group_end; k += 16) {
+      std::int64_t packed;
+      std::memcpy(&packed, packed_row + k / 2, sizeof(packed));
+      const __m128i bytes = _mm_cvtsi64_si128(packed);
+      const __m128i low = _mm_and_si128(bytes, nibble_mask);
+      const __m128i high = _mm_and_si128(
+          _mm_srli_epi16(bytes, 4),
+          nibble_mask);
+      const __m512i indices =
+          _mm512_cvtepu8_epi32(_mm_unpacklo_epi8(low, high));
+      const __m512 weight =
+          _mm512_permutexvar_ps(indices, centroid_lut);
+#pragma clang loop unroll(full)
+      for (int row = 0; row < row_tile; ++row) {
+        const std::int64_t input_offset =
+            (row_start + row) * args.in_features + k;
+        accumulators[row] = _mm512_fmadd_ps(
+            load_bfloat16(args.x, input_offset),
+            weight,
+            accumulators[row]);
+      }
+    }
+    for (; k < group_end; ++k) {
+      const float weight = lut[unpack_adaln_index(packed_row, k)];
+#pragma clang loop unroll(full)
+      for (int row = 0; row < row_tile; ++row) {
+        tails[row] += load_bfloat(
+            args.x,
+            (row_start + row) * args.in_features + k) * weight;
+      }
+    }
+  }
+
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    float accumulator = horizontal_sum(accumulators[row]) + tails[row];
+    if (args.has_bias) {
+      accumulator += args.bias[out_col];
+    }
+    store_bfloat(
+        args.out,
+        (row_start + row) * args.out_features + out_col,
+        accumulator);
+  }
+}
+
+#if defined(ORBITQUANT_HAS_AVX512_BF16_INTRINSICS)
+template <bool aligned_k>
+ORBITQUANT_TARGET_AVX512_BF16 inline __m512bh load_bfloat32(
+    std::uint16_t const *data,
+    __mmask32 valid_mask) {
+  if constexpr (aligned_k) {
+    return (__m512bh)_mm512_loadu_si512(data);
+  }
+  return (__m512bh)_mm512_maskz_loadu_epi16(valid_mask, data);
+}
+
+template <int row_tile, bool aligned_k>
+ORBITQUANT_TARGET_AVX512_BF16 inline void packed_adaln_avx512_bf16_rows(
+    AdalnArgs const &args,
+    std::uint8_t const *packed_row,
+    float const *scale_row,
+    std::int64_t out_col,
+    std::int64_t row_start) {
+  static_assert(row_tile >= 1 && row_tile <= 8);
+  __m512 accumulator0 = _mm512_setzero_ps();
+  __m512 accumulator1 = _mm512_setzero_ps();
+  __m512 accumulator2 = _mm512_setzero_ps();
+  __m512 accumulator3 = _mm512_setzero_ps();
+  __m512 accumulator4 = _mm512_setzero_ps();
+  __m512 accumulator5 = _mm512_setzero_ps();
+  __m512 accumulator6 = _mm512_setzero_ps();
+  __m512 accumulator7 = _mm512_setzero_ps();
+  const __m128i nibble_mask = _mm_set1_epi8(15);
+  const __m512 signed_codes = _mm512_setr_ps(
+      -8.0f, -7.0f, -6.0f, -5.0f,
+      -4.0f, -3.0f, -2.0f, -1.0f,
+      0.0f, 1.0f, 2.0f, 3.0f,
+      4.0f, 5.0f, 6.0f, 7.0f);
+  const auto *input_base =
+      static_cast<std::uint16_t const *>(args.x) +
+      row_start * args.in_features;
+  const std::int64_t input_stride = args.in_features;
+
+  for (std::int64_t group = 0; group < args.num_groups; ++group) {
+    const __m512 scaled_codes = _mm512_mul_ps(
+        signed_codes,
+        _mm512_set1_ps(scale_row[group]));
+    const __m512i lut_words = (__m512i)_mm512_cvtne2ps_pbh(
+        scaled_codes,
+        scaled_codes);
+    const std::int64_t group_start = group * args.group_size;
+    for (std::int64_t offset = 0; offset < args.group_size; offset += 32) {
+      const std::int64_t k = group_start + offset;
+      __mmask32 valid_mask = static_cast<__mmask32>(0xffffffffu);
+      if constexpr (!aligned_k) {
+        const std::int64_t valid = std::max<std::int64_t>(
+            0,
+            std::min<std::int64_t>(32, args.in_features - k));
+        if (valid == 0) {
+          continue;
+        }
+        valid_mask = valid == 32
+            ? static_cast<__mmask32>(0xffffffffu)
+            : static_cast<__mmask32>((1u << valid) - 1u);
+      }
+      const __m128i bytes = _mm_loadu_si128(
+          reinterpret_cast<__m128i const *>(packed_row + k / 2));
+      const __m128i low = _mm_and_si128(bytes, nibble_mask);
+      const __m128i high = _mm_and_si128(
+          _mm_srli_epi16(bytes, 4),
+          nibble_mask);
+      const __m256i packed_indices = _mm256_set_m128i(
+          _mm_unpackhi_epi8(low, high),
+          _mm_unpacklo_epi8(low, high));
+      const __m512i indices =
+          _mm512_cvtepu8_epi16(packed_indices);
+      const __m512bh weights = (__m512bh)_mm512_permutexvar_epi16(
+          indices,
+          lut_words);
+      accumulator0 = _mm512_dpbf16_ps(
+          accumulator0,
+          load_bfloat32<aligned_k>(input_base + k, valid_mask),
+          weights);
+      if constexpr (row_tile > 1) {
+        accumulator1 = _mm512_dpbf16_ps(
+            accumulator1,
+            load_bfloat32<aligned_k>(
+                input_base + input_stride + k,
+                valid_mask),
+            weights);
+      }
+      if constexpr (row_tile > 2) {
+        accumulator2 = _mm512_dpbf16_ps(
+            accumulator2,
+            load_bfloat32<aligned_k>(
+                input_base + 2 * input_stride + k,
+                valid_mask),
+            weights);
+      }
+      if constexpr (row_tile > 3) {
+        accumulator3 = _mm512_dpbf16_ps(
+            accumulator3,
+            load_bfloat32<aligned_k>(
+                input_base + 3 * input_stride + k,
+                valid_mask),
+            weights);
+      }
+      if constexpr (row_tile > 4) {
+        accumulator4 = _mm512_dpbf16_ps(
+            accumulator4,
+            load_bfloat32<aligned_k>(
+                input_base + 4 * input_stride + k,
+                valid_mask),
+            weights);
+      }
+      if constexpr (row_tile > 5) {
+        accumulator5 = _mm512_dpbf16_ps(
+            accumulator5,
+            load_bfloat32<aligned_k>(
+                input_base + 5 * input_stride + k,
+                valid_mask),
+            weights);
+      }
+      if constexpr (row_tile > 6) {
+        accumulator6 = _mm512_dpbf16_ps(
+            accumulator6,
+            load_bfloat32<aligned_k>(
+                input_base + 6 * input_stride + k,
+                valid_mask),
+            weights);
+      }
+      if constexpr (row_tile > 7) {
+        accumulator7 = _mm512_dpbf16_ps(
+            accumulator7,
+            load_bfloat32<aligned_k>(
+                input_base + 7 * input_stride + k,
+                valid_mask),
+            weights);
+      }
+    }
+  }
+
+  const float bias = args.has_bias ? args.bias[out_col] : 0.0f;
+  const std::int64_t output_offset =
+      row_start * args.out_features + out_col;
+  store_bfloat(
+      args.out,
+      output_offset,
+      horizontal_sum(accumulator0) + bias);
+  if constexpr (row_tile > 1) {
+    store_bfloat(
+        args.out,
+        output_offset + args.out_features,
+        horizontal_sum(accumulator1) + bias);
+  }
+  if constexpr (row_tile > 2) {
+    store_bfloat(
+        args.out,
+        output_offset + 2 * args.out_features,
+        horizontal_sum(accumulator2) + bias);
+  }
+  if constexpr (row_tile > 3) {
+    store_bfloat(
+        args.out,
+        output_offset + 3 * args.out_features,
+        horizontal_sum(accumulator3) + bias);
+  }
+  if constexpr (row_tile > 4) {
+    store_bfloat(
+        args.out,
+        output_offset + 4 * args.out_features,
+        horizontal_sum(accumulator4) + bias);
+  }
+  if constexpr (row_tile > 5) {
+    store_bfloat(
+        args.out,
+        output_offset + 5 * args.out_features,
+        horizontal_sum(accumulator5) + bias);
+  }
+  if constexpr (row_tile > 6) {
+    store_bfloat(
+        args.out,
+        output_offset + 6 * args.out_features,
+        horizontal_sum(accumulator6) + bias);
+  }
+  if constexpr (row_tile > 7) {
+    store_bfloat(
+        args.out,
+        output_offset + 7 * args.out_features,
+        horizontal_sum(accumulator7) + bias);
+  }
+}
+
+bool adaln_avx512_bf16_available() {
+  __builtin_cpu_init();
+  return orbitquant::cpu::packed_matmul_x86_avx512_available() &&
+      __builtin_cpu_supports("avx512bf16");
+}
+#else
+bool adaln_avx512_bf16_available() {
+  return false;
+}
+#endif
+
+template <
+    void (*rows8)(AdalnArgs const &, std::uint8_t const *, float const *, std::int64_t, std::int64_t),
+    void (*rows4)(AdalnArgs const &, std::uint8_t const *, float const *, std::int64_t, std::int64_t),
+    void (*rows3)(AdalnArgs const &, std::uint8_t const *, float const *, std::int64_t, std::int64_t),
+    void (*rows2)(AdalnArgs const &, std::uint8_t const *, float const *, std::int64_t, std::int64_t),
+    void (*rows1)(AdalnArgs const &, std::uint8_t const *, float const *, std::int64_t, std::int64_t)>
+void packed_adaln_x86_tiled_range(
+    AdalnArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  const std::int64_t packed_row_bytes = args.padded_in_features / 2;
+  for (std::int64_t out_col = out_start; out_col < out_end; ++out_col) {
+    const auto *packed_row =
+        args.packed_weight + out_col * packed_row_bytes;
+    const auto *scale_row =
+        args.scales + out_col * args.num_groups;
+    std::int64_t row = 0;
+    for (; row + 8 <= args.rows; row += 8) {
+      rows8(args, packed_row, scale_row, out_col, row);
+    }
+    if (row + 4 <= args.rows) {
+      rows4(args, packed_row, scale_row, out_col, row);
+      row += 4;
+    }
+    switch (args.rows - row) {
+      case 3:
+        rows3(args, packed_row, scale_row, out_col, row);
+        break;
+      case 2:
+        rows2(args, packed_row, scale_row, out_col, row);
+        break;
+      case 1:
+        rows1(args, packed_row, scale_row, out_col, row);
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+void packed_adaln_avx2_range(
+    AdalnArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  if (args.group_size % 8 != 0 || args.padded_in_features % 2 != 0) {
+    packed_adaln_scalar_range(args, out_start, out_end);
+    return;
+  }
+  packed_adaln_x86_tiled_range<
+      packed_adaln_avx2_rows<8>,
+      packed_adaln_avx2_rows<4>,
+      packed_adaln_avx2_rows<3>,
+      packed_adaln_avx2_rows<2>,
+      packed_adaln_avx2_rows<1>>(args, out_start, out_end);
+}
+
+void packed_adaln_avx512_range(
+    AdalnArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+#if defined(ORBITQUANT_HAS_AVX512_BF16_INTRINSICS)
+  if (args.group_size % 32 == 0 &&
+      args.padded_in_features % 2 == 0 &&
+      adaln_avx512_bf16_available()) {
+    if (args.in_features % args.group_size == 0) {
+      packed_adaln_x86_tiled_range<
+          packed_adaln_avx512_bf16_rows<8, true>,
+          packed_adaln_avx512_bf16_rows<4, true>,
+          packed_adaln_avx512_bf16_rows<3, true>,
+          packed_adaln_avx512_bf16_rows<2, true>,
+          packed_adaln_avx512_bf16_rows<1, true>>(args, out_start, out_end);
+      return;
+    }
+    packed_adaln_x86_tiled_range<
+        packed_adaln_avx512_bf16_rows<8, false>,
+        packed_adaln_avx512_bf16_rows<4, false>,
+        packed_adaln_avx512_bf16_rows<3, false>,
+        packed_adaln_avx512_bf16_rows<2, false>,
+        packed_adaln_avx512_bf16_rows<1, false>>(args, out_start, out_end);
+    return;
+  }
+#endif
+  if (args.group_size % 16 != 0 || args.padded_in_features % 2 != 0) {
+    packed_adaln_scalar_range(args, out_start, out_end);
+    return;
+  }
+  packed_adaln_x86_tiled_range<
+      packed_adaln_avx512_rows<8>,
+      packed_adaln_avx512_rows<4>,
+      packed_adaln_avx512_rows<3>,
+      packed_adaln_avx512_rows<2>,
+      packed_adaln_avx512_rows<1>>(args, out_start, out_end);
+}
+#else
+void packed_adaln_avx2_range(
+    AdalnArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  packed_adaln_scalar_range(args, out_start, out_end);
+}
+
+void packed_adaln_avx512_range(
+    AdalnArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  packed_adaln_scalar_range(args, out_start, out_end);
+}
+#endif
+
+AdalnRangeFn select_adaln_kernel() {
+  const char *requested = std::getenv("ORBITQUANT_CPU_ISA");
+  if (requested == nullptr || std::strcmp(requested, "auto") == 0) {
+    if (orbitquant::cpu::packed_matmul_x86_avx512_available()) {
+      return packed_adaln_avx512_range;
+    }
+    if (orbitquant::cpu::packed_matmul_x86_avx2_available()) {
+#if defined(_MSC_VER) && defined(_M_X64)
+      return orbitquant::cpu::packed_adaln_msvc_avx2_range;
+#else
+      return packed_adaln_avx2_range;
+#endif
+    }
+    if (orbitquant::cpu::packed_matmul_neon_available()) {
+      return packed_adaln_neon_range;
+    }
+    return packed_adaln_scalar_range;
+  }
+  if (std::strcmp(requested, "scalar") == 0) {
+    return packed_adaln_scalar_range;
+  }
+  if (std::strcmp(requested, "avx2") == 0) {
+    STD_TORCH_CHECK(
+        orbitquant::cpu::packed_matmul_x86_avx2_available(),
+        "ORBITQUANT_CPU_ISA=avx2 requested AVX2/FMA/F16C on an unsupported CPU");
+#if defined(_MSC_VER) && defined(_M_X64)
+    return orbitquant::cpu::packed_adaln_msvc_avx2_range;
+#else
+    return packed_adaln_avx2_range;
+#endif
+  }
+  if (std::strcmp(requested, "avx512") == 0) {
+    STD_TORCH_CHECK(
+        orbitquant::cpu::packed_matmul_x86_avx512_available(),
+        "ORBITQUANT_CPU_ISA=avx512 requested AVX-512F/DQ/BW/VL on an unsupported CPU");
+    return packed_adaln_avx512_range;
+  }
+  if (std::strcmp(requested, "neon") == 0) {
+    STD_TORCH_CHECK(
+        orbitquant::cpu::packed_matmul_neon_available(),
+        "ORBITQUANT_CPU_ISA=neon requested NEON on an unsupported CPU");
+    return packed_adaln_neon_range;
+  }
+  STD_TORCH_CHECK(
+      false,
+      "ORBITQUANT_CPU_ISA must be auto, scalar, avx2, avx512, or neon");
+  return packed_adaln_scalar_range;
+}
+
+void parallel_packed_adaln(
+    AdalnArgs const &args,
+    AdalnRangeFn function) {
+  const std::int64_t arithmetic =
+      args.rows * args.out_features * args.in_features;
+  const int max_threads = orbitquant::cpu::requested_threads();
+  const int threads = arithmetic < 1'000'000
+      ? 1
+      : std::max<int>(
+            1,
+            std::min<std::int64_t>(
+                max_threads,
+                args.out_features / 16));
+  if (threads == 1) {
+    function(args, 0, args.out_features);
+    return;
+  }
+
+  std::vector<std::thread> workers;
+  workers.reserve(threads);
+  const std::int64_t columns_per_thread =
+      (args.out_features + threads - 1) / threads;
+  for (int thread = 0; thread < threads; ++thread) {
+    const std::int64_t start = thread * columns_per_thread;
+    const std::int64_t end = std::min(
+        args.out_features,
+        start + columns_per_thread);
+    if (start >= end) {
+      break;
+    }
+    workers.emplace_back([&args, function, start, end] {
+      function(args, start, end);
+    });
+  }
+  for (auto &worker : workers) {
+    worker.join();
+  }
+}
+
+}  // namespace
+
+void matmul_packed_adaln_int4_cpu(
+    OrbitQuantTensor &out,
+    OrbitQuantTensor const &x,
+    OrbitQuantTensor const &packed_weight,
+    OrbitQuantTensor const &scales,
+    OrbitQuantTensor const &bias,
+    bool has_bias,
+    int64_t out_features,
+    int64_t in_features,
+    int64_t group_size) {
+  using torch::headeronly::DeviceType;
+  using torch::headeronly::ScalarType;
+
+  STD_TORCH_CHECK(x.device().type() == DeviceType::CPU, "x must be a CPU tensor");
+  STD_TORCH_CHECK(out.device().type() == DeviceType::CPU, "out must be a CPU tensor");
+  STD_TORCH_CHECK(
+      packed_weight.device().type() == DeviceType::CPU,
+      "packed_weight must be a CPU tensor");
+  STD_TORCH_CHECK(
+      scales.device().type() == DeviceType::CPU,
+      "scales must be a CPU tensor");
+  STD_TORCH_CHECK(x.is_contiguous(), "x must be contiguous");
+  STD_TORCH_CHECK(out.is_contiguous(), "out must be contiguous");
+  STD_TORCH_CHECK(packed_weight.is_contiguous(), "packed_weight must be contiguous");
+  STD_TORCH_CHECK(scales.is_contiguous(), "scales must be contiguous");
+  STD_TORCH_CHECK(x.scalar_type() == ScalarType::BFloat16, "x must be bfloat16");
+  STD_TORCH_CHECK(out.scalar_type() == ScalarType::BFloat16, "out must be bfloat16");
+  STD_TORCH_CHECK(
+      packed_weight.scalar_type() == ScalarType::Byte,
+      "packed_weight must be uint8");
+  STD_TORCH_CHECK(scales.scalar_type() == ScalarType::Float, "scales must be float32");
+  STD_TORCH_CHECK(x.dim() == 2, "x must be rank 2");
+  STD_TORCH_CHECK(out.dim() == 2, "out must be rank 2");
+  STD_TORCH_CHECK(group_size > 0, "group_size must be positive");
+  STD_TORCH_CHECK(x.size(1) == in_features, "x has an unexpected input dimension");
+  STD_TORCH_CHECK(out.size(0) == x.size(0), "out has an unexpected row count");
+  STD_TORCH_CHECK(out.size(1) == out_features, "out has an unexpected output dimension");
+  const int64_t num_groups = (in_features + group_size - 1) / group_size;
+  const int64_t padded_in_features = num_groups * group_size;
+  const int64_t packed_values = out_features * padded_in_features;
+  STD_TORCH_CHECK(
+      packed_weight.numel() >= (packed_values + 1) / 2,
+      "packed_weight is too short");
+  STD_TORCH_CHECK(
+      scales.numel() == out_features * num_groups,
+      "scales must match out_features and num_groups");
+  if (has_bias) {
+    STD_TORCH_CHECK(bias.device().type() == DeviceType::CPU, "bias must be a CPU tensor");
+    STD_TORCH_CHECK(bias.is_contiguous(), "bias must be contiguous");
+    STD_TORCH_CHECK(bias.scalar_type() == ScalarType::Float, "bias must be float32");
+    STD_TORCH_CHECK(bias.numel() == out_features, "bias must match out_features");
+  }
+  if (x.numel() == 0 || out_features == 0) {
+    return;
+  }
+
+  const AdalnArgs args{
+      out.mutable_data_ptr(),
+      x.const_data_ptr(),
+      packed_weight.const_data_ptr<std::uint8_t>(),
+      scales.const_data_ptr<float>(),
+      has_bias ? bias.const_data_ptr<float>() : nullptr,
+      has_bias,
+      x.size(0),
+      out_features,
+      in_features,
+      group_size,
+      num_groups,
+      padded_in_features,
+  };
+  parallel_packed_adaln(args, select_adaln_kernel());
+}

--- a/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_matmul_cpu.cpp
+++ b/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_matmul_cpu.cpp
@@ -1,0 +1,200 @@
+#include "cpu_threads.h"
+#include "packed_matmul_cpu.h"
+#include "../torch-ext/torch_binding.h"
+
+#include <torch/headeronly/core/DeviceType.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/macros/Macros.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <thread>
+#include <vector>
+
+namespace {
+
+orbitquant::cpu::ScalarKind scalar_kind(OrbitQuantTensor const &tensor) {
+  using torch::headeronly::ScalarType;
+  switch (tensor.scalar_type()) {
+    case ScalarType::Float:
+      return orbitquant::cpu::ScalarKind::Float32;
+    case ScalarType::Half:
+      return orbitquant::cpu::ScalarKind::Float16;
+    case ScalarType::BFloat16:
+      return orbitquant::cpu::ScalarKind::BFloat16;
+    default:
+      STD_TORCH_CHECK(
+          false,
+          "CPU packed matmul supports float32, float16, and bfloat16 inputs");
+  }
+  return orbitquant::cpu::ScalarKind::Float32;
+}
+
+void parallel_packed_matmul(
+    orbitquant::cpu::PackedMatmulArgs const &args,
+    orbitquant::cpu::PackedMatmulRangeFn function) {
+  const std::int64_t arithmetic =
+      args.rows * args.out_features * args.in_features;
+  const int max_threads = orbitquant::cpu::requested_threads();
+  const int threads = arithmetic < 1'000'000
+      ? 1
+      : std::max<int>(
+            1,
+            std::min<std::int64_t>(max_threads, args.out_features / 16));
+  if (threads == 1) {
+    function(args, 0, args.out_features);
+    return;
+  }
+
+  std::vector<std::thread> workers;
+  workers.reserve(threads);
+  const std::int64_t columns_per_thread =
+      (args.out_features + threads - 1) / threads;
+  for (int thread = 0; thread < threads; ++thread) {
+    const std::int64_t start = thread * columns_per_thread;
+    const std::int64_t end = std::min(
+        args.out_features,
+        start + columns_per_thread);
+    if (start >= end) {
+      break;
+    }
+    workers.emplace_back([&args, function, start, end] {
+      function(args, start, end);
+    });
+  }
+  for (auto &worker : workers) {
+    worker.join();
+  }
+}
+
+orbitquant::cpu::PackedMatmulRangeFn select_packed_matmul() {
+  const char *requested = std::getenv("ORBITQUANT_CPU_ISA");
+  if (requested == nullptr || std::strcmp(requested, "auto") == 0) {
+    if (orbitquant::cpu::packed_matmul_x86_avx512_available()) {
+      return orbitquant::cpu::packed_matmul_x86_avx512_range;
+    }
+    if (orbitquant::cpu::packed_matmul_x86_avx2_available()) {
+      return orbitquant::cpu::packed_matmul_x86_avx2_range;
+    }
+    if (orbitquant::cpu::packed_matmul_neon_available()) {
+      return orbitquant::cpu::packed_matmul_neon_range;
+    }
+    return orbitquant::cpu::packed_matmul_scalar_range;
+  }
+  if (std::strcmp(requested, "scalar") == 0) {
+    return orbitquant::cpu::packed_matmul_scalar_range;
+  }
+  if (std::strcmp(requested, "avx2") == 0) {
+    STD_TORCH_CHECK(
+        orbitquant::cpu::packed_matmul_x86_avx2_available(),
+        "ORBITQUANT_CPU_ISA=avx2 requested AVX2/FMA/F16C on an unsupported CPU");
+    return orbitquant::cpu::packed_matmul_x86_avx2_range;
+  }
+  if (std::strcmp(requested, "avx512") == 0) {
+    STD_TORCH_CHECK(
+        orbitquant::cpu::packed_matmul_x86_avx512_available(),
+        "ORBITQUANT_CPU_ISA=avx512 requested AVX-512F/DQ/BW/VL on an unsupported CPU");
+    return orbitquant::cpu::packed_matmul_x86_avx512_range;
+  }
+  if (std::strcmp(requested, "neon") == 0) {
+    STD_TORCH_CHECK(
+        orbitquant::cpu::packed_matmul_neon_available(),
+        "ORBITQUANT_CPU_ISA=neon requested NEON on an unsupported CPU");
+    return orbitquant::cpu::packed_matmul_neon_range;
+  }
+  STD_TORCH_CHECK(
+      false,
+      "ORBITQUANT_CPU_ISA must be auto, scalar, avx2, avx512, or neon");
+  return orbitquant::cpu::packed_matmul_scalar_range;
+}
+
+}  // namespace
+
+void matmul_packed_weight(
+    OrbitQuantTensor &out,
+    OrbitQuantTensor const &x,
+    OrbitQuantTensor const &packed_weight_indices,
+    OrbitQuantTensor const &row_norms,
+    OrbitQuantTensor const &centroids,
+    OrbitQuantTensor const &bias,
+    bool has_bias,
+    int64_t bits,
+    int64_t out_features,
+    int64_t in_features,
+    int64_t block_m,
+    int64_t block_n,
+    int64_t block_k) {
+  using torch::headeronly::DeviceType;
+  using torch::headeronly::ScalarType;
+
+  STD_TORCH_CHECK(x.device().type() == DeviceType::CPU, "x must be a CPU tensor");
+  STD_TORCH_CHECK(out.device().type() == DeviceType::CPU, "out must be a CPU tensor");
+  STD_TORCH_CHECK(
+      packed_weight_indices.device().type() == DeviceType::CPU,
+      "packed weights must be CPU tensors");
+  STD_TORCH_CHECK(
+      row_norms.device().type() == DeviceType::CPU,
+      "row norms must be CPU tensors");
+  STD_TORCH_CHECK(
+      centroids.device().type() == DeviceType::CPU,
+      "centroids must be CPU tensors");
+  STD_TORCH_CHECK(x.is_contiguous(), "x must be contiguous");
+  STD_TORCH_CHECK(out.is_contiguous(), "out must be contiguous");
+  STD_TORCH_CHECK(
+      packed_weight_indices.is_contiguous(), "packed weights must be contiguous");
+  STD_TORCH_CHECK(row_norms.is_contiguous(), "row norms must be contiguous");
+  STD_TORCH_CHECK(centroids.is_contiguous(), "centroids must be contiguous");
+  STD_TORCH_CHECK(
+      packed_weight_indices.scalar_type() == ScalarType::Byte,
+      "packed weights must be uint8");
+  STD_TORCH_CHECK(
+      row_norms.scalar_type() == ScalarType::Float,
+      "row_norms must be float32");
+  STD_TORCH_CHECK(
+      centroids.scalar_type() == ScalarType::Float,
+      "centroids must be float32");
+  STD_TORCH_CHECK(out.scalar_type() == x.scalar_type(), "out dtype must match x dtype");
+  STD_TORCH_CHECK(x.dim() == 2, "x must be rank 2");
+  STD_TORCH_CHECK(out.dim() == 2, "out must be rank 2");
+  STD_TORCH_CHECK(bits > 0 && bits <= 8, "bits must be in [1, 8]");
+  STD_TORCH_CHECK(block_m > 0 && block_n > 0 && block_k > 0, "tile sizes must be positive");
+  STD_TORCH_CHECK(x.size(1) == in_features, "x has an unexpected input dimension");
+  STD_TORCH_CHECK(out.size(0) == x.size(0), "out has an unexpected row count");
+  STD_TORCH_CHECK(out.size(1) == out_features, "out has an unexpected output dimension");
+  STD_TORCH_CHECK(row_norms.numel() == out_features, "row_norms must match out_features");
+  STD_TORCH_CHECK(centroids.numel() >= (1LL << bits), "centroids are too short");
+  const int64_t packed_bytes = (out_features * in_features * bits + 7) / 8;
+  STD_TORCH_CHECK(
+      packed_weight_indices.numel() >= packed_bytes,
+      "packed weights are too short");
+  if (has_bias) {
+    STD_TORCH_CHECK(
+        bias.device().type() == DeviceType::CPU,
+        "bias must be a CPU tensor");
+    STD_TORCH_CHECK(bias.is_contiguous(), "bias must be contiguous");
+    STD_TORCH_CHECK(
+        bias.scalar_type() == ScalarType::Float,
+        "bias must be float32");
+    STD_TORCH_CHECK(bias.numel() == out_features, "bias must match out_features");
+  }
+  if (x.numel() == 0 || out_features == 0) {
+    return;
+  }
+
+  orbitquant::cpu::PackedMatmulArgs args{
+      out.mutable_data_ptr(),
+      x.const_data_ptr(),
+      packed_weight_indices.const_data_ptr<std::uint8_t>(),
+      row_norms.const_data_ptr<float>(),
+      centroids.const_data_ptr<float>(),
+      has_bias ? bias.const_data_ptr<float>() : nullptr,
+      has_bias,
+      scalar_kind(x),
+      x.size(0),
+      out_features,
+      in_features,
+      bits,
+  };
+  parallel_packed_matmul(args, select_packed_matmul());
+}

--- a/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_matmul_cpu.h
+++ b/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_matmul_cpu.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <cstdint>
+
+namespace orbitquant::cpu {
+
+enum class ScalarKind : std::uint8_t {
+  Float32,
+  Float16,
+  BFloat16,
+};
+
+struct PackedMatmulArgs {
+  void *out;
+  void const *x;
+  std::uint8_t const *packed_weight_indices;
+  float const *row_norms;
+  float const *centroids;
+  float const *bias;
+  bool has_bias;
+  ScalarKind scalar_kind;
+  std::int64_t rows;
+  std::int64_t out_features;
+  std::int64_t in_features;
+  std::int64_t bits;
+};
+
+using PackedMatmulRangeFn = void (*)(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end);
+
+void packed_matmul_scalar_range(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end);
+
+bool packed_matmul_neon_available();
+
+void packed_matmul_neon_range(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end);
+
+bool packed_matmul_x86_avx2_available();
+
+void packed_matmul_x86_avx2_range(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end);
+
+bool packed_matmul_x86_avx512_available();
+
+void packed_matmul_x86_avx512_range(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end);
+
+}  // namespace orbitquant::cpu

--- a/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_matmul_neon.cpp
+++ b/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_matmul_neon.cpp
@@ -1,0 +1,216 @@
+#include "packed_matmul_cpu.h"
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+#include <arm_neon.h>
+
+#include <torch/headeronly/util/BFloat16.h>
+#include <torch/headeronly/util/Half.h>
+
+#include <type_traits>
+
+namespace orbitquant::cpu {
+namespace {
+
+inline float horizontal_sum(float32x4_t value) {
+#if defined(__aarch64__)
+  return vaddvq_f32(value);
+#else
+  const float32x2_t pair = vadd_f32(vget_low_f32(value), vget_high_f32(value));
+  return vget_lane_f32(vpadd_f32(pair, pair), 0);
+#endif
+}
+
+inline float32x4_t load_float4(void const *data, std::int64_t offset) {
+  return vld1q_f32(static_cast<float const *>(data) + offset);
+}
+
+inline float32x4_t load_half4(void const *data, std::int64_t offset) {
+  const auto *source = reinterpret_cast<float16_t const *>(
+      static_cast<std::uint16_t const *>(data) + offset);
+  return vcvt_f32_f16(vld1_f16(source));
+}
+
+inline float32x4_t load_bfloat4(void const *data, std::int64_t offset) {
+  const uint16x4_t raw = vld1_u16(
+      static_cast<std::uint16_t const *>(data) + offset);
+  return vreinterpretq_f32_u32(vshlq_n_u32(vmovl_u16(raw), 16));
+}
+
+template <typename scalar_t>
+inline void store_value(void *data, std::int64_t offset, float value) {
+  static_cast<scalar_t *>(data)[offset] = scalar_t(value);
+}
+
+template <>
+inline void store_value<float>(void *data, std::int64_t offset, float value) {
+  static_cast<float *>(data)[offset] = value;
+}
+
+template <
+    typename scalar_t,
+    float32x4_t (*load4)(void const *, std::int64_t),
+    int row_tile>
+inline void packed_matmul_neon_w4_rows(
+    PackedMatmulArgs const &args,
+    std::uint8_t const *packed_row,
+    std::int64_t out_col,
+    std::int64_t row_start) {
+  float32x4_t accumulator0[row_tile];
+  float32x4_t accumulator1[row_tile];
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    accumulator0[row] = vdupq_n_f32(0.0f);
+    accumulator1[row] = vdupq_n_f32(0.0f);
+  }
+
+  std::int64_t k = 0;
+  for (; k + 8 <= args.in_features; k += 8) {
+    const std::int64_t byte_offset = k / 2;
+    float weights0[4];
+    float weights1[4];
+#pragma clang loop unroll(full)
+    for (int pair = 0; pair < 4; ++pair) {
+      const std::uint8_t packed = packed_row[byte_offset + pair];
+      const int value = pair * 2;
+      if (value < 4) {
+        weights0[value] = args.centroids[packed & 15u];
+        weights0[value + 1] = args.centroids[(packed >> 4) & 15u];
+      } else {
+        weights1[value - 4] = args.centroids[packed & 15u];
+        weights1[value - 3] = args.centroids[(packed >> 4) & 15u];
+      }
+    }
+    const float32x4_t weight0 = vld1q_f32(weights0);
+    const float32x4_t weight1 = vld1q_f32(weights1);
+#pragma clang loop unroll(full)
+    for (int row = 0; row < row_tile; ++row) {
+      const std::int64_t input_offset =
+          (row_start + row) * args.in_features + k;
+      accumulator0[row] =
+          vfmaq_f32(accumulator0[row], load4(args.x, input_offset), weight0);
+      accumulator1[row] = vfmaq_f32(
+          accumulator1[row], load4(args.x, input_offset + 4), weight1);
+    }
+  }
+
+  const float row_norm = args.row_norms[out_col];
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    const std::int64_t input_row_offset =
+        (row_start + row) * args.in_features;
+    float accumulator =
+        horizontal_sum(vaddq_f32(accumulator0[row], accumulator1[row]));
+    for (std::int64_t tail = k; tail < args.in_features; ++tail) {
+      const std::uint8_t packed = packed_row[tail / 2];
+      const std::uint8_t index =
+          (tail & 1) == 0 ? packed & 15u : (packed >> 4) & 15u;
+      if constexpr (std::is_same_v<scalar_t, float>) {
+        accumulator +=
+            static_cast<float const *>(args.x)[input_row_offset + tail] *
+            args.centroids[index];
+      } else {
+        accumulator += static_cast<float>(
+                           static_cast<scalar_t const *>(
+                               args.x)[input_row_offset + tail]) *
+            args.centroids[index];
+      }
+    }
+    accumulator *= row_norm;
+    if (args.has_bias) {
+      accumulator += args.bias[out_col];
+    }
+    store_value<scalar_t>(
+        args.out,
+        (row_start + row) * args.out_features + out_col,
+        accumulator);
+  }
+}
+
+template <typename scalar_t, float32x4_t (*load4)(void const *, std::int64_t)>
+void packed_matmul_neon_w4_typed(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  constexpr int kPrimaryRowTile = 8;
+  const std::int64_t packed_row_bytes = args.in_features / 2;
+  for (std::int64_t out_col = out_start; out_col < out_end; ++out_col) {
+    const auto *packed_row =
+        args.packed_weight_indices + out_col * packed_row_bytes;
+    std::int64_t row = 0;
+    if constexpr (kPrimaryRowTile == 8) {
+      for (; row + 8 <= args.rows; row += 8) {
+        packed_matmul_neon_w4_rows<scalar_t, load4, 8>(
+            args, packed_row, out_col, row);
+      }
+    }
+    for (; row + 4 <= args.rows; row += 4) {
+      packed_matmul_neon_w4_rows<scalar_t, load4, 4>(
+          args, packed_row, out_col, row);
+    }
+    switch (args.rows - row) {
+      case 3:
+        packed_matmul_neon_w4_rows<scalar_t, load4, 3>(
+            args, packed_row, out_col, row);
+        break;
+      case 2:
+        packed_matmul_neon_w4_rows<scalar_t, load4, 2>(
+            args, packed_row, out_col, row);
+        break;
+      case 1:
+        packed_matmul_neon_w4_rows<scalar_t, load4, 1>(
+            args, packed_row, out_col, row);
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+}  // namespace
+
+bool packed_matmul_neon_available() {
+  return true;
+}
+
+void packed_matmul_neon_range(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  if (args.bits != 4 || args.in_features % 2 != 0) {
+    packed_matmul_scalar_range(args, out_start, out_end);
+    return;
+  }
+  switch (args.scalar_kind) {
+    case ScalarKind::Float32:
+      packed_matmul_neon_w4_typed<float, load_float4>(args, out_start, out_end);
+      return;
+    case ScalarKind::Float16:
+      packed_matmul_neon_w4_typed<c10::Half, load_half4>(args, out_start, out_end);
+      return;
+    case ScalarKind::BFloat16:
+      packed_matmul_neon_w4_typed<c10::BFloat16, load_bfloat4>(
+          args, out_start, out_end);
+      return;
+  }
+}
+
+}  // namespace orbitquant::cpu
+
+#else
+
+namespace orbitquant::cpu {
+
+bool packed_matmul_neon_available() {
+  return false;
+}
+
+void packed_matmul_neon_range(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  packed_matmul_scalar_range(args, out_start, out_end);
+}
+
+}  // namespace orbitquant::cpu
+
+#endif

--- a/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_matmul_scalar.cpp
+++ b/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_matmul_scalar.cpp
@@ -1,0 +1,95 @@
+#include "packed_matmul_cpu.h"
+
+#include <torch/headeronly/util/BFloat16.h>
+#include <torch/headeronly/util/Half.h>
+
+#include <cstddef>
+
+namespace orbitquant::cpu {
+namespace {
+
+template <typename scalar_t>
+inline float load_scalar(void const *data, std::int64_t offset) {
+  return static_cast<float>(static_cast<scalar_t const *>(data)[offset]);
+}
+
+template <typename scalar_t>
+inline void store_scalar(void *data, std::int64_t offset, float value) {
+  static_cast<scalar_t *>(data)[offset] = scalar_t(value);
+}
+
+template <>
+inline float load_scalar<float>(void const *data, std::int64_t offset) {
+  return static_cast<float const *>(data)[offset];
+}
+
+template <>
+inline void store_scalar<float>(void *data, std::int64_t offset, float value) {
+  static_cast<float *>(data)[offset] = value;
+}
+
+inline std::uint32_t unpack_index(
+    std::uint8_t const *packed,
+    std::int64_t value_offset,
+    std::int64_t bits) {
+  const std::int64_t bit_start = value_offset * bits;
+  const std::int64_t byte_index = bit_start >> 3;
+  const unsigned bit_offset = static_cast<unsigned>(bit_start & 7);
+  std::uint32_t raw = packed[byte_index];
+  if (bit_offset + static_cast<unsigned>(bits) > 8) {
+    raw |= static_cast<std::uint32_t>(packed[byte_index + 1]) << 8;
+  }
+  return (raw >> bit_offset) & ((1u << static_cast<unsigned>(bits)) - 1u);
+}
+
+template <typename scalar_t>
+void packed_matmul_scalar_typed(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  for (std::int64_t out_col = out_start; out_col < out_end; ++out_col) {
+    const float row_norm = args.row_norms[out_col];
+    const std::int64_t weight_row_offset = out_col * args.in_features;
+    for (std::int64_t row = 0; row < args.rows; ++row) {
+      const std::int64_t input_row_offset = row * args.in_features;
+      float accumulator = 0.0f;
+      for (std::int64_t k = 0; k < args.in_features; ++k) {
+        const std::uint32_t index = unpack_index(
+            args.packed_weight_indices,
+            weight_row_offset + k,
+            args.bits);
+        accumulator += load_scalar<scalar_t>(args.x, input_row_offset + k) *
+            args.centroids[index];
+      }
+      accumulator *= row_norm;
+      if (args.has_bias) {
+        accumulator += args.bias[out_col];
+      }
+      store_scalar<scalar_t>(
+          args.out,
+          row * args.out_features + out_col,
+          accumulator);
+    }
+  }
+}
+
+}  // namespace
+
+void packed_matmul_scalar_range(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  switch (args.scalar_kind) {
+    case ScalarKind::Float32:
+      packed_matmul_scalar_typed<float>(args, out_start, out_end);
+      return;
+    case ScalarKind::Float16:
+      packed_matmul_scalar_typed<c10::Half>(args, out_start, out_end);
+      return;
+    case ScalarKind::BFloat16:
+      packed_matmul_scalar_typed<c10::BFloat16>(args, out_start, out_end);
+      return;
+  }
+}
+
+}  // namespace orbitquant::cpu

--- a/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_matmul_x86.cpp
+++ b/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_matmul_x86.cpp
@@ -1,0 +1,227 @@
+#include "packed_matmul_cpu.h"
+
+#if defined(__x86_64__) || defined(_M_X64)
+#include <immintrin.h>
+
+#include <torch/headeronly/util/BFloat16.h>
+#include <torch/headeronly/util/Half.h>
+
+#include <cstring>
+#include <cstdint>
+#include <type_traits>
+
+#if defined(_MSC_VER)
+#define ORBITQUANT_TARGET_AVX2
+#define ORBITQUANT_NOINLINE __declspec(noinline)
+#else
+#define ORBITQUANT_TARGET_AVX2 __attribute__((target("avx2,fma,f16c")))
+#define ORBITQUANT_NOINLINE __attribute__((noinline))
+#endif
+
+namespace orbitquant::cpu {
+namespace {
+
+ORBITQUANT_TARGET_AVX2 inline float horizontal_sum(__m256 value) {
+  const __m128 halves =
+      _mm_add_ps(_mm256_castps256_ps128(value), _mm256_extractf128_ps(value, 1));
+  const __m128 pairs = _mm_hadd_ps(halves, halves);
+  return _mm_cvtss_f32(_mm_hadd_ps(pairs, pairs));
+}
+
+ORBITQUANT_TARGET_AVX2 inline __m256 load_float8(
+    void const *data,
+    std::int64_t offset) {
+  return _mm256_loadu_ps(static_cast<float const *>(data) + offset);
+}
+
+ORBITQUANT_TARGET_AVX2 inline __m256 load_half8(
+    void const *data,
+    std::int64_t offset) {
+  const auto *source = static_cast<std::uint16_t const *>(data) + offset;
+  const __m128i packed =
+      _mm_loadu_si128(reinterpret_cast<__m128i const *>(source));
+  return _mm256_cvtph_ps(packed);
+}
+
+ORBITQUANT_TARGET_AVX2 inline __m256 load_bfloat8(
+    void const *data,
+    std::int64_t offset) {
+  const auto *source = static_cast<std::uint16_t const *>(data) + offset;
+  const __m128i packed =
+      _mm_loadu_si128(reinterpret_cast<__m128i const *>(source));
+  const __m256i widened = _mm256_cvtepu16_epi32(packed);
+  return _mm256_castsi256_ps(_mm256_slli_epi32(widened, 16));
+}
+
+template <typename scalar_t>
+inline void store_value(void *data, std::int64_t offset, float value) {
+  static_cast<scalar_t *>(data)[offset] = scalar_t(value);
+}
+
+template <>
+inline void store_value<float>(void *data, std::int64_t offset, float value) {
+  static_cast<float *>(data)[offset] = value;
+}
+
+template <
+    typename scalar_t,
+    __m256 (*load8)(void const *, std::int64_t),
+    int row_tile>
+ORBITQUANT_TARGET_AVX2 inline void packed_matmul_avx2_w4_rows(
+    PackedMatmulArgs const &args,
+    std::uint8_t const *packed_row,
+    std::int64_t out_col,
+    std::int64_t row_start) {
+  __m256 accumulators[row_tile];
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    accumulators[row] = _mm256_setzero_ps();
+  }
+  const __m256 centroid_lut_low = _mm256_loadu_ps(args.centroids);
+  const __m256 centroid_lut_high = _mm256_loadu_ps(args.centroids + 8);
+  const __m128i nibble_mask = _mm_set1_epi8(15);
+  const __m256i low_table_limit = _mm256_set1_epi32(7);
+
+  std::int64_t k = 0;
+  for (; k + 8 <= args.in_features; k += 8) {
+    const std::int64_t byte_offset = k / 2;
+    std::int32_t packed;
+    std::memcpy(&packed, packed_row + byte_offset, sizeof(packed));
+    const __m128i bytes = _mm_cvtsi32_si128(packed);
+    const __m128i low = _mm_and_si128(bytes, nibble_mask);
+    const __m128i high = _mm_and_si128(
+        _mm_srli_epi16(bytes, 4),
+        nibble_mask);
+    const __m256i indices =
+        _mm256_cvtepu8_epi32(_mm_unpacklo_epi8(low, high));
+    const __m256 low_weights =
+        _mm256_permutevar8x32_ps(centroid_lut_low, indices);
+    const __m256 high_weights =
+        _mm256_permutevar8x32_ps(centroid_lut_high, indices);
+    const __m256 weight = _mm256_blendv_ps(
+        low_weights,
+        high_weights,
+        _mm256_castsi256_ps(_mm256_cmpgt_epi32(indices, low_table_limit)));
+#pragma clang loop unroll(full)
+    for (int row = 0; row < row_tile; ++row) {
+      const std::int64_t input_offset =
+          (row_start + row) * args.in_features + k;
+      accumulators[row] = _mm256_fmadd_ps(
+          load8(args.x, input_offset),
+          weight,
+          accumulators[row]);
+    }
+  }
+
+  const float row_norm = args.row_norms[out_col];
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    const std::int64_t input_row_offset =
+        (row_start + row) * args.in_features;
+    float accumulator = horizontal_sum(accumulators[row]);
+    for (std::int64_t tail = k; tail < args.in_features; ++tail) {
+      const std::uint8_t packed = packed_row[tail / 2];
+      const std::uint8_t index =
+          (tail & 1) == 0 ? packed & 15u : (packed >> 4) & 15u;
+      if constexpr (std::is_same_v<scalar_t, float>) {
+        accumulator +=
+            static_cast<float const *>(args.x)[input_row_offset + tail] *
+            args.centroids[index];
+      } else {
+        accumulator += static_cast<float>(
+                           static_cast<scalar_t const *>(
+                               args.x)[input_row_offset + tail]) *
+            args.centroids[index];
+      }
+    }
+    accumulator *= row_norm;
+    if (args.has_bias) {
+      accumulator += args.bias[out_col];
+    }
+    store_value<scalar_t>(
+        args.out,
+        (row_start + row) * args.out_features + out_col,
+        accumulator);
+  }
+}
+
+template <typename scalar_t, __m256 (*load8)(void const *, std::int64_t)>
+ORBITQUANT_TARGET_AVX2 ORBITQUANT_NOINLINE void packed_matmul_avx2_w4_typed(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  constexpr int kPrimaryRowTile = 8;
+  const std::int64_t packed_row_bytes = args.in_features / 2;
+  for (std::int64_t out_col = out_start; out_col < out_end; ++out_col) {
+    const auto *packed_row =
+        args.packed_weight_indices + out_col * packed_row_bytes;
+    std::int64_t row = 0;
+    for (; row + kPrimaryRowTile <= args.rows; row += kPrimaryRowTile) {
+      packed_matmul_avx2_w4_rows<scalar_t, load8, kPrimaryRowTile>(
+          args, packed_row, out_col, row);
+    }
+    if (row + 4 <= args.rows) {
+      packed_matmul_avx2_w4_rows<scalar_t, load8, 4>(
+          args, packed_row, out_col, row);
+      row += 4;
+    }
+    switch (args.rows - row) {
+      case 3:
+        packed_matmul_avx2_w4_rows<scalar_t, load8, 3>(
+            args, packed_row, out_col, row);
+        break;
+      case 2:
+        packed_matmul_avx2_w4_rows<scalar_t, load8, 2>(
+            args, packed_row, out_col, row);
+        break;
+      case 1:
+        packed_matmul_avx2_w4_rows<scalar_t, load8, 1>(
+            args, packed_row, out_col, row);
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+}  // namespace
+
+void packed_matmul_x86_avx2_range(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  if (!packed_matmul_x86_avx2_available() || args.bits != 4 ||
+      args.in_features % 2 != 0) {
+    packed_matmul_scalar_range(args, out_start, out_end);
+    return;
+  }
+  switch (args.scalar_kind) {
+    case ScalarKind::Float32:
+      packed_matmul_avx2_w4_typed<float, load_float8>(args, out_start, out_end);
+      return;
+    case ScalarKind::Float16:
+      packed_matmul_avx2_w4_typed<c10::Half, load_half8>(args, out_start, out_end);
+      return;
+    case ScalarKind::BFloat16:
+      packed_matmul_avx2_w4_typed<c10::BFloat16, load_bfloat8>(
+          args, out_start, out_end);
+      return;
+  }
+}
+
+}  // namespace orbitquant::cpu
+
+#else
+
+namespace orbitquant::cpu {
+
+void packed_matmul_x86_avx2_range(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  packed_matmul_scalar_range(args, out_start, out_end);
+}
+
+}  // namespace orbitquant::cpu
+
+#endif

--- a/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_matmul_x86_avx512.cpp
+++ b/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/packed_matmul_x86_avx512.cpp
@@ -1,0 +1,393 @@
+#include "packed_matmul_cpu.h"
+
+#if (defined(__x86_64__) || defined(_M_X64)) && !defined(_MSC_VER)
+#include <immintrin.h>
+
+#include <torch/headeronly/util/BFloat16.h>
+#include <torch/headeronly/util/Half.h>
+
+#include <cstring>
+#include <cstdint>
+#include <type_traits>
+
+#define ORBITQUANT_TARGET_AVX512 \
+  __attribute__((target("avx512f,avx512dq,avx512bw,avx512vl,fma,f16c")))
+#define ORBITQUANT_TARGET_AVX512_BF16 \
+  __attribute__((target( \
+      "avx512f,avx512dq,avx512bw,avx512vl,avx512bf16,fma,f16c")))
+#define ORBITQUANT_HAS_AVX512_BF16_INTRINSICS 1
+#define ORBITQUANT_NOINLINE __attribute__((noinline))
+
+namespace orbitquant::cpu {
+namespace {
+
+ORBITQUANT_TARGET_AVX512 inline float horizontal_sum(__m512 value) {
+  return _mm512_reduce_add_ps(value);
+}
+
+ORBITQUANT_TARGET_AVX512 inline __m512 load_float16(
+    void const *data,
+    std::int64_t offset) {
+  return _mm512_loadu_ps(static_cast<float const *>(data) + offset);
+}
+
+ORBITQUANT_TARGET_AVX512 inline __m512 load_half16(
+    void const *data,
+    std::int64_t offset) {
+  const auto *source = static_cast<std::uint16_t const *>(data) + offset;
+  const __m256i packed =
+      _mm256_loadu_si256(reinterpret_cast<__m256i const *>(source));
+  return _mm512_cvtph_ps(packed);
+}
+
+ORBITQUANT_TARGET_AVX512 inline __m512 load_bfloat16(
+    void const *data,
+    std::int64_t offset) {
+  const auto *source = static_cast<std::uint16_t const *>(data) + offset;
+  const __m256i packed =
+      _mm256_loadu_si256(reinterpret_cast<__m256i const *>(source));
+  const __m512i widened = _mm512_cvtepu16_epi32(packed);
+  return _mm512_castsi512_ps(_mm512_slli_epi32(widened, 16));
+}
+
+template <typename scalar_t>
+inline void store_value(void *data, std::int64_t offset, float value) {
+  static_cast<scalar_t *>(data)[offset] = scalar_t(value);
+}
+
+template <>
+inline void store_value<float>(void *data, std::int64_t offset, float value) {
+  static_cast<float *>(data)[offset] = value;
+}
+
+template <
+    typename scalar_t,
+    __m512 (*load16)(void const *, std::int64_t),
+    int row_tile>
+ORBITQUANT_TARGET_AVX512 inline void packed_matmul_avx512_w4_rows(
+    PackedMatmulArgs const &args,
+    std::uint8_t const *packed_row,
+    std::int64_t out_col,
+    std::int64_t row_start) {
+  __m512 accumulators[row_tile];
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    accumulators[row] = _mm512_setzero_ps();
+  }
+  const __m512 centroid_lut = _mm512_loadu_ps(args.centroids);
+  const __m128i nibble_mask = _mm_set1_epi8(15);
+
+  std::int64_t k = 0;
+  for (; k + 16 <= args.in_features; k += 16) {
+    const std::int64_t byte_offset = k / 2;
+    std::int64_t packed;
+    std::memcpy(&packed, packed_row + byte_offset, sizeof(packed));
+    const __m128i bytes = _mm_cvtsi64_si128(packed);
+    const __m128i low = _mm_and_si128(bytes, nibble_mask);
+    const __m128i high = _mm_and_si128(
+        _mm_srli_epi16(bytes, 4),
+        nibble_mask);
+    const __m512i indices =
+        _mm512_cvtepu8_epi32(_mm_unpacklo_epi8(low, high));
+    const __m512 weight = _mm512_permutexvar_ps(indices, centroid_lut);
+#pragma clang loop unroll(full)
+    for (int row = 0; row < row_tile; ++row) {
+      const std::int64_t input_offset =
+          (row_start + row) * args.in_features + k;
+      accumulators[row] = _mm512_fmadd_ps(
+          load16(args.x, input_offset),
+          weight,
+          accumulators[row]);
+    }
+  }
+
+  const float row_norm = args.row_norms[out_col];
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    const std::int64_t input_row_offset =
+        (row_start + row) * args.in_features;
+    float accumulator = horizontal_sum(accumulators[row]);
+    for (std::int64_t tail = k; tail < args.in_features; ++tail) {
+      const std::uint8_t packed = packed_row[tail / 2];
+      const std::uint8_t index =
+          (tail & 1) == 0 ? packed & 15u : (packed >> 4) & 15u;
+      if constexpr (std::is_same_v<scalar_t, float>) {
+        accumulator +=
+            static_cast<float const *>(args.x)[input_row_offset + tail] *
+            args.centroids[index];
+      } else {
+        accumulator += static_cast<float>(
+                           static_cast<scalar_t const *>(
+                               args.x)[input_row_offset + tail]) *
+            args.centroids[index];
+      }
+    }
+    accumulator *= row_norm;
+    if (args.has_bias) {
+      accumulator += args.bias[out_col];
+    }
+    store_value<scalar_t>(
+        args.out,
+        (row_start + row) * args.out_features + out_col,
+        accumulator);
+  }
+}
+
+template <typename scalar_t, __m512 (*load16)(void const *, std::int64_t)>
+ORBITQUANT_TARGET_AVX512 ORBITQUANT_NOINLINE void packed_matmul_avx512_w4_typed(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  constexpr int kPrimaryRowTile = 8;
+  const std::int64_t packed_row_bytes = args.in_features / 2;
+  for (std::int64_t out_col = out_start; out_col < out_end; ++out_col) {
+    const auto *packed_row =
+        args.packed_weight_indices + out_col * packed_row_bytes;
+    std::int64_t row = 0;
+    for (; row + kPrimaryRowTile <= args.rows; row += kPrimaryRowTile) {
+      packed_matmul_avx512_w4_rows<scalar_t, load16, kPrimaryRowTile>(
+          args, packed_row, out_col, row);
+    }
+    if (row + 8 <= args.rows) {
+      packed_matmul_avx512_w4_rows<scalar_t, load16, 8>(
+          args, packed_row, out_col, row);
+      row += 8;
+    }
+    if (row + 4 <= args.rows) {
+      packed_matmul_avx512_w4_rows<scalar_t, load16, 4>(
+          args, packed_row, out_col, row);
+      row += 4;
+    }
+    switch (args.rows - row) {
+      case 3:
+        packed_matmul_avx512_w4_rows<scalar_t, load16, 3>(
+            args, packed_row, out_col, row);
+        break;
+      case 2:
+        packed_matmul_avx512_w4_rows<scalar_t, load16, 2>(
+            args, packed_row, out_col, row);
+        break;
+      case 1:
+        packed_matmul_avx512_w4_rows<scalar_t, load16, 1>(
+            args, packed_row, out_col, row);
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+#if defined(ORBITQUANT_HAS_AVX512_BF16_INTRINSICS)
+template <int row_tile, bool aligned_k>
+ORBITQUANT_TARGET_AVX512_BF16 inline void packed_matmul_avx512_bf16_w4_rows(
+    PackedMatmulArgs const &args,
+    std::uint8_t const *packed_row,
+    std::int64_t out_col,
+    std::int64_t row_start) {
+  __m512 accumulators[row_tile];
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    accumulators[row] = _mm512_setzero_ps();
+  }
+  const float row_norm = args.row_norms[out_col];
+  const __m512 centroid_lut = _mm512_mul_ps(
+      _mm512_loadu_ps(args.centroids),
+      _mm512_set1_ps(row_norm));
+  const __m512i centroid_lut_words = (__m512i)_mm512_cvtne2ps_pbh(
+      centroid_lut,
+      centroid_lut);
+  const __m128i nibble_mask = _mm_set1_epi8(15);
+
+  std::int64_t k = 0;
+  for (; k + 32 <= args.in_features; k += 32) {
+    const std::int64_t byte_offset = k / 2;
+    const __m128i bytes = _mm_loadu_si128(
+        reinterpret_cast<__m128i const *>(packed_row + byte_offset));
+    const __m128i low = _mm_and_si128(bytes, nibble_mask);
+    const __m128i high = _mm_and_si128(
+        _mm_srli_epi16(bytes, 4),
+        nibble_mask);
+    const __m256i packed_indices = _mm256_set_m128i(
+        _mm_unpackhi_epi8(low, high),
+        _mm_unpacklo_epi8(low, high));
+    const __m512i indices = _mm512_cvtepu8_epi16(packed_indices);
+    const __m512bh weights = (__m512bh)_mm512_permutexvar_epi16(
+        indices,
+        centroid_lut_words);
+#pragma clang loop unroll(full)
+    for (int row = 0; row < row_tile; ++row) {
+      const std::int64_t input_offset =
+          (row_start + row) * args.in_features + k;
+      const __m512bh activations = (__m512bh)_mm512_loadu_si512(
+          static_cast<std::uint16_t const *>(args.x) + input_offset);
+      accumulators[row] =
+          _mm512_dpbf16_ps(accumulators[row], activations, weights);
+    }
+  }
+
+#pragma clang loop unroll(full)
+  for (int row = 0; row < row_tile; ++row) {
+    const std::int64_t input_row_offset =
+        (row_start + row) * args.in_features;
+    float accumulator = horizontal_sum(accumulators[row]);
+    if constexpr (!aligned_k) {
+      for (std::int64_t tail = k; tail < args.in_features; ++tail) {
+        const std::uint8_t packed = packed_row[tail / 2];
+        const std::uint8_t index =
+            (tail & 1) == 0 ? packed & 15u : (packed >> 4) & 15u;
+        const float activation = static_cast<float>(
+            static_cast<c10::BFloat16 const *>(args.x)[input_row_offset + tail]);
+        const float weight = static_cast<float>(
+            c10::BFloat16(args.centroids[index] * row_norm));
+        accumulator += activation * weight;
+      }
+    }
+    if (args.has_bias) {
+      accumulator += args.bias[out_col];
+    }
+    store_value<c10::BFloat16>(
+        args.out,
+        (row_start + row) * args.out_features + out_col,
+        accumulator);
+  }
+}
+
+template <bool aligned_k>
+ORBITQUANT_TARGET_AVX512_BF16 ORBITQUANT_NOINLINE void
+packed_matmul_avx512_bf16_w4_typed(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  constexpr int kPrimaryRowTile = 8;
+  const std::int64_t packed_row_bytes = args.in_features / 2;
+  for (std::int64_t out_col = out_start; out_col < out_end; ++out_col) {
+    const auto *packed_row =
+        args.packed_weight_indices + out_col * packed_row_bytes;
+    std::int64_t row = 0;
+    for (; row + kPrimaryRowTile <= args.rows; row += kPrimaryRowTile) {
+      packed_matmul_avx512_bf16_w4_rows<kPrimaryRowTile, aligned_k>(
+          args, packed_row, out_col, row);
+    }
+    if (row + 4 <= args.rows) {
+      packed_matmul_avx512_bf16_w4_rows<4, aligned_k>(
+          args, packed_row, out_col, row);
+      row += 4;
+    }
+    switch (args.rows - row) {
+      case 3:
+        packed_matmul_avx512_bf16_w4_rows<3, aligned_k>(
+            args, packed_row, out_col, row);
+        break;
+      case 2:
+        packed_matmul_avx512_bf16_w4_rows<2, aligned_k>(
+            args, packed_row, out_col, row);
+        break;
+      case 1:
+        packed_matmul_avx512_bf16_w4_rows<1, aligned_k>(
+            args, packed_row, out_col, row);
+        break;
+      default:
+        break;
+    }
+  }
+}
+#endif
+
+bool runtime_has_avx512() {
+#if defined(_MSC_VER)
+  int registers[4]{};
+  __cpuid(registers, 1);
+  const bool osxsave = (registers[2] & (1 << 27)) != 0;
+  const bool avx = (registers[2] & (1 << 28)) != 0;
+  const bool fma = (registers[2] & (1 << 12)) != 0;
+  const bool f16c = (registers[2] & (1 << 29)) != 0;
+  if (!osxsave || !avx || !fma || !f16c || (_xgetbv(0) & 0xE6) != 0xE6) {
+    return false;
+  }
+  __cpuidex(registers, 7, 0);
+  constexpr unsigned required_ebx =
+      (1u << 16) | (1u << 17) | (1u << 30) | (1u << 31);
+  return (static_cast<unsigned>(registers[1]) & required_ebx) == required_ebx;
+#else
+  __builtin_cpu_init();
+  return __builtin_cpu_supports("avx512f") &&
+      __builtin_cpu_supports("avx512dq") &&
+      __builtin_cpu_supports("avx512bw") &&
+      __builtin_cpu_supports("avx512vl") &&
+      __builtin_cpu_supports("fma") && __builtin_cpu_supports("f16c");
+#endif
+}
+
+bool runtime_has_avx512_bf16() {
+#if defined(ORBITQUANT_HAS_AVX512_BF16_INTRINSICS)
+  __builtin_cpu_init();
+  return runtime_has_avx512() && __builtin_cpu_supports("avx512bf16");
+#else
+  return false;
+#endif
+}
+
+}  // namespace
+
+bool packed_matmul_x86_avx512_available() {
+  static const bool available = runtime_has_avx512();
+  return available;
+}
+
+void packed_matmul_x86_avx512_range(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  if (!packed_matmul_x86_avx512_available() || args.bits != 4 ||
+      args.in_features % 2 != 0) {
+    packed_matmul_scalar_range(args, out_start, out_end);
+    return;
+  }
+  switch (args.scalar_kind) {
+    case ScalarKind::Float32:
+      packed_matmul_avx512_w4_typed<float, load_float16>(
+          args, out_start, out_end);
+      return;
+    case ScalarKind::Float16:
+      packed_matmul_avx512_w4_typed<c10::Half, load_half16>(
+          args, out_start, out_end);
+      return;
+    case ScalarKind::BFloat16:
+#if defined(ORBITQUANT_HAS_AVX512_BF16_INTRINSICS)
+      if (runtime_has_avx512_bf16()) {
+        if (args.in_features % 32 == 0) {
+          packed_matmul_avx512_bf16_w4_typed<true>(
+              args, out_start, out_end);
+        } else {
+          packed_matmul_avx512_bf16_w4_typed<false>(
+              args, out_start, out_end);
+        }
+        return;
+      }
+#endif
+      packed_matmul_avx512_w4_typed<c10::BFloat16, load_bfloat16>(
+          args, out_start, out_end);
+      return;
+  }
+}
+
+}  // namespace orbitquant::cpu
+
+#else
+
+namespace orbitquant::cpu {
+
+bool packed_matmul_x86_avx512_available() {
+  return false;
+}
+
+void packed_matmul_x86_avx512_range(
+    PackedMatmulArgs const &args,
+    std::int64_t out_start,
+    std::int64_t out_end) {
+  packed_matmul_scalar_range(args, out_start, out_end);
+}
+
+}  // namespace orbitquant::cpu
+
+#endif

--- a/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/quantize_activations_cpu.cpp
+++ b/native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu/quantize_activations_cpu.cpp
@@ -1,0 +1,763 @@
+#include "cpu_threads.h"
+#include "cpu_kernel_args.h"
+#include "packed_matmul_cpu.h"
+#include "../torch-ext/torch_binding.h"
+
+#include <torch/headeronly/core/DeviceType.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/macros/Macros.h>
+#include <torch/headeronly/util/BFloat16.h>
+#include <torch/headeronly/util/Half.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <cstdint>
+#include <cstring>
+#include <thread>
+#include <type_traits>
+#include <vector>
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+#include <arm_neon.h>
+#endif
+
+#if (defined(__x86_64__) || defined(_M_X64)) && !defined(_MSC_VER)
+#include <immintrin.h>
+#define ORBITQUANT_TARGET_AVX2 __attribute__((target("avx2,fma,f16c")))
+#define ORBITQUANT_TARGET_AVX512 \
+  __attribute__((target("avx512f,avx512dq,avx512bw,avx512vl,fma,f16c")))
+#endif
+
+namespace {
+
+using orbitquant::cpu::ActivationArgs;
+using orbitquant::cpu::ActivationIsa;
+
+ActivationIsa select_activation_isa() {
+  const char *requested = std::getenv("ORBITQUANT_CPU_ISA");
+  if (requested == nullptr || std::strcmp(requested, "auto") == 0) {
+    if (orbitquant::cpu::packed_matmul_x86_avx512_available()) {
+      return ActivationIsa::Avx512;
+    }
+    if (orbitquant::cpu::packed_matmul_x86_avx2_available()) {
+      return ActivationIsa::Avx2;
+    }
+    if (orbitquant::cpu::packed_matmul_neon_available()) {
+      return ActivationIsa::Neon;
+    }
+    return ActivationIsa::Portable;
+  }
+  if (std::strcmp(requested, "scalar") == 0) {
+    return ActivationIsa::Portable;
+  }
+  if (std::strcmp(requested, "avx2") == 0) {
+    STD_TORCH_CHECK(
+        orbitquant::cpu::packed_matmul_x86_avx2_available(),
+        "ORBITQUANT_CPU_ISA=avx2 requested AVX2/FMA/F16C on an unsupported CPU");
+    return ActivationIsa::Avx2;
+  }
+  if (std::strcmp(requested, "avx512") == 0) {
+    STD_TORCH_CHECK(
+        orbitquant::cpu::packed_matmul_x86_avx512_available(),
+        "ORBITQUANT_CPU_ISA=avx512 requested AVX-512F/DQ/BW/VL on an unsupported CPU");
+    return ActivationIsa::Avx512;
+  }
+  if (std::strcmp(requested, "neon") == 0) {
+    STD_TORCH_CHECK(
+        orbitquant::cpu::packed_matmul_neon_available(),
+        "ORBITQUANT_CPU_ISA=neon requested NEON on an unsupported CPU");
+    return ActivationIsa::Neon;
+  }
+  STD_TORCH_CHECK(
+      false,
+      "ORBITQUANT_CPU_ISA must be auto, scalar, avx2, avx512, or neon");
+  return ActivationIsa::Portable;
+}
+
+orbitquant::cpu::ScalarKind activation_scalar_kind(
+    OrbitQuantTensor const &tensor) {
+  using torch::headeronly::ScalarType;
+  switch (tensor.scalar_type()) {
+    case ScalarType::Float:
+      return orbitquant::cpu::ScalarKind::Float32;
+    case ScalarType::Half:
+      return orbitquant::cpu::ScalarKind::Float16;
+    case ScalarType::BFloat16:
+      return orbitquant::cpu::ScalarKind::BFloat16;
+    default:
+      STD_TORCH_CHECK(
+          false,
+          "CPU activation quantization supports float32, float16, and bfloat16 inputs");
+  }
+  return orbitquant::cpu::ScalarKind::Float32;
+}
+
+template <typename scalar_t>
+inline float load_scalar(void const *data, std::int64_t offset) {
+  return static_cast<float>(static_cast<scalar_t const *>(data)[offset]);
+}
+
+template <>
+inline float load_scalar<float>(void const *data, std::int64_t offset) {
+  return static_cast<float const *>(data)[offset];
+}
+
+template <typename scalar_t>
+inline void store_scalar(void *data, std::int64_t offset, float value) {
+  static_cast<scalar_t *>(data)[offset] = scalar_t(value);
+}
+
+template <>
+inline void store_scalar<float>(void *data, std::int64_t offset, float value) {
+  static_cast<float *>(data)[offset] = value;
+}
+
+inline void fwht_block_portable(float *values, std::int64_t block_size) {
+  for (std::int64_t half = 1; half < block_size; half *= 2) {
+    for (std::int64_t base = 0; base < block_size; base += 2 * half) {
+      for (std::int64_t offset = 0; offset < half; ++offset) {
+        const float left = values[base + offset];
+        const float right = values[base + half + offset];
+        values[base + offset] = left + right;
+        values[base + half + offset] = left - right;
+      }
+    }
+  }
+}
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+inline void fwht_block_neon(float *values, std::int64_t block_size) {
+  for (std::int64_t half = 1; half < block_size; half *= 2) {
+    for (std::int64_t base = 0; base < block_size; base += 2 * half) {
+      std::int64_t offset = 0;
+      for (; offset + 4 <= half; offset += 4) {
+        const float32x4_t left = vld1q_f32(values + base + offset);
+        const float32x4_t right = vld1q_f32(values + base + half + offset);
+        vst1q_f32(values + base + offset, vaddq_f32(left, right));
+        vst1q_f32(values + base + half + offset, vsubq_f32(left, right));
+      }
+      for (; offset < half; ++offset) {
+        const float left = values[base + offset];
+        const float right = values[base + half + offset];
+        values[base + offset] = left + right;
+        values[base + half + offset] = left - right;
+      }
+    }
+  }
+}
+#endif
+
+#if (defined(__x86_64__) || defined(_M_X64)) && !defined(_MSC_VER)
+ORBITQUANT_TARGET_AVX2 void fwht_block_avx2(
+    float *values,
+    std::int64_t block_size) {
+  for (std::int64_t half = 1; half < block_size; half *= 2) {
+    for (std::int64_t base = 0; base < block_size; base += 2 * half) {
+      std::int64_t offset = 0;
+      for (; offset + 8 <= half; offset += 8) {
+        const __m256 left = _mm256_loadu_ps(values + base + offset);
+        const __m256 right =
+            _mm256_loadu_ps(values + base + half + offset);
+        _mm256_storeu_ps(values + base + offset, _mm256_add_ps(left, right));
+        _mm256_storeu_ps(
+            values + base + half + offset,
+            _mm256_sub_ps(left, right));
+      }
+      for (; offset < half; ++offset) {
+        const float left = values[base + offset];
+        const float right = values[base + half + offset];
+        values[base + offset] = left + right;
+        values[base + half + offset] = left - right;
+      }
+    }
+  }
+}
+
+ORBITQUANT_TARGET_AVX512 void fwht_block_avx512(
+    float *values,
+    std::int64_t block_size) {
+  for (std::int64_t half = 1; half < block_size; half *= 2) {
+    for (std::int64_t base = 0; base < block_size; base += 2 * half) {
+      std::int64_t offset = 0;
+      for (; offset + 16 <= half; offset += 16) {
+        const __m512 left = _mm512_loadu_ps(values + base + offset);
+        const __m512 right =
+            _mm512_loadu_ps(values + base + half + offset);
+        _mm512_storeu_ps(values + base + offset, _mm512_add_ps(left, right));
+        _mm512_storeu_ps(
+            values + base + half + offset,
+            _mm512_sub_ps(left, right));
+      }
+      for (; offset < half; ++offset) {
+        const float left = values[base + offset];
+        const float right = values[base + half + offset];
+        values[base + offset] = left + right;
+        values[base + half + offset] = left - right;
+      }
+    }
+  }
+}
+#endif
+
+inline void fwht_block(
+    float *values,
+    std::int64_t block_size,
+    ActivationIsa isa) {
+#if defined(__x86_64__) || defined(_M_X64)
+  if (isa == ActivationIsa::Avx512) {
+#if defined(_MSC_VER)
+    orbitquant::cpu::activation_fwht_msvc_avx2(values, block_size);
+#else
+    fwht_block_avx512(values, block_size);
+#endif
+    return;
+  }
+  if (isa == ActivationIsa::Avx2) {
+#if defined(_MSC_VER)
+    orbitquant::cpu::activation_fwht_msvc_avx2(values, block_size);
+#else
+    fwht_block_avx2(values, block_size);
+#endif
+    return;
+  }
+#endif
+#if defined(__aarch64__) || defined(_M_ARM64)
+  if (isa == ActivationIsa::Neon) {
+    fwht_block_neon(values, block_size);
+    return;
+  }
+#endif
+  fwht_block_portable(values, block_size);
+}
+
+template <typename scalar_t>
+float squared_norm_scalar(void const *data, std::int64_t offset, std::int64_t dim) {
+  float result = 0.0f;
+  for (std::int64_t index = 0; index < dim; ++index) {
+    const float value = load_scalar<scalar_t>(data, offset + index);
+    result += value * value;
+  }
+  return result;
+}
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+template <typename scalar_t>
+float squared_norm_neon(void const *data, std::int64_t offset, std::int64_t dim) {
+  float32x4_t accumulator = vdupq_n_f32(0.0f);
+  std::int64_t index = 0;
+  for (; index + 4 <= dim; index += 4) {
+    float32x4_t values;
+    if constexpr (std::is_same_v<scalar_t, float>) {
+      values = vld1q_f32(static_cast<float const *>(data) + offset + index);
+    } else if constexpr (std::is_same_v<scalar_t, c10::Half>) {
+      const auto *source = reinterpret_cast<float16_t const *>(
+          static_cast<std::uint16_t const *>(data) + offset + index);
+      values = vcvt_f32_f16(vld1_f16(source));
+    } else {
+      const uint16x4_t raw = vld1_u16(
+          static_cast<std::uint16_t const *>(data) + offset + index);
+      values = vreinterpretq_f32_u32(vshlq_n_u32(vmovl_u16(raw), 16));
+    }
+    accumulator = vfmaq_f32(accumulator, values, values);
+  }
+  float result = vaddvq_f32(accumulator);
+  for (; index < dim; ++index) {
+    const float value = load_scalar<scalar_t>(data, offset + index);
+    result += value * value;
+  }
+  return result;
+}
+#endif
+
+#if (defined(__x86_64__) || defined(_M_X64)) && !defined(_MSC_VER)
+template <typename scalar_t>
+ORBITQUANT_TARGET_AVX2 float squared_norm_avx2(
+    void const *data,
+    std::int64_t offset,
+    std::int64_t dim) {
+  __m256 accumulator = _mm256_setzero_ps();
+  std::int64_t index = 0;
+  for (; index + 8 <= dim; index += 8) {
+    __m256 values;
+    if constexpr (std::is_same_v<scalar_t, float>) {
+      values = _mm256_loadu_ps(
+          static_cast<float const *>(data) + offset + index);
+    } else if constexpr (std::is_same_v<scalar_t, c10::Half>) {
+      const auto *source =
+          static_cast<std::uint16_t const *>(data) + offset + index;
+      values = _mm256_cvtph_ps(
+          _mm_loadu_si128(reinterpret_cast<__m128i const *>(source)));
+    } else {
+      const auto *source =
+          static_cast<std::uint16_t const *>(data) + offset + index;
+      const __m128i packed =
+          _mm_loadu_si128(reinterpret_cast<__m128i const *>(source));
+      values = _mm256_castsi256_ps(
+          _mm256_slli_epi32(_mm256_cvtepu16_epi32(packed), 16));
+    }
+    accumulator = _mm256_fmadd_ps(values, values, accumulator);
+  }
+  const __m128 halves = _mm_add_ps(
+      _mm256_castps256_ps128(accumulator),
+      _mm256_extractf128_ps(accumulator, 1));
+  const __m128 pairs = _mm_hadd_ps(halves, halves);
+  float result = _mm_cvtss_f32(_mm_hadd_ps(pairs, pairs));
+  for (; index < dim; ++index) {
+    const float value = load_scalar<scalar_t>(data, offset + index);
+    result += value * value;
+  }
+  return result;
+}
+
+template <typename scalar_t>
+ORBITQUANT_TARGET_AVX512 float squared_norm_avx512(
+    void const *data,
+    std::int64_t offset,
+    std::int64_t dim) {
+  __m512 accumulator = _mm512_setzero_ps();
+  std::int64_t index = 0;
+  for (; index + 16 <= dim; index += 16) {
+    __m512 values;
+    if constexpr (std::is_same_v<scalar_t, float>) {
+      values = _mm512_loadu_ps(
+          static_cast<float const *>(data) + offset + index);
+    } else if constexpr (std::is_same_v<scalar_t, c10::Half>) {
+      const auto *source =
+          static_cast<std::uint16_t const *>(data) + offset + index;
+      values = _mm512_cvtph_ps(
+          _mm256_loadu_si256(reinterpret_cast<__m256i const *>(source)));
+    } else {
+      const auto *source =
+          static_cast<std::uint16_t const *>(data) + offset + index;
+      const __m256i packed =
+          _mm256_loadu_si256(reinterpret_cast<__m256i const *>(source));
+      values = _mm512_castsi512_ps(
+          _mm512_slli_epi32(_mm512_cvtepu16_epi32(packed), 16));
+    }
+    accumulator = _mm512_fmadd_ps(values, values, accumulator);
+  }
+  float result = _mm512_reduce_add_ps(accumulator);
+  for (; index < dim; ++index) {
+    const float value = load_scalar<scalar_t>(data, offset + index);
+    result += value * value;
+  }
+  return result;
+}
+#endif
+
+template <typename scalar_t>
+float squared_norm(
+    void const *data,
+    std::int64_t offset,
+    std::int64_t dim,
+    ActivationIsa isa) {
+#if defined(__x86_64__) || defined(_M_X64)
+  if (isa == ActivationIsa::Avx512) {
+#if defined(_MSC_VER)
+    constexpr auto scalar_kind = std::is_same_v<scalar_t, float>
+        ? orbitquant::cpu::ScalarKind::Float32
+        : std::is_same_v<scalar_t, c10::Half>
+        ? orbitquant::cpu::ScalarKind::Float16
+        : orbitquant::cpu::ScalarKind::BFloat16;
+    return orbitquant::cpu::activation_squared_norm_msvc_avx2(
+        data, scalar_kind, offset, dim);
+#else
+    return squared_norm_avx512<scalar_t>(data, offset, dim);
+#endif
+  }
+  if (isa == ActivationIsa::Avx2) {
+#if defined(_MSC_VER)
+    constexpr auto scalar_kind = std::is_same_v<scalar_t, float>
+        ? orbitquant::cpu::ScalarKind::Float32
+        : std::is_same_v<scalar_t, c10::Half>
+        ? orbitquant::cpu::ScalarKind::Float16
+        : orbitquant::cpu::ScalarKind::BFloat16;
+    return orbitquant::cpu::activation_squared_norm_msvc_avx2(
+        data, scalar_kind, offset, dim);
+#else
+    return squared_norm_avx2<scalar_t>(data, offset, dim);
+#endif
+  }
+#endif
+#if defined(__aarch64__) || defined(_M_ARM64)
+  if (isa == ActivationIsa::Neon) {
+    return squared_norm_neon<scalar_t>(data, offset, dim);
+  }
+#endif
+  return squared_norm_scalar<scalar_t>(data, offset, dim);
+}
+
+inline std::int64_t nearest_centroid(
+    float value,
+    float const *boundaries,
+    std::int64_t boundary_count) {
+  std::int64_t low = 0;
+  std::int64_t high = boundary_count;
+  while (low < high) {
+    const std::int64_t middle = low + (high - low) / 2;
+    if (value <= boundaries[middle]) {
+      high = middle;
+    } else {
+      low = middle + 1;
+    }
+  }
+  return low;
+}
+
+template <typename scalar_t>
+void quantize_lookup_scalar(
+    ActivationArgs const &args,
+    float const *scratch,
+    std::int64_t output_offset,
+    float norm,
+    std::int64_t start = 0) {
+  for (std::int64_t index = start; index < args.dim; ++index) {
+    const float direction = scratch[index] * args.inv_sqrt_block;
+    const std::int64_t centroid_index =
+        nearest_centroid(direction, args.boundaries, args.boundary_count);
+    store_scalar<scalar_t>(
+        args.out,
+        output_offset + index,
+        args.centroids[centroid_index] * norm);
+  }
+}
+
+#if (defined(__x86_64__) || defined(_M_X64)) && !defined(_MSC_VER)
+ORBITQUANT_TARGET_AVX2 inline __m128i float8_to_bfloat8(__m256 values) {
+  const __m256i bits = _mm256_castps_si256(values);
+  const __m256i absolute_bits =
+      _mm256_and_si256(bits, _mm256_set1_epi32(0x7fffffff));
+  const __m256i nan_mask =
+      _mm256_cmpgt_epi32(absolute_bits, _mm256_set1_epi32(0x7f800000));
+  const __m256i rounding = _mm256_add_epi32(
+      _mm256_set1_epi32(0x7fff),
+      _mm256_and_si256(_mm256_srli_epi32(bits, 16), _mm256_set1_epi32(1)));
+  const __m256i upper = _mm256_srli_epi32(
+      _mm256_add_epi32(bits, rounding),
+      16);
+  __m128i packed = _mm_packus_epi32(
+      _mm256_castsi256_si128(upper),
+      _mm256_extracti128_si256(upper, 1));
+  const __m128i packed_nan_mask = _mm_packs_epi32(
+      _mm256_castsi256_si128(nan_mask),
+      _mm256_extracti128_si256(nan_mask, 1));
+  packed = _mm_blendv_epi8(
+      packed,
+      _mm_set1_epi16(0x7fc0),
+      packed_nan_mask);
+  return packed;
+}
+
+ORBITQUANT_TARGET_AVX512 inline __m256i float16_to_bfloat16(__m512 values) {
+  const __m512i bits = _mm512_castps_si512(values);
+  const __m512i absolute_bits =
+      _mm512_and_si512(bits, _mm512_set1_epi32(0x7fffffff));
+  const __mmask16 nan_mask = _mm512_cmp_epu32_mask(
+      absolute_bits,
+      _mm512_set1_epi32(0x7f800000),
+      _MM_CMPINT_GT);
+  const __m512i rounding = _mm512_add_epi32(
+      _mm512_set1_epi32(0x7fff),
+      _mm512_and_si512(_mm512_srli_epi32(bits, 16), _mm512_set1_epi32(1)));
+  const __m512i upper = _mm512_srli_epi32(
+      _mm512_add_epi32(bits, rounding),
+      16);
+  return _mm256_mask_mov_epi16(
+      _mm512_cvtepi32_epi16(upper),
+      nan_mask,
+      _mm256_set1_epi16(0x7fc0));
+}
+
+template <typename scalar_t>
+ORBITQUANT_TARGET_AVX2 void quantize_lookup_avx2(
+    ActivationArgs const &args,
+    float const *scratch,
+    std::int64_t output_offset,
+    float norm) {
+  const __m256 inverse_sqrt_block = _mm256_set1_ps(args.inv_sqrt_block);
+  const __m256 output_norm = _mm256_set1_ps(norm);
+  const __m256i ones = _mm256_set1_epi32(1);
+  std::int64_t index = 0;
+  for (; index + 8 <= args.dim; index += 8) {
+    const __m256 direction = _mm256_mul_ps(
+        _mm256_loadu_ps(scratch + index), inverse_sqrt_block);
+    __m256i centroid_indices = _mm256_setzero_si256();
+    for (std::int64_t boundary = 0; boundary < args.boundary_count; ++boundary) {
+      const __m256 comparison = _mm256_cmp_ps(
+          direction,
+          _mm256_set1_ps(args.boundaries[boundary]),
+          _CMP_NLE_UQ);
+      centroid_indices = _mm256_add_epi32(
+          centroid_indices,
+          _mm256_and_si256(_mm256_castps_si256(comparison), ones));
+    }
+    const __m256 output = _mm256_mul_ps(
+        _mm256_i32gather_ps(args.centroids, centroid_indices, 4), output_norm);
+    if constexpr (std::is_same_v<scalar_t, float>) {
+      _mm256_storeu_ps(
+          static_cast<float *>(args.out) + output_offset + index,
+          output);
+    } else if constexpr (std::is_same_v<scalar_t, c10::Half>) {
+      _mm_storeu_si128(
+          reinterpret_cast<__m128i *>(
+              static_cast<std::uint16_t *>(args.out) + output_offset + index),
+          _mm256_cvtps_ph(output, _MM_FROUND_TO_NEAREST_INT));
+    } else {
+      _mm_storeu_si128(
+          reinterpret_cast<__m128i *>(
+              static_cast<std::uint16_t *>(args.out) + output_offset + index),
+          float8_to_bfloat8(output));
+    }
+  }
+  quantize_lookup_scalar<scalar_t>(args, scratch, output_offset, norm, index);
+}
+
+template <typename scalar_t>
+ORBITQUANT_TARGET_AVX512 void quantize_lookup_avx512(
+    ActivationArgs const &args,
+    float const *scratch,
+    std::int64_t output_offset,
+    float norm) {
+  const __m512 inverse_sqrt_block = _mm512_set1_ps(args.inv_sqrt_block);
+  const __m512 output_norm = _mm512_set1_ps(norm);
+  const __m512i ones = _mm512_set1_epi32(1);
+  std::int64_t index = 0;
+  for (; index + 16 <= args.dim; index += 16) {
+    const __m512 direction = _mm512_mul_ps(
+        _mm512_loadu_ps(scratch + index), inverse_sqrt_block);
+    __m512i centroid_indices = _mm512_setzero_si512();
+    for (std::int64_t boundary = 0; boundary < args.boundary_count; ++boundary) {
+      const __mmask16 comparison = _mm512_cmp_ps_mask(
+          direction,
+          _mm512_set1_ps(args.boundaries[boundary]),
+          _CMP_NLE_UQ);
+      centroid_indices = _mm512_mask_add_epi32(
+          centroid_indices,
+          comparison,
+          centroid_indices,
+          ones);
+    }
+    const __m512 output = _mm512_mul_ps(
+        _mm512_i32gather_ps(centroid_indices, args.centroids, 4),
+        output_norm);
+    if constexpr (std::is_same_v<scalar_t, float>) {
+      _mm512_storeu_ps(
+          static_cast<float *>(args.out) + output_offset + index,
+          output);
+    } else if constexpr (std::is_same_v<scalar_t, c10::Half>) {
+      _mm256_storeu_si256(
+          reinterpret_cast<__m256i *>(
+              static_cast<std::uint16_t *>(args.out) + output_offset + index),
+          _mm512_cvtps_ph(output, _MM_FROUND_TO_NEAREST_INT));
+    } else {
+      _mm256_storeu_si256(
+          reinterpret_cast<__m256i *>(
+              static_cast<std::uint16_t *>(args.out) + output_offset + index),
+          float16_to_bfloat16(output));
+    }
+  }
+  quantize_lookup_scalar<scalar_t>(args, scratch, output_offset, norm, index);
+}
+#endif
+
+template <typename scalar_t>
+void quantize_lookup(
+    ActivationArgs const &args,
+    float const *scratch,
+    std::int64_t output_offset,
+    float norm,
+    ActivationIsa isa) {
+#if defined(__x86_64__) || defined(_M_X64)
+  if (isa == ActivationIsa::Avx512) {
+#if defined(_MSC_VER)
+    orbitquant::cpu::activation_quantize_lookup_msvc_avx2(
+        args, scratch, output_offset, norm);
+#else
+    quantize_lookup_avx512<scalar_t>(args, scratch, output_offset, norm);
+#endif
+    return;
+  }
+  if (isa == ActivationIsa::Avx2) {
+#if defined(_MSC_VER)
+    orbitquant::cpu::activation_quantize_lookup_msvc_avx2(
+        args, scratch, output_offset, norm);
+#else
+    quantize_lookup_avx2<scalar_t>(args, scratch, output_offset, norm);
+#endif
+    return;
+  }
+#endif
+  quantize_lookup_scalar<scalar_t>(args, scratch, output_offset, norm);
+}
+
+template <typename scalar_t>
+void quantize_activation_range(
+    ActivationArgs const &args,
+    std::int64_t row_start,
+    std::int64_t row_end) {
+  std::vector<float> scratch(static_cast<std::size_t>(args.dim));
+  for (std::int64_t row = row_start; row < row_end; ++row) {
+    const std::int64_t input_offset = row * args.dim;
+    const float norm_squared =
+        squared_norm<scalar_t>(args.x, input_offset, args.dim, args.isa);
+    const float norm = std::sqrt(norm_squared);
+    const float inverse_norm = 1.0f / (norm + args.eps);
+    for (std::int64_t index = 0; index < args.dim; ++index) {
+      const float value = load_scalar<scalar_t>(
+          args.x,
+          input_offset + args.permutation[index]);
+      scratch[index] = value * static_cast<float>(args.signs[index]) * inverse_norm;
+    }
+    for (std::int64_t block = 0; block < args.dim; block += args.block_size) {
+      fwht_block(scratch.data() + block, args.block_size, args.isa);
+    }
+    quantize_lookup<scalar_t>(
+        args,
+        scratch.data(),
+        input_offset,
+        norm,
+        args.isa);
+  }
+}
+
+void quantize_activation_dispatch(
+    ActivationArgs const &args,
+    std::int64_t row_start,
+    std::int64_t row_end) {
+  switch (args.scalar_kind) {
+    case orbitquant::cpu::ScalarKind::Float32:
+      quantize_activation_range<float>(args, row_start, row_end);
+      return;
+    case orbitquant::cpu::ScalarKind::Float16:
+      quantize_activation_range<c10::Half>(args, row_start, row_end);
+      return;
+    case orbitquant::cpu::ScalarKind::BFloat16:
+      quantize_activation_range<c10::BFloat16>(args, row_start, row_end);
+      return;
+  }
+}
+
+void parallel_quantize_activations(ActivationArgs const &args) {
+  const std::int64_t values = args.rows * args.dim;
+  const int threads = values < 16'384
+      ? 1
+      : std::max<int>(
+            1,
+            std::min<std::int64_t>(
+                orbitquant::cpu::requested_threads(),
+                args.rows));
+  if (threads == 1) {
+    quantize_activation_dispatch(args, 0, args.rows);
+    return;
+  }
+
+  std::vector<std::thread> workers;
+  workers.reserve(threads);
+  const std::int64_t rows_per_thread = (args.rows + threads - 1) / threads;
+  for (int thread = 0; thread < threads; ++thread) {
+    const std::int64_t start = thread * rows_per_thread;
+    const std::int64_t end = std::min(args.rows, start + rows_per_thread);
+    if (start >= end) {
+      break;
+    }
+    workers.emplace_back([&args, start, end] {
+      quantize_activation_dispatch(args, start, end);
+    });
+  }
+  for (auto &worker : workers) {
+    worker.join();
+  }
+}
+
+}  // namespace
+
+void quantize_activations_cpu(
+    OrbitQuantTensor &out,
+    OrbitQuantTensor const &x,
+    OrbitQuantTensor const &permutation,
+    OrbitQuantTensor const &signs,
+    OrbitQuantTensor const &centroids,
+    OrbitQuantTensor const &boundaries,
+    double eps,
+    double inv_sqrt_block,
+    int64_t block_size) {
+  using torch::headeronly::DeviceType;
+  using torch::headeronly::ScalarType;
+
+  STD_TORCH_CHECK(x.device().type() == DeviceType::CPU, "x must be a CPU tensor");
+  STD_TORCH_CHECK(out.device().type() == DeviceType::CPU, "out must be a CPU tensor");
+  STD_TORCH_CHECK(
+      permutation.device().type() == DeviceType::CPU,
+      "permutation must be a CPU tensor");
+  STD_TORCH_CHECK(signs.device().type() == DeviceType::CPU, "signs must be a CPU tensor");
+  STD_TORCH_CHECK(
+      centroids.device().type() == DeviceType::CPU,
+      "centroids must be a CPU tensor");
+  STD_TORCH_CHECK(
+      boundaries.device().type() == DeviceType::CPU,
+      "boundaries must be a CPU tensor");
+  STD_TORCH_CHECK(x.is_contiguous(), "x must be contiguous");
+  STD_TORCH_CHECK(out.is_contiguous(), "out must be contiguous");
+  STD_TORCH_CHECK(permutation.is_contiguous(), "permutation must be contiguous");
+  STD_TORCH_CHECK(signs.is_contiguous(), "signs must be contiguous");
+  STD_TORCH_CHECK(centroids.is_contiguous(), "centroids must be contiguous");
+  STD_TORCH_CHECK(boundaries.is_contiguous(), "boundaries must be contiguous");
+  STD_TORCH_CHECK(out.scalar_type() == x.scalar_type(), "out dtype must match x dtype");
+  STD_TORCH_CHECK(
+      permutation.scalar_type() == ScalarType::Long,
+      "permutation must be int64");
+  STD_TORCH_CHECK(signs.scalar_type() == ScalarType::Char, "signs must be int8");
+  STD_TORCH_CHECK(centroids.scalar_type() == ScalarType::Float, "centroids must be float32");
+  STD_TORCH_CHECK(boundaries.scalar_type() == ScalarType::Float, "boundaries must be float32");
+  STD_TORCH_CHECK(x.dim() == 2, "x must be rank 2");
+  STD_TORCH_CHECK(out.dim() == 2, "out must be rank 2");
+  STD_TORCH_CHECK(out.size(0) == x.size(0), "out row count must match x");
+  STD_TORCH_CHECK(out.size(1) == x.size(1), "out dimension must match x");
+  const int64_t dim = x.size(1);
+  STD_TORCH_CHECK(permutation.numel() == dim, "permutation must match the input dimension");
+  STD_TORCH_CHECK(signs.numel() == dim, "signs must match the input dimension");
+  STD_TORCH_CHECK(
+      centroids.numel() == boundaries.numel() + 1,
+      "centroids must contain exactly one more value than boundaries");
+  STD_TORCH_CHECK(centroids.numel() >= 2, "at least two centroids are required");
+  STD_TORCH_CHECK(block_size > 0, "block_size must be positive");
+  STD_TORCH_CHECK(
+      (block_size & (block_size - 1)) == 0,
+      "block_size must be a power of two");
+  STD_TORCH_CHECK(dim % block_size == 0, "block_size must divide the input dimension");
+  STD_TORCH_CHECK(eps >= 0.0, "eps must be non-negative");
+  STD_TORCH_CHECK(inv_sqrt_block > 0.0, "inv_sqrt_block must be positive");
+
+  const auto *permutation_values = permutation.const_data_ptr<std::int64_t>();
+  const auto *sign_values = signs.const_data_ptr<std::int8_t>();
+  for (int64_t index = 0; index < dim; ++index) {
+    STD_TORCH_CHECK(
+        permutation_values[index] >= 0 && permutation_values[index] < dim,
+        "permutation contains an out-of-range index");
+    STD_TORCH_CHECK(
+        sign_values[index] == -1 || sign_values[index] == 1,
+        "signs must contain only -1 and 1");
+  }
+  if (x.numel() == 0) {
+    return;
+  }
+
+  const ActivationArgs args{
+      out.mutable_data_ptr(),
+      x.const_data_ptr(),
+      permutation_values,
+      sign_values,
+      centroids.const_data_ptr<float>(),
+      boundaries.const_data_ptr<float>(),
+      activation_scalar_kind(x),
+      select_activation_isa(),
+      x.size(0),
+      dim,
+      boundaries.numel(),
+      block_size,
+      static_cast<float>(eps),
+      static_cast<float>(inv_sqrt_block),
+  };
+  parallel_quantize_activations(args);
+}

--- a/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
+++ b/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Prepare kernel-builder output for a platform wheel build."
+    )
+    parser.add_argument("project", type=Path)
+    parser.add_argument("--version", required=True)
+    args = parser.parse_args()
+
+    pyproject = args.project / "pyproject.toml"
+    text = pyproject.read_text(encoding="utf-8")
+
+    old_version = 'version = "0.1.0"'
+    if text.count(old_version) != 1:
+        raise RuntimeError("generated pyproject must contain one stub version")
+    text = text.replace(old_version, f'version = "{args.version}"', 1)
+
+    requires_python = 'requires-python = ">=3.9"'
+    if text.count(requires_python) != 1:
+        raise RuntimeError("generated pyproject must contain one Python requirement")
+    text = text.replace(
+        requires_python,
+        f'{requires_python}\ndependencies = ["torch>=2.11"]',
+        1,
+    )
+    pyproject.write_text(text, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/native-kernels/orbitquant-packed-matmul/tests/test_packed_matmul.py
+++ b/native-kernels/orbitquant-packed-matmul/tests/test_packed_matmul.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
+import platform
+
 import pytest
 import torch
 from orbitquant_packed_matmul import (
+    matmul_packed_adaln_int4_cpu,
     matmul_packed_w4a4_int8,
     matmul_packed_weight,
+    quantize_activations_cpu,
     quantize_activations_int8,
     quantize_activations_packed_w4,
+    supports_cpu_activation,
+    supports_cpu_adaln,
+    supports_device,
 )
 
 
@@ -24,15 +31,17 @@ def _pack(values: torch.Tensor, bits: int) -> torch.Tensor:
 
 
 def _device() -> str:
-    if torch.cuda.is_available():
+    if supports_device("cuda") and torch.cuda.is_available():
         return "cuda"
-    if torch.backends.mps.is_available():
+    if supports_device("mps") and torch.backends.mps.is_available():
         return "mps"
-    pytest.skip("CUDA or MPS is required")
+    if supports_device("cpu"):
+        return "cpu"
+    pytest.skip("the built variant has no runnable backend")
 
 
 def _mps_device() -> str:
-    if not torch.backends.mps.is_available():
+    if not supports_device("mps") or not torch.backends.mps.is_available():
         pytest.skip("MPS is required")
     return "mps"
 
@@ -47,14 +56,215 @@ def _mps_bfloat16_device() -> str:
 
 
 def _cuda_device() -> str:
-    if not torch.cuda.is_available():
+    if not supports_device("cuda") or not torch.cuda.is_available():
         pytest.skip("CUDA is required")
     return "cuda"
+
+
+def _runnable_cpu_isas() -> list[str]:
+    machine = platform.machine().lower()
+    capability = torch.backends.cpu.get_cpu_capability().upper()
+    isas = ["scalar"]
+    if machine in {"x86_64", "amd64"} and capability in {"AVX2", "AVX512"}:
+        isas.append("avx2")
+    if machine in {"x86_64", "amd64"} and capability == "AVX512":
+        isas.append("avx512")
+    if machine in {"aarch64", "arm64"}:
+        isas.append("neon")
+    return isas
 
 
 def _row_norms(device: str, out_features: int) -> torch.Tensor:
     dtype = torch.bfloat16 if device == "cuda" else torch.float32
     return torch.linspace(0.5, 1.5, out_features, device=device, dtype=dtype)
+
+
+def _fwht_reference(values: torch.Tensor) -> torch.Tensor:
+    output = values.clone()
+    half = 1
+    while half < output.shape[-1]:
+        blocks = output.reshape(*output.shape[:-1], -1, 2 * half)
+        left = blocks[..., :half].clone()
+        right = blocks[..., half:].clone()
+        blocks[..., :half] = left + right
+        blocks[..., half:] = left - right
+        half *= 2
+    return output
+
+
+@pytest.mark.kernels_ci
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_quantize_activations_cpu_matches_independent_reference(dtype: torch.dtype) -> None:
+    if not supports_cpu_activation():
+        pytest.skip("the built variant has no native CPU activation pipeline")
+    torch.manual_seed(41)
+    dim = 24
+    block_size = 8
+    x = torch.randn(2, 3, dim, dtype=dtype)
+    x[0, 0].zero_()
+    permutation = torch.randperm(dim)
+    signs = torch.randint(0, 2, (dim,), dtype=torch.int8).mul(2).sub(1)
+    centroids = torch.tanh(torch.linspace(-1.7, 1.7, 16))
+    boundaries = (centroids[:-1] + centroids[1:]) / 2
+    eps = 1e-10
+
+    work = x.float()
+    norms = work.norm(dim=-1, keepdim=True)
+    unit = work / (norms + eps)
+    gathered = unit.index_select(-1, permutation) * signs.float()
+    rotated = _fwht_reference(gathered.reshape(2, 3, 3, block_size)) / block_size**0.5
+    rotated = rotated.reshape_as(work)
+    indices = (rotated.unsqueeze(-1) - centroids).abs().argmin(dim=-1)
+    expected = (centroids[indices] * norms).to(dtype)
+
+    actual = quantize_activations_cpu(
+        x,
+        permutation,
+        signs,
+        centroids,
+        boundaries,
+        eps=eps,
+        inv_sqrt_block=block_size**-0.5,
+        block_size=block_size,
+    )
+
+    torch.testing.assert_close(actual, expected, atol=2e-3, rtol=2e-3)
+    assert torch.equal(actual[0, 0], torch.zeros(dim, dtype=dtype))
+
+
+@pytest.mark.kernels_ci
+def test_cpu_runtime_isa_dispatch_matches_scalar_reference(monkeypatch) -> None:
+    if not supports_device("cpu") or not supports_cpu_activation():
+        pytest.skip("the built variant has no complete native CPU pipeline")
+    torch.manual_seed(43)
+    rows = 8
+    in_features = 64
+    out_features = 11
+    x = torch.randn(rows, in_features)
+    indices = torch.randint(0, 16, (out_features, in_features), dtype=torch.uint8)
+    packed = _pack(indices, 4)
+    row_norms = torch.linspace(0.5, 1.5, out_features)
+    centroids = torch.tanh(torch.linspace(-1.7, 1.7, 16))
+    boundaries = (centroids[:-1] + centroids[1:]) / 2
+    bias = torch.randn(out_features)
+    permutation = torch.randperm(in_features)
+    signs = torch.randint(0, 2, (in_features,), dtype=torch.int8).mul(2).sub(1)
+
+    outputs = {}
+    activations = {}
+    for isa in _runnable_cpu_isas():
+        monkeypatch.setenv("ORBITQUANT_CPU_ISA", isa)
+        activations[isa] = quantize_activations_cpu(
+            x,
+            permutation,
+            signs,
+            centroids,
+            boundaries,
+            eps=1e-10,
+            inv_sqrt_block=in_features**-0.5,
+            block_size=in_features,
+        )
+        outputs[isa] = matmul_packed_weight(
+            activations[isa],
+            packed,
+            row_norms,
+            centroids,
+            bits=4,
+            out_features=out_features,
+            in_features=in_features,
+            bias=bias,
+        )
+
+    for isa in _runnable_cpu_isas()[1:]:
+        torch.testing.assert_close(
+            activations[isa], activations["scalar"], atol=2e-6, rtol=2e-6
+        )
+        torch.testing.assert_close(outputs[isa], outputs["scalar"], atol=2e-5, rtol=2e-5)
+
+
+@pytest.mark.kernels_ci
+@pytest.mark.parametrize("group_size", [8, 64])
+@pytest.mark.parametrize("with_bias", [False, True])
+def test_matmul_packed_adaln_cpu_matches_independent_bf16_reference(
+    group_size: int,
+    with_bias: bool,
+) -> None:
+    if not supports_cpu_adaln():
+        pytest.skip("the built variant has no native CPU AdaLN kernel")
+    torch.manual_seed(47)
+    in_features = 65
+    out_features = 9
+    num_groups = (in_features + group_size - 1) // group_size
+    padded_in_features = num_groups * group_size
+    indices = torch.randint(
+        0,
+        16,
+        (out_features, num_groups, group_size),
+        dtype=torch.uint8,
+    )
+    indices.reshape(out_features, padded_in_features)[:, in_features:] = 8
+    packed = _pack(indices, 4)
+    scales = torch.rand(out_features, num_groups, dtype=torch.bfloat16).mul(0.1)
+    x = torch.randn(2, 3, in_features, dtype=torch.bfloat16)
+    bias = torch.randn(out_features, dtype=torch.bfloat16) if with_bias else None
+
+    signed = indices.to(torch.int16).sub(8).float()
+    weight = (signed * scales.float()[..., None]).reshape(
+        out_features, padded_in_features
+    )[:, :in_features]
+    expected = torch.nn.functional.linear(x, weight.to(torch.bfloat16), bias)
+    actual = matmul_packed_adaln_int4_cpu(
+        x,
+        packed,
+        scales,
+        out_features=out_features,
+        in_features=in_features,
+        group_size=group_size,
+        bias=bias,
+    )
+
+    assert actual.dtype == torch.bfloat16
+    assert actual.shape == (2, 3, out_features)
+    torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.kernels_ci
+def test_cpu_adaln_runtime_isa_dispatch_matches_scalar_reference(monkeypatch) -> None:
+    if not supports_cpu_adaln():
+        pytest.skip("the built variant has no native CPU AdaLN kernel")
+    torch.manual_seed(53)
+    rows = 8
+    in_features = 64
+    out_features = 11
+    group_size = 64
+    indices = torch.randint(
+        0,
+        16,
+        (out_features, 1, group_size),
+        dtype=torch.uint8,
+    )
+    packed = _pack(indices, 4)
+    scales = torch.rand(out_features, 1, dtype=torch.bfloat16).mul(0.1)
+    x = torch.randn(rows, in_features, dtype=torch.bfloat16)
+    bias = torch.randn(out_features, dtype=torch.bfloat16)
+
+    outputs = {}
+    for isa in _runnable_cpu_isas():
+        monkeypatch.setenv("ORBITQUANT_CPU_ISA", isa)
+        outputs[isa] = matmul_packed_adaln_int4_cpu(
+            x,
+            packed,
+            scales,
+            out_features=out_features,
+            in_features=in_features,
+            group_size=group_size,
+            bias=bias,
+        )
+
+    for isa in _runnable_cpu_isas()[1:]:
+        torch.testing.assert_close(
+            outputs[isa], outputs["scalar"], atol=3e-2, rtol=3e-2
+        )
 
 
 @pytest.mark.kernels_ci
@@ -113,6 +323,7 @@ def test_matmul_packed_weight_short_sequence_matches_reference(
     in_features: int,
     out_features: int,
 ) -> None:
+    torch.manual_seed(1000 + bits * 100 + rows * 10 + in_features + out_features)
     device = _device()
     dtype = torch.float16 if device == "mps" else torch.bfloat16
     x = torch.randn(rows, in_features, device=device, dtype=dtype)
@@ -123,7 +334,16 @@ def test_matmul_packed_weight_short_sequence_matches_reference(
     bias = torch.randn(out_features, device=device, dtype=dtype)
 
     expected_weight = row_norms.cpu()[:, None] * centroids.cpu()[indices.long()]
-    expected = torch.nn.functional.linear(x.float().cpu(), expected_weight, bias.float().cpu())
+    if device == "cpu":
+        expected = torch.nn.functional.linear(
+            x.cpu(),
+            expected_weight.to(torch.bfloat16),
+            bias.cpu(),
+        ).float()
+    else:
+        expected = torch.nn.functional.linear(
+            x.float().cpu(), expected_weight, bias.float().cpu()
+        )
     actual = matmul_packed_weight(
         x,
         packed,

--- a/native-kernels/orbitquant-packed-matmul/torch-ext/orbitquant_packed_matmul/__init__.py
+++ b/native-kernels/orbitquant-packed-matmul/torch-ext/orbitquant_packed_matmul/__init__.py
@@ -6,10 +6,103 @@ from ._ops import ops
 
 __all__ = [
     "matmul_packed_w4a4_int8",
+    "matmul_packed_adaln_int4_cpu",
     "matmul_packed_weight",
+    "quantize_activations_cpu",
     "quantize_activations_int8",
     "quantize_activations_packed_w4",
+    "supports_cpu_activation",
+    "supports_cpu_adaln",
+    "supports_device",
 ]
+
+
+def supports_device(device_type: str) -> bool:
+    dispatch_keys = {
+        "cpu": "CPU",
+        "cuda": "CUDA",
+        "mps": "MPS",
+    }
+    try:
+        dispatch_key = dispatch_keys[device_type]
+    except KeyError as exc:
+        raise ValueError(f"unknown device type {device_type!r}") from exc
+    return bool(
+        torch._C._dispatch_has_kernel_for_dispatch_key(  # noqa: SLF001
+            ops.matmul_packed_weight._qualified_op_name,  # noqa: SLF001
+            dispatch_key,
+        )
+    )
+
+
+def supports_cpu_activation() -> bool:
+    try:
+        operation = ops.quantize_activations_cpu
+        qualified_name = operation._qualified_op_name  # noqa: SLF001
+    except (AttributeError, RuntimeError):
+        return False
+    return bool(
+        torch._C._dispatch_has_kernel_for_dispatch_key(  # noqa: SLF001
+            qualified_name,
+            "CPU",
+        )
+    )
+
+
+def supports_cpu_adaln() -> bool:
+    try:
+        operation = ops.matmul_packed_adaln_int4_cpu
+        qualified_name = operation._qualified_op_name  # noqa: SLF001
+    except (AttributeError, RuntimeError):
+        return False
+    return bool(
+        torch._C._dispatch_has_kernel_for_dispatch_key(  # noqa: SLF001
+            qualified_name,
+            "CPU",
+        )
+    )
+
+
+def quantize_activations_cpu(
+    x: torch.Tensor,
+    permutation: torch.Tensor,
+    signs: torch.Tensor,
+    centroids: torch.Tensor,
+    boundaries: torch.Tensor,
+    *,
+    eps: float,
+    inv_sqrt_block: float,
+    block_size: int,
+) -> torch.Tensor:
+    if x.device.type != "cpu":
+        raise RuntimeError("native CPU activation quantization requires CPU tensors")
+    if x.dtype not in {torch.float32, torch.float16, torch.bfloat16}:
+        raise ValueError("x must be float32, float16, or bfloat16")
+    if block_size <= 0 or block_size & (block_size - 1):
+        raise ValueError("block_size must be a positive power of two")
+    dim = x.shape[-1]
+    if dim % block_size != 0:
+        raise ValueError("block_size must divide the input dimension")
+
+    original_shape = x.shape
+    values = x.contiguous().reshape(-1, dim)
+    out = torch.empty_like(values)
+    permutation_values = permutation.to(device="cpu", dtype=torch.int64).contiguous()
+    sign_values = signs.to(device="cpu", dtype=torch.int8).contiguous()
+    centroid_values = centroids.to(device="cpu", dtype=torch.float32).contiguous()
+    boundary_values = boundaries.to(device="cpu", dtype=torch.float32).contiguous()
+    ops.quantize_activations_cpu(
+        out,
+        values,
+        permutation_values,
+        sign_values,
+        centroid_values,
+        boundary_values,
+        eps,
+        inv_sqrt_block,
+        block_size,
+    )
+    return out.reshape(original_shape)
 
 
 def matmul_packed_weight(
@@ -62,6 +155,50 @@ def matmul_packed_weight(
         block_m,
         block_n,
         block_k,
+    )
+    return out.reshape(*original_shape[:-1], out_features)
+
+
+def matmul_packed_adaln_int4_cpu(
+    x: torch.Tensor,
+    packed_weight: torch.Tensor,
+    scales: torch.Tensor,
+    *,
+    out_features: int,
+    in_features: int,
+    group_size: int,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if x.device.type != "cpu":
+        raise RuntimeError("native packed AdaLN requires CPU tensors")
+    if x.shape[-1] != in_features:
+        raise ValueError(f"expected input last dimension {in_features}, got {x.shape[-1]}")
+    if group_size <= 0:
+        raise ValueError("group_size must be positive")
+
+    original_shape = x.shape
+    x_2d = x.to(dtype=torch.bfloat16).contiguous().reshape(-1, in_features)
+    out = torch.empty((x_2d.shape[0], out_features), dtype=torch.bfloat16)
+    packed = packed_weight.to(device="cpu", dtype=torch.uint8).contiguous()
+    scale_values = scales.to(device="cpu", dtype=torch.float32).contiguous()
+    if bias is None:
+        bias_values = torch.empty((1,), dtype=torch.float32)
+        has_bias = False
+    else:
+        bias_values = (
+            bias.to(device="cpu", dtype=torch.bfloat16).to(dtype=torch.float32).contiguous()
+        )
+        has_bias = True
+    ops.matmul_packed_adaln_int4_cpu(
+        out,
+        x_2d,
+        packed,
+        scale_values,
+        bias_values,
+        has_bias,
+        out_features,
+        in_features,
+        group_size,
     )
     return out.reshape(*original_shape[:-1], out_features)
 

--- a/native-kernels/orbitquant-packed-matmul/torch-ext/torch_binding.cpp
+++ b/native-kernels/orbitquant-packed-matmul/torch-ext/torch_binding.cpp
@@ -1,7 +1,33 @@
-#include <torch/library.h>
-
 #include "registration.h"
 #include "torch_binding.h"
+
+#if defined(CPU_KERNEL)
+#include <torch/csrc/stable/library.h>
+
+STABLE_TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
+  ops.def(
+      "matmul_packed_weight(Tensor! out, Tensor x, Tensor packed_weight_indices, "
+      "Tensor row_norms, Tensor centroids, Tensor bias, bool has_bias, int bits, "
+      "int out_features, int in_features, int block_m, int block_n, int block_k) -> ()");
+  ops.def(
+      "quantize_activations_cpu(Tensor! out, Tensor x, Tensor permutation, "
+      "Tensor signs, Tensor centroids, Tensor boundaries, float eps, "
+      "float inv_sqrt_block, int block_size) -> ()");
+  ops.def(
+      "matmul_packed_adaln_int4_cpu(Tensor! out, Tensor x, Tensor packed_weight, "
+      "Tensor scales, Tensor bias, bool has_bias, int out_features, "
+      "int in_features, int group_size) -> ()");
+}
+
+STABLE_TORCH_LIBRARY_IMPL_EXPAND(TORCH_EXTENSION_NAME, CPU, ops) {
+  ops.impl("matmul_packed_weight", TORCH_BOX(&matmul_packed_weight));
+  ops.impl("quantize_activations_cpu", TORCH_BOX(&quantize_activations_cpu));
+  ops.impl(
+      "matmul_packed_adaln_int4_cpu",
+      TORCH_BOX(&matmul_packed_adaln_int4_cpu));
+}
+#else
+#include <torch/library.h>
 
 TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.def(
@@ -38,5 +64,6 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.impl("matmul_packed_weight", torch::kMPS, &matmul_packed_weight);
 #endif
 }
+#endif
 
 REGISTER_EXTENSION(TORCH_EXTENSION_NAME)

--- a/native-kernels/orbitquant-packed-matmul/torch-ext/torch_binding.h
+++ b/native-kernels/orbitquant-packed-matmul/torch-ext/torch_binding.h
@@ -1,14 +1,20 @@
 #pragma once
 
+#if defined(CPU_KERNEL)
+#include <torch/csrc/stable/tensor.h>
+using OrbitQuantTensor = torch::stable::Tensor;
+#else
 #include <torch/torch.h>
+using OrbitQuantTensor = torch::Tensor;
+#endif
 
 void matmul_packed_weight(
-    torch::Tensor &out,
-    torch::Tensor const &x,
-    torch::Tensor const &packed_weight_indices,
-    torch::Tensor const &row_norms,
-    torch::Tensor const &centroids,
-    torch::Tensor const &bias,
+    OrbitQuantTensor &out,
+    OrbitQuantTensor const &x,
+    OrbitQuantTensor const &packed_weight_indices,
+    OrbitQuantTensor const &row_norms,
+    OrbitQuantTensor const &centroids,
+    OrbitQuantTensor const &bias,
     bool has_bias,
     int64_t bits,
     int64_t out_features,
@@ -16,6 +22,30 @@ void matmul_packed_weight(
     int64_t block_m,
     int64_t block_n,
     int64_t block_k);
+
+#if defined(CPU_KERNEL)
+void quantize_activations_cpu(
+    OrbitQuantTensor &out,
+    OrbitQuantTensor const &x,
+    OrbitQuantTensor const &permutation,
+    OrbitQuantTensor const &signs,
+    OrbitQuantTensor const &centroids,
+    OrbitQuantTensor const &boundaries,
+    double eps,
+    double inv_sqrt_block,
+    int64_t block_size);
+
+void matmul_packed_adaln_int4_cpu(
+    OrbitQuantTensor &out,
+    OrbitQuantTensor const &x,
+    OrbitQuantTensor const &packed_weight,
+    OrbitQuantTensor const &scales,
+    OrbitQuantTensor const &bias,
+    bool has_bias,
+    int64_t out_features,
+    int64_t in_features,
+    int64_t group_size);
+#endif
 
 #if defined(CUDA_KERNEL)
 void matmul_packed_w4a4_int8(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ eval = [
   "pillow>=11.0",
 ]
 dev = [
+  "psutil>=7.0",
   "pytest>=8.4",
   "pytest-xdist>=3.8",
   "ruff>=0.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "orbitquant"
-version = "0.3.1"
+version = "0.4.0"
 description = "Calibration-free OrbitQuant for transformer linear projections"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/measure_streaming_load_memory.py
+++ b/scripts/measure_streaming_load_memory.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import psutil
+
+_RESULT_PREFIX = "ORBITQUANT_LOAD_RESULT="
+
+
+def _dtype(name: str):
+    import torch
+
+    return {
+        "bfloat16": torch.bfloat16,
+        "float16": torch.float16,
+        "float32": torch.float32,
+    }[name]
+
+
+def _tensor_bytes(tensor: Any) -> int:
+    if tensor is None or getattr(tensor, "device", None) is None:
+        return 0
+    if tensor.device.type == "meta":
+        return 0
+    return int(tensor.numel() * tensor.element_size())
+
+
+def _module_metrics(module: Any) -> dict[str, int]:
+    state_bytes = sum(_tensor_bytes(tensor) for tensor in module.state_dict().values())
+    cache_bytes = sum(
+        _tensor_bytes(getattr(child, "_dequantized_weight_cache", None))
+        for child in module.modules()
+    )
+    quantizer = getattr(module, "hf_quantizer", None)
+    return {
+        "resident_state_bytes": state_bytes,
+        "full_dequantized_cache_bytes": cache_bytes,
+        "streamed_source_tensor_bytes": int(
+            getattr(quantizer, "released_source_tensor_bytes", 0)
+        ),
+        "source_page_release_failures": int(
+            getattr(quantizer, "source_page_release_failures", 0)
+        ),
+    }
+
+
+def _worker(spec: dict[str, Any]) -> dict[str, Any]:
+    import torch
+
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats()
+
+    framework = spec["framework"]
+    mode = spec["mode"]
+    model_id = spec["model_id"]
+    if mode != "baseline":
+        import orbitquant  # noqa: F401
+
+    common: dict[str, Any] = {
+        "revision": spec.get("revision"),
+        "variant": spec.get("variant"),
+        "local_files_only": spec.get("local_files_only", False),
+        "trust_remote_code": spec.get("trust_remote_code", False),
+        "torch_dtype": _dtype(spec["torch_dtype"]),
+    }
+    common = {key: value for key, value in common.items() if value is not None}
+
+    started_at = time.perf_counter()
+    if framework == "transformers":
+        from transformers import AutoModel
+
+        if mode == "streaming":
+            from orbitquant import OrbitQuantConfig
+
+            common["quantization_config"] = OrbitQuantConfig(
+                target_policy=spec["target_policy"],
+                weight_row_tile_size=spec["weight_row_tile_size"],
+            )
+            common["low_cpu_mem_usage"] = True
+            common["use_safetensors"] = True
+        model = AutoModel.from_pretrained(model_id, **common)
+        metrics = _module_metrics(model)
+    else:
+        from diffusers import DiffusionPipeline
+
+        if mode == "streaming":
+            from orbitquant import (
+                OrbitQuantConfig,
+                build_diffusers_pipeline_quantization_config,
+            )
+
+            common["quantization_config"] = build_diffusers_pipeline_quantization_config(
+                OrbitQuantConfig(
+                    target_policy=spec["target_policy"],
+                    weight_row_tile_size=spec["weight_row_tile_size"],
+                ),
+                components=spec["component"],
+            )
+            common["use_safetensors"] = True
+        model = DiffusionPipeline.from_pretrained(model_id, **common)
+        modules = [
+            value
+            for value in model.components.values()
+            if isinstance(value, torch.nn.Module)
+        ]
+        metrics = {
+            "resident_state_bytes": sum(
+                _module_metrics(item)["resident_state_bytes"] for item in modules
+            ),
+            "full_dequantized_cache_bytes": sum(
+                _module_metrics(item)["full_dequantized_cache_bytes"] for item in modules
+            ),
+            "streamed_source_tensor_bytes": sum(
+                _module_metrics(item)["streamed_source_tensor_bytes"] for item in modules
+            ),
+            "source_page_release_failures": sum(
+                _module_metrics(item)["source_page_release_failures"] for item in modules
+            ),
+        }
+
+    metrics["load_wall_seconds"] = time.perf_counter() - started_at
+    metrics["torch_cuda_allocated_peak_bytes"] = (
+        int(torch.cuda.max_memory_allocated()) if torch.cuda.is_available() else None
+    )
+    metrics["torch_cuda_reserved_peak_bytes"] = (
+        int(torch.cuda.max_memory_reserved()) if torch.cuda.is_available() else None
+    )
+    return metrics
+
+
+class _NvmlSampler:
+    def __init__(self) -> None:
+        self.error: str | None = None
+        self._nvml = None
+        self._handles: list[Any] = []
+        try:
+            import pynvml
+
+            pynvml.nvmlInit()
+            self._nvml = pynvml
+            self._handles = [
+                pynvml.nvmlDeviceGetHandleByIndex(index)
+                for index in range(pynvml.nvmlDeviceGetCount())
+            ]
+        except Exception as exc:
+            self.error = str(exc)
+
+    def sample(self, pid: int) -> int | None:
+        if self._nvml is None:
+            return None
+        total = 0
+        for handle in self._handles:
+            process_lists = []
+            for name in (
+                "nvmlDeviceGetComputeRunningProcesses",
+                "nvmlDeviceGetGraphicsRunningProcesses",
+            ):
+                try:
+                    process_lists.append(getattr(self._nvml, name)(handle))
+                except Exception:
+                    continue
+            for processes in process_lists:
+                total += sum(
+                    int(process.usedGpuMemory)
+                    for process in processes
+                    if process.pid == pid and process.usedGpuMemory is not None
+                )
+        return total
+
+
+def _run_clean_worker(spec: dict[str, Any], poll_interval: float) -> dict[str, Any]:
+    command = [sys.executable, str(Path(__file__).resolve()), "--worker-spec", json.dumps(spec)]
+    process = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env={**os.environ, "PYTHONUNBUFFERED": "1"},
+    )
+    observed = psutil.Process(process.pid)
+    peak_rss = 0
+    peak_vms = 0
+    peak_nvml: int | None = None
+    nvml = _NvmlSampler()
+    while process.poll() is None:
+        try:
+            memory = observed.memory_info()
+            peak_rss = max(peak_rss, int(memory.rss))
+            peak_vms = max(peak_vms, int(memory.vms))
+            sample = nvml.sample(process.pid)
+            if sample is not None:
+                peak_nvml = max(peak_nvml or 0, sample)
+        except psutil.NoSuchProcess:
+            break
+        time.sleep(poll_interval)
+    stdout, stderr = process.communicate()
+    if process.returncode != 0:
+        raise RuntimeError(
+            f"{spec['mode']} worker failed with exit {process.returncode}:\n{stderr}"
+        )
+    result_lines = [line for line in stdout.splitlines() if line.startswith(_RESULT_PREFIX)]
+    if len(result_lines) != 1:
+        raise RuntimeError(
+            f"worker emitted no unique result line; stdout:\n{stdout}\nstderr:\n{stderr}"
+        )
+    result = json.loads(result_lines[0].removeprefix(_RESULT_PREFIX))
+    result.update(
+        {
+            "cpu_rss_peak_bytes": peak_rss,
+            "virtual_memory_peak_bytes": peak_vms,
+            "nvml_process_peak_bytes": peak_nvml,
+            "nvml_unavailable_reason": nvml.error,
+        }
+    )
+    return result
+
+
+def _resolve_local_snapshot(model_id: str, revision: str | None) -> Path | None:
+    path = Path(model_id).expanduser()
+    if path.exists():
+        return path.resolve()
+    try:
+        from huggingface_hub import snapshot_download
+
+        return Path(
+            snapshot_download(
+                model_id,
+                revision=revision,
+                local_files_only=True,
+            )
+        )
+    except Exception:
+        return None
+
+
+def _disk_size(path: Path | None) -> int | None:
+    if path is None:
+        return None
+    return sum(item.stat().st_size for item in path.rglob("*") if item.is_file())
+
+
+def _safetensors_stats(path: Path | None) -> dict[str, int | None]:
+    if path is None:
+        return {"source_tensor_bytes": None, "largest_source_tensor_bytes": None}
+    from safetensors import safe_open
+
+    dtype_sizes = {
+        "BOOL": 1,
+        "F8_E4M3": 1,
+        "F8_E5M2": 1,
+        "I8": 1,
+        "U8": 1,
+        "BF16": 2,
+        "F16": 2,
+        "I16": 2,
+        "U16": 2,
+        "F32": 4,
+        "I32": 4,
+        "U32": 4,
+        "F64": 8,
+        "I64": 8,
+        "U64": 8,
+    }
+
+    total = 0
+    largest = 0
+    for checkpoint in path.rglob("*.safetensors"):
+        with safe_open(checkpoint, framework="pt", device="cpu") as handle:
+            for key in handle.keys():  # noqa: SIM118 - safe_open is not iterable
+                tensor_slice = handle.get_slice(key)
+                element_size = dtype_sizes[tensor_slice.get_dtype()]
+                size = element_size
+                for dimension in tensor_slice.get_shape():
+                    size *= dimension
+                total += size
+                largest = max(largest, size)
+    return {
+        "source_tensor_bytes": total,
+        "largest_source_tensor_bytes": largest,
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compare clean-process baseline, streaming, and prequantized load peaks."
+    )
+    parser.add_argument("--framework", choices=("transformers", "diffusers"))
+    parser.add_argument("--model-id")
+    parser.add_argument("--prequantized-model-id")
+    parser.add_argument("--revision")
+    parser.add_argument("--variant")
+    parser.add_argument("--component", default="transformer")
+    parser.add_argument(
+        "--torch-dtype",
+        choices=("bfloat16", "float16", "float32"),
+        default="bfloat16",
+    )
+    parser.add_argument("--target-policy", default="auto")
+    parser.add_argument("--weight-row-tile-size", type=int, default=256)
+    parser.add_argument("--poll-interval", type=float, default=0.01)
+    parser.add_argument("--local-files-only", action="store_true")
+    parser.add_argument("--trust-remote-code", action="store_true")
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--worker-spec", help=argparse.SUPPRESS)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    if args.worker_spec is not None:
+        print(_RESULT_PREFIX + json.dumps(_worker(json.loads(args.worker_spec)), sort_keys=True))
+        return
+    if not args.framework or not args.model_id or not args.prequantized_model_id:
+        raise SystemExit("--framework, --model-id, and --prequantized-model-id are required")
+    if args.weight_row_tile_size <= 0 or args.poll_interval <= 0:
+        raise SystemExit("tile size and poll interval must be positive")
+
+    common = {
+        "framework": args.framework,
+        "revision": args.revision,
+        "variant": args.variant,
+        "component": args.component,
+        "torch_dtype": args.torch_dtype,
+        "target_policy": args.target_policy,
+        "weight_row_tile_size": args.weight_row_tile_size,
+        "local_files_only": args.local_files_only,
+        "trust_remote_code": args.trust_remote_code,
+    }
+    results = {}
+    for mode, model_id in (
+        ("baseline", args.model_id),
+        ("streaming", args.model_id),
+        ("prequantized", args.prequantized_model_id),
+    ):
+        results[mode] = _run_clean_worker(
+            {**common, "mode": mode, "model_id": model_id},
+            args.poll_interval,
+        )
+        snapshot = _resolve_local_snapshot(model_id, args.revision)
+        results[mode]["disk_artifact_bytes"] = _disk_size(snapshot)
+        results[mode].update(_safetensors_stats(snapshot))
+
+    results["comparison"] = {
+        "streaming_rss_reduction_vs_baseline_bytes": (
+            results["baseline"]["cpu_rss_peak_bytes"]
+            - results["streaming"]["cpu_rss_peak_bytes"]
+        ),
+        "prequantized_rss_reduction_vs_baseline_bytes": (
+            results["baseline"]["cpu_rss_peak_bytes"]
+            - results["prequantized"]["cpu_rss_peak_bytes"]
+        ),
+        "rss_and_virtual_memory_reported_separately": True,
+    }
+    payload = json.dumps(results, indent=2, sort_keys=True) + "\n"
+    if args.output is None:
+        print(payload, end="")
+    else:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_hf_compat_checks.sh
+++ b/scripts/run_hf_compat_checks.sh
@@ -54,6 +54,9 @@ DEFAULT_TESTS=(
   "tests/test_pipeline_helpers.py"
   "tests/test_diffusers_modelmixin_integration.py"
   "tests/test_transformers_pretrained_integration.py"
+  "tests/test_offload_integration.py"
+  "tests/test_streaming_quantization.py"
+  "tests/test_universal_transformers.py"
 )
 
 compat_tests=("${DEFAULT_TESTS[@]}")
@@ -193,7 +196,7 @@ prepare_venv() {
     install_with_python \
       "$python_path" \
       "diffusers>=0.35" \
-      "transformers>=4.53" \
+      "transformers>=5.0,<6" \
       "accelerate>=1.8" \
       "huggingface_hub>=0.33" \
       "safetensors>=0.5" \

--- a/src/orbitquant/__init__.py
+++ b/src/orbitquant/__init__.py
@@ -18,7 +18,7 @@ from orbitquant.pipeline import (
 from orbitquant.quantizer import register_hf_quantizers
 from orbitquant.recipes import recipe
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"
 
 register_hf_quantizers()
 

--- a/src/orbitquant/adaln.py
+++ b/src/orbitquant/adaln.py
@@ -7,6 +7,7 @@ from torch.nn import functional as F
 from orbitquant.config import OrbitQuantConfig
 from orbitquant.linear_adapters import canonical_linear_weight, linear_module_spec
 from orbitquant.packing import pack_lowbit, unpack_lowbit
+from orbitquant.streaming import accelerate_hook_offloads, iter_aligned_row_tiles
 
 
 def _packed_length(value_count: int, bits: int) -> int:
@@ -49,8 +50,60 @@ def _quantize_adaln_weight(
     return _quantize_adaln_weight_reference(weight, group_size=group_size)
 
 
+def _quantize_adaln_weight_bounded(
+    weight: torch.Tensor,
+    *,
+    group_size: int,
+    row_tile_size: int,
+    quantization_device: torch.device | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if weight.ndim != 2:
+        raise ValueError("weight must be a matrix")
+    out_features, in_features = weight.shape
+    num_groups = (in_features + group_size - 1) // group_size
+    padded_values_per_row = num_groups * group_size
+    output_device = weight.device
+    work_device = output_device if quantization_device is None else quantization_device
+    packed = torch.empty(
+        _packed_length(out_features * padded_values_per_row, 4),
+        dtype=torch.uint8,
+        device=output_device,
+    )
+    scales_output = torch.empty(
+        out_features,
+        num_groups,
+        dtype=torch.bfloat16,
+        device=output_device,
+    )
+    packed_offset = 0
+    for row_start, row_end in iter_aligned_row_tiles(
+        out_features,
+        padded_values_per_row,
+        4,
+        row_tile_size,
+    ):
+        tile = weight[row_start:row_end].to(device=work_device)
+        packed_tile, scales = _quantize_adaln_weight(tile, group_size=group_size)
+        packed_end = packed_offset + packed_tile.numel()
+        packed[packed_offset:packed_end].copy_(packed_tile.to(device=output_device))
+        scales_output[row_start:row_end].copy_(
+            scales.to(device=output_device, dtype=torch.bfloat16)
+        )
+        packed_offset = packed_end
+    if packed_offset != packed.numel():
+        raise RuntimeError(
+            f"row-tiled packing wrote {packed_offset} bytes, expected {packed.numel()}"
+        )
+    return packed, scales_output
+
+
 class RTNInt4Linear(nn.Module):
     """Symmetric INT4 round-to-nearest linear used for AdaLN modulation weights."""
+
+    def __setattr__(self, name, value):
+        super().__setattr__(name, value)
+        if name == "_hf_hook" and accelerate_hook_offloads(self):
+            self.clear_dequantized_cache()
 
     def __init__(
         self,
@@ -71,8 +124,8 @@ class RTNInt4Linear(nn.Module):
         self.module_name = module_name
         self.source_weight_layout = source_weight_layout
         self.num_groups = (in_features + group_size - 1) // group_size
-        self.register_buffer("packed_weight", packed_weight)
-        self.register_buffer("scales", scales)
+        self.packed_weight = nn.Parameter(packed_weight, requires_grad=False)
+        self.scales = nn.Parameter(scales, requires_grad=False)
         if bias is None:
             self.register_parameter("bias", None)
         else:
@@ -84,6 +137,16 @@ class RTNInt4Linear(nn.Module):
         self._dequantized_weight_cache = None
         self._dequantized_weight_cache_key = None
 
+    def _remember_dequantized_weight(
+        self,
+        weight: torch.Tensor,
+        cache_key: tuple[str, torch.dtype],
+    ) -> torch.Tensor:
+        if not accelerate_hook_offloads(self):
+            self._dequantized_weight_cache = weight.detach()
+            self._dequantized_weight_cache_key = cache_key
+        return weight
+
     @classmethod
     def from_linear(
         cls, layer: nn.Module, *, config: OrbitQuantConfig, module_name: str
@@ -91,25 +154,62 @@ class RTNInt4Linear(nn.Module):
         spec = linear_module_spec(layer)
         if spec is None:
             raise TypeError(f"no OrbitQuant linear adapter registered for {type(layer).__name__}")
-        group_size = config.adaln_group_size
-        weight = canonical_linear_weight(layer).detach().to(torch.float32)
-        packed, scales = _quantize_adaln_weight(weight, group_size=group_size)
+        weight = canonical_linear_weight(layer).detach()
         source_bias = getattr(layer, "bias", None)
         bias = None if source_bias is None else source_bias.detach()
-        return cls(
+        return cls.from_weight(
+            weight,
+            bias=bias,
             in_features=spec.in_features,
             out_features=spec.out_features,
+            source_weight_layout=spec.weight_layout,
+            config=config,
+            module_name=module_name,
+        )
+
+    @classmethod
+    def from_weight(
+        cls,
+        weight: torch.Tensor,
+        *,
+        bias: torch.Tensor | None,
+        in_features: int,
+        out_features: int,
+        source_weight_layout: str,
+        config: OrbitQuantConfig,
+        module_name: str,
+        quantization_device: torch.device | None = None,
+    ) -> RTNInt4Linear:
+        expected_shape = (out_features, in_features)
+        if tuple(weight.shape) != expected_shape:
+            raise ValueError(
+                f"expected canonical weight shape {expected_shape}, got {tuple(weight.shape)}"
+            )
+        group_size = config.adaln_group_size
+        packed, scales = _quantize_adaln_weight_bounded(
+            weight,
+            group_size=group_size,
+            row_tile_size=config.weight_row_tile_size,
+            quantization_device=quantization_device,
+        )
+        return cls(
+            in_features=in_features,
+            out_features=out_features,
             group_size=group_size,
             module_name=module_name,
-            source_weight_layout=spec.weight_layout,
+            source_weight_layout=source_weight_layout,
             packed_weight=packed,
-            scales=scales.to(torch.bfloat16),
+            scales=scales,
             bias=bias,
         )
 
     @classmethod
     def empty_from_linear(
-        cls, layer: nn.Module, *, config: OrbitQuantConfig, module_name: str
+        cls,
+        layer: nn.Module,
+        *,
+        config: OrbitQuantConfig,
+        module_name: str,
     ) -> RTNInt4Linear:
         spec = linear_module_spec(layer)
         if spec is None:
@@ -144,7 +244,8 @@ class RTNInt4Linear(nn.Module):
     def _dequantize_weight(self, *, device: torch.device, dtype: torch.dtype) -> torch.Tensor:
         cache_key = (str(device), dtype)
         if (
-            self._dequantized_weight_cache is not None
+            not accelerate_hook_offloads(self)
+            and self._dequantized_weight_cache is not None
             and self._dequantized_weight_cache_key == cache_key
         ):
             return self._dequantized_weight_cache
@@ -164,9 +265,7 @@ class RTNInt4Linear(nn.Module):
                     device=device,
                 )
                 dequantized = weight.to(dtype=dtype)
-                self._dequantized_weight_cache = dequantized.detach()
-                self._dequantized_weight_cache_key = cache_key
-                return dequantized
+                return self._remember_dequantized_weight(dequantized, cache_key)
 
         total = self.out_features * self.num_groups * self.group_size
         unsigned = unpack_lowbit(self.packed_weight, bits=4, length=total).to(device=device)
@@ -178,9 +277,7 @@ class RTNInt4Linear(nn.Module):
         )
         weight = weight[:, : self.in_features]
         dequantized = weight.to(device=device, dtype=dtype)
-        self._dequantized_weight_cache = dequantized.detach()
-        self._dequantized_weight_cache_key = cache_key
-        return dequantized
+        return self._remember_dequantized_weight(dequantized, cache_key)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         activation = x.to(torch.bfloat16)

--- a/src/orbitquant/adaln.py
+++ b/src/orbitquant/adaln.py
@@ -58,6 +58,7 @@ class RTNInt4Linear(nn.Module):
         in_features: int,
         out_features: int,
         group_size: int,
+        runtime_mode: str,
         module_name: str,
         source_weight_layout: str,
         packed_weight: torch.Tensor,
@@ -68,6 +69,7 @@ class RTNInt4Linear(nn.Module):
         self.in_features = in_features
         self.out_features = out_features
         self.group_size = group_size
+        self.runtime_mode = runtime_mode
         self.module_name = module_name
         self.source_weight_layout = source_weight_layout
         self.num_groups = (in_features + group_size - 1) // group_size
@@ -79,6 +81,7 @@ class RTNInt4Linear(nn.Module):
             self.bias = nn.Parameter(bias.detach().clone(), requires_grad=False)
         self._dequantized_weight_cache: torch.Tensor | None = None
         self._dequantized_weight_cache_key: tuple[str, torch.dtype] | None = None
+        self.last_effective_runtime_mode: str | None = None
 
     def clear_dequantized_cache(self) -> None:
         self._dequantized_weight_cache = None
@@ -100,6 +103,7 @@ class RTNInt4Linear(nn.Module):
             in_features=spec.in_features,
             out_features=spec.out_features,
             group_size=group_size,
+            runtime_mode=config.runtime_mode,
             module_name=module_name,
             source_weight_layout=spec.weight_layout,
             packed_weight=packed,
@@ -134,6 +138,7 @@ class RTNInt4Linear(nn.Module):
             in_features=spec.in_features,
             out_features=spec.out_features,
             group_size=group_size,
+            runtime_mode=config.runtime_mode,
             module_name=module_name,
             source_weight_layout=spec.weight_layout,
             packed_weight=packed,
@@ -184,6 +189,44 @@ class RTNInt4Linear(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         activation = x.to(torch.bfloat16)
+        if x.device.type == "cpu" and self.runtime_mode in {
+            "auto_fused",
+            "native_packed_matmul",
+        }:
+            try:
+                from orbitquant.kernels.native_packed_matmul import (
+                    matmul_packed_adaln_int4_with_native_cpu_kernel,
+                    native_cpu_adaln_available,
+                )
+
+                native_available = native_cpu_adaln_available()
+            except Exception as exc:
+                if self.runtime_mode == "native_packed_matmul":
+                    raise RuntimeError(
+                        "native_packed_matmul AdaLN on CPU requires a current "
+                        "orbitquant_packed_matmul CPU package with the INT4 group "
+                        "kernel; install/build it or use runtime_mode='dequant_bf16'."
+                    ) from exc
+                native_available = False
+            if native_available:
+                self.last_effective_runtime_mode = "native_packed_adaln_int4"
+                return matmul_packed_adaln_int4_with_native_cpu_kernel(
+                    activation,
+                    self.packed_weight,
+                    self.scales,
+                    out_features=self.out_features,
+                    in_features=self.in_features,
+                    group_size=self.group_size,
+                    bias=self.bias,
+                )
+            if self.runtime_mode == "native_packed_matmul":
+                raise RuntimeError(
+                    "the loaded orbitquant_packed_matmul CPU package has no packed "
+                    "AdaLN INT4 kernel; build a current variant or use "
+                    "runtime_mode='dequant_bf16'."
+                )
+
+        self.last_effective_runtime_mode = "dequant_bf16"
         weight = self._dequantize_weight(device=x.device, dtype=torch.bfloat16)
         bias = None if self.bias is None else self.bias.to(device=x.device, dtype=torch.bfloat16)
         return F.linear(activation, weight, bias)

--- a/src/orbitquant/artifacts/model_card.py
+++ b/src/orbitquant/artifacts/model_card.py
@@ -66,7 +66,7 @@ def _install_snippet() -> str:
     return "\n".join(
         [
             "```bash",
-            "pip install \"orbitquant[hf,kernels]>=0.2.0\"",
+            "pip install \"orbitquant[hf,kernels]>=0.3.1\"",
             "```",
         ]
     )
@@ -146,6 +146,33 @@ def _usage_snippet(source_model_id: str, bits: str) -> str:
         ]
     )
     return "\n".join(lines)
+
+
+def _on_the_fly_conversion_snippet(source_model_id: str) -> str:
+    return "\n".join(
+        [
+            "```python",
+            "import torch",
+            "import orbitquant",
+            "from diffusers import DiffusionPipeline",
+            "from orbitquant import (",
+            "    OrbitQuantConfig,",
+            "    build_diffusers_pipeline_quantization_config,",
+            ")",
+            "",
+            "qconfig = build_diffusers_pipeline_quantization_config(",
+            "    OrbitQuantConfig(target_policy=\"auto\"),",
+            "    components=\"transformer\",",
+            ")",
+            "pipe = DiffusionPipeline.from_pretrained(",
+            f'    "{source_model_id}",',
+            "    quantization_config=qconfig,",
+            "    torch_dtype=torch.bfloat16,",
+            ")",
+            "pipe.enable_model_cpu_offload()",
+            "```",
+        ]
+    )
 
 
 def _native_settings_section(source_model_id: str) -> list[str]:
@@ -509,6 +536,15 @@ def render_model_card(
             "",
             _usage_snippet(data["source_model_id"], bits),
             "",
+            "### Convert the source checkpoint on load",
+            "",
+            "For a safetensors source checkpoint, OrbitQuant can row-stream the "
+            "denoiser into packed weights through the normal Diffusers loader. "
+            "Use sequential offload by replacing the final call with "
+            "`pipe.enable_sequential_cpu_offload()`.",
+            "",
+            _on_the_fly_conversion_snippet(data["source_model_id"]),
+            "",
             "`runtime_mode=\"auto_fused\"` is the default optimized runtime. On "
             "CUDA, the `kernels` extra provides the Triton packed fallback; a "
             "locally built native CUDA package is preferred automatically when "
@@ -570,6 +606,9 @@ def render_model_card(
             "",
             "- This is a transformer-component artifact; load it into the source "
             "pipeline as shown above.",
+            "- Guaranteed on-the-fly bounded-memory conversion requires a "
+            "safetensors source checkpoint. Unknown architectures have structural "
+            "coverage only and require policy inspection plus quality validation.",
             "- CUDA and MPS `auto_fused` inference requires a packed matmul kernel "
             "and fails loudly when the required kernel is unavailable. The explicit "
             "`dequant_bf16` reference mode materializes dequantized weights before "

--- a/src/orbitquant/artifacts/model_card.py
+++ b/src/orbitquant/artifacts/model_card.py
@@ -66,7 +66,7 @@ def _install_snippet() -> str:
     return "\n".join(
         [
             "```bash",
-            "pip install \"orbitquant[hf,kernels]>=0.3.1\"",
+            "pip install \"orbitquant[hf,kernels]>=0.4.0\"",
             "```",
         ]
     )

--- a/src/orbitquant/checkpoint_streaming.py
+++ b/src/orbitquant/checkpoint_streaming.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import tempfile
+from dataclasses import dataclass
+from math import prod
+from pathlib import Path
+from typing import Any
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+from orbitquant.adaln import RTNInt4Linear
+from orbitquant.config import OrbitQuantConfig
+from orbitquant.layers import OrbitQuantLinear
+from orbitquant.linear_adapters import linear_module_spec
+
+_DTYPE_SIZES = {
+    "BF16": 2,
+    "F16": 2,
+    "F32": 4,
+    "F64": 8,
+}
+
+
+@dataclass(frozen=True)
+class StreamingCheckpoint:
+    directory: tempfile.TemporaryDirectory[str]
+    packed_file: Path
+    replaced_source_keys: tuple[str, ...]
+    source_tensor_bytes: int
+
+
+@dataclass(frozen=True)
+class StreamingConversion:
+    packed_state: dict[str, torch.Tensor]
+    replaced_source_keys: tuple[str, ...]
+    source_tensor_bytes: int
+
+
+class _SafetensorsCanonicalRows:
+    ndim = 2
+    device = torch.device("cpu")
+
+    def __init__(self, tensor_slice: Any, source_weight_layout: str) -> None:
+        source_shape = tuple(tensor_slice.get_shape())
+        self._slice = tensor_slice
+        self._source_weight_layout = source_weight_layout
+        self.shape = (
+            source_shape
+            if source_weight_layout == "out_in"
+            else (source_shape[1], source_shape[0])
+        )
+
+    def __getitem__(self, rows: slice) -> torch.Tensor:
+        if self._source_weight_layout == "out_in":
+            return self._slice[rows, :]
+        return self._slice[:, rows].transpose(0, 1)
+
+
+def _tensor_index(
+    checkpoint_files: list[Any],
+) -> dict[str, tuple[str, tuple[int, ...], int]]:
+    index: dict[str, tuple[str, tuple[int, ...], int]] = {}
+    for checkpoint_file in checkpoint_files:
+        path = str(checkpoint_file)
+        with safe_open(path, framework="pt", device="cpu") as handle:
+            for key in handle.keys():  # noqa: SIM118 - safe_open is not iterable
+                tensor_slice = handle.get_slice(key)
+                dtype = tensor_slice.get_dtype()
+                index[key] = (
+                    path,
+                    tuple(tensor_slice.get_shape()),
+                    _DTYPE_SIZES.get(dtype, 1),
+                )
+    return index
+
+
+def _convert_streaming_checkpoint(
+    model: torch.nn.Module,
+    config: OrbitQuantConfig,
+    checkpoint_files: list[Any],
+    *,
+    orbit_module_names: list[str],
+    adaln_module_names: list[str],
+    base_model_prefix: str,
+    quantization_device: torch.device | None,
+    apply_transformers_mapping: bool,
+) -> StreamingConversion:
+    """Convert selected safetensors rows with one source mapping open at a time."""
+
+    tensor_index = _tensor_index(checkpoint_files)
+    target_to_source = {key: key for key in tensor_index}
+    if apply_transformers_mapping:
+        from transformers.conversion_mapping import get_model_conversion_mapping
+        from transformers.core_model_loading import (
+            WeightConverter,
+            WeightRenaming,
+            rename_source_key,
+        )
+
+        model_conversions = get_model_conversion_mapping(model, hf_quantizer=None)
+        renamings = [item for item in model_conversions if isinstance(item, WeightRenaming)]
+        converters = [item for item in model_conversions if isinstance(item, WeightConverter)]
+        meta_state_dict = model.state_dict()
+        for source_key in tensor_index:
+            target_key, _ = rename_source_key(
+                source_key,
+                renamings,
+                converters,
+                base_model_prefix=getattr(model, "base_model_prefix", ""),
+                meta_state_dict=meta_state_dict,
+            )
+            target_to_source.setdefault(target_key, source_key)
+
+    packed_state: dict[str, torch.Tensor] = {}
+    replaced_source_keys: list[str] = []
+    source_tensor_bytes = 0
+
+    def source_key_for(module_name: str) -> str:
+        candidates = [f"{module_name}.weight"]
+        if base_model_prefix and module_name.startswith(f"{base_model_prefix}."):
+            candidates.append(
+                f"{module_name.removeprefix(f'{base_model_prefix}.')}.weight"
+            )
+        try:
+            return next(
+                target_to_source.get(key, key)
+                for key in candidates
+                if key in target_to_source or key in tensor_index
+            )
+        except StopIteration as exc:
+            raise RuntimeError(
+                f"OrbitQuant could not find a safetensors source for {module_name}.weight"
+            ) from exc
+
+    for module_name in orbit_module_names + adaln_module_names:
+        module = model.get_submodule(module_name)
+        source_key = source_key_for(module_name)
+        checkpoint_file, source_shape, element_size = tensor_index[source_key]
+        source_tensor_bytes += prod(source_shape) * element_size
+        spec = linear_module_spec(module)
+        if spec is None:
+            raise TypeError(f"no OrbitQuant linear adapter registered for {type(module).__name__}")
+        with torch.device("cpu"), safe_open(
+            checkpoint_file, framework="pt", device="cpu"
+        ) as handle:
+            weight = _SafetensorsCanonicalRows(
+                handle.get_slice(source_key),
+                spec.weight_layout,
+            )
+            if module_name in orbit_module_names:
+                quantized = OrbitQuantLinear.from_weight(
+                    weight,
+                    bias=None,
+                    in_features=weight.shape[1],
+                    out_features=weight.shape[0],
+                    source_weight_layout=spec.weight_layout,
+                    config=config,
+                    module_name=module_name,
+                    quantization_device=quantization_device,
+                )
+                if quantized.debug_weight is not None:
+                    packed_state[f"{module_name}.debug_weight"] = quantized.debug_weight.detach()
+                else:
+                    packed_state[f"{module_name}.packed_weight_indices"] = (
+                        quantized.packed_weight_indices.detach()
+                    )
+                    packed_state[f"{module_name}.row_norms"] = quantized.row_norms.detach()
+            else:
+                quantized = RTNInt4Linear.from_weight(
+                    weight,
+                    bias=None,
+                    in_features=weight.shape[1],
+                    out_features=weight.shape[0],
+                    source_weight_layout=spec.weight_layout,
+                    config=config,
+                    module_name=module_name,
+                    quantization_device=quantization_device,
+                )
+                packed_state[f"{module_name}.packed_weight"] = quantized.packed_weight.detach()
+                packed_state[f"{module_name}.scales"] = quantized.scales.detach()
+        replaced_source_keys.append(source_key)
+
+    return StreamingConversion(
+        packed_state=packed_state,
+        replaced_source_keys=tuple(replaced_source_keys),
+        source_tensor_bytes=source_tensor_bytes,
+    )
+
+
+def build_transformers_streaming_checkpoint(
+    model: torch.nn.Module,
+    config: OrbitQuantConfig,
+    checkpoint_files: list[Any],
+    *,
+    orbit_module_names: list[str],
+    adaln_module_names: list[str],
+    base_model_prefix: str,
+    quantization_device: torch.device | None,
+) -> StreamingCheckpoint:
+    conversion = _convert_streaming_checkpoint(
+        model,
+        config,
+        checkpoint_files,
+        orbit_module_names=orbit_module_names,
+        adaln_module_names=adaln_module_names,
+        base_model_prefix=base_model_prefix,
+        quantization_device=quantization_device,
+        apply_transformers_mapping=True,
+    )
+    directory = tempfile.TemporaryDirectory(prefix="orbitquant-streaming-")
+    packed_file = Path(directory.name) / "orbitquant-streaming.safetensors"
+    save_file(conversion.packed_state, packed_file, metadata={"format": "pt"})
+    return StreamingCheckpoint(
+        directory=directory,
+        packed_file=packed_file,
+        replaced_source_keys=conversion.replaced_source_keys,
+        source_tensor_bytes=conversion.source_tensor_bytes,
+    )
+
+
+def build_diffusers_streaming_conversion(
+    model: torch.nn.Module,
+    config: OrbitQuantConfig,
+    checkpoint_files: list[Any],
+    *,
+    orbit_module_names: list[str],
+    adaln_module_names: list[str],
+    quantization_device: torch.device | None,
+) -> StreamingConversion:
+    return _convert_streaming_checkpoint(
+        model,
+        config,
+        checkpoint_files,
+        orbit_module_names=orbit_module_names,
+        adaln_module_names=adaln_module_names,
+        base_model_prefix="",
+        quantization_device=quantization_device,
+        apply_transformers_mapping=False,
+    )
+
+
+__all__ = [
+    "StreamingCheckpoint",
+    "StreamingConversion",
+    "build_diffusers_streaming_conversion",
+    "build_transformers_streaming_checkpoint",
+]

--- a/src/orbitquant/config.py
+++ b/src/orbitquant/config.py
@@ -85,6 +85,7 @@ class OrbitQuantConfig(QuantizationConfigMixin):
     packed_matmul_block_n: int = 64
     packed_matmul_block_k: int = 128
     packed_matmul_num_warps: int = 4
+    weight_row_tile_size: int = 256
 
     def __post_init__(self) -> None:
         if self.weight_bits not in _SUPPORTED_BITS:
@@ -122,6 +123,7 @@ class OrbitQuantConfig(QuantizationConfigMixin):
             "packed_matmul_block_n",
             "packed_matmul_block_k",
             "packed_matmul_num_warps",
+            "weight_row_tile_size",
         ):
             if getattr(self, field_name) <= 0:
                 raise ValueError(f"{field_name} must be positive")

--- a/src/orbitquant/kernels/dispatch.py
+++ b/src/orbitquant/kernels/dispatch.py
@@ -12,6 +12,10 @@ BackendCapabilities = dict[str, dict[str, object]]
 _MPS_SHADER_STAGE = "activation_norm_rpbh_quant_rescale,packed_weight_dequant"
 _MPS_NATIVE_STAGE = "packed_weight_matmul"
 _MPS_IMPLEMENTED_STAGE = f"{_MPS_SHADER_STAGE},{_MPS_NATIVE_STAGE}"
+_CPU_IMPLEMENTED_STAGE = (
+    "activation_norm_rpbh_quant_rescale,packed_weight_matmul,"
+    "adaln_rtn_packed_matmul"
+)
 _TRITON_CUDA_IMPLEMENTED_STAGE = (
     "activation_norm_rpbh_quant_rescale,packed_weight_dequant,"
     "packed_weight_matmul,lowbit_pack,lowbit_unpack,weight_rotation_fwht_quant_pack,"
@@ -46,6 +50,39 @@ def _native_packed_matmul_available() -> bool:
     return True
 
 
+def _native_cpu_packed_matmul_available() -> bool:
+    try:
+        from orbitquant.kernels.native_packed_matmul import (
+            native_packed_matmul_device_available,
+        )
+
+        return native_packed_matmul_device_available("cpu")
+    except Exception:
+        return False
+
+
+def _native_cpu_activation_available() -> bool:
+    try:
+        from orbitquant.kernels.native_packed_matmul import (
+            native_cpu_activation_available,
+        )
+
+        return native_cpu_activation_available()
+    except Exception:
+        return False
+
+
+def _native_cpu_adaln_available() -> bool:
+    try:
+        from orbitquant.kernels.native_packed_matmul import (
+            native_cpu_adaln_available,
+        )
+
+        return native_cpu_adaln_available()
+    except Exception:
+        return False
+
+
 def _join_stages(stages: list[str]) -> str | None:
     return ",".join(stages) if stages else None
 
@@ -60,6 +97,63 @@ def available_backends() -> BackendAvailability:
 
 def backend_capabilities(backends: BackendAvailability | None = None) -> BackendCapabilities:
     available = available_backends() if backends is None else backends
+    cpu_native_matmul_optimized = bool(
+        available["cpu"] and _native_cpu_packed_matmul_available()
+    )
+    cpu_native_activation_optimized = bool(
+        available["cpu"] and _native_cpu_activation_available()
+    )
+    cpu_native_adaln_optimized = bool(
+        available["cpu"] and _native_cpu_adaln_available()
+    )
+    cpu_optimized_stages = _join_stages(
+        [
+            *(
+                ["activation_norm_rpbh_quant_rescale"]
+                if cpu_native_activation_optimized
+                else []
+            ),
+            *(["packed_weight_matmul"] if cpu_native_matmul_optimized else []),
+            *(
+                ["adaln_rtn_packed_matmul"]
+                if cpu_native_adaln_optimized
+                else []
+            ),
+        ]
+    )
+    cpu_implementation = (
+        "native_exact_activation+native_exact_packed_matmul"
+        if cpu_native_activation_optimized and cpu_native_matmul_optimized
+        else "native_exact_packed_matmul+torch_activation_reference"
+        if cpu_native_matmul_optimized
+        else "native_exact_activation+reference_weight_matmul"
+        if cpu_native_activation_optimized
+        else "torch_reference"
+    )
+    if cpu_native_adaln_optimized:
+        cpu_implementation += "+native_packed_adaln_int4"
+    cpu_notes = []
+    if cpu_native_activation_optimized:
+        cpu_notes.append(
+            "The native exact activation pipeline performs FP32 token norm, "
+            "RPBH/FWHT, codebook assignment, and rescale."
+        )
+    else:
+        cpu_notes.append("Activation quantization uses the reference PyTorch CPU path.")
+    if cpu_native_matmul_optimized:
+        cpu_notes.append(
+            "Native exact packed matmul consumes low-bit weights without a full "
+            "floating-point cache."
+        )
+    else:
+        cpu_notes.append("The main linear matmul uses the reference PyTorch CPU path.")
+    if cpu_native_adaln_optimized:
+        cpu_notes.append(
+            "Native packed INT4 AdaLN matmul consumes group-64 weights without a "
+            "full floating-point cache."
+        )
+    else:
+        cpu_notes.append("AdaLN uses the explicit BF16 dequantization path.")
     mps_shader_optimized = bool(available["mps"] and _mps_metal_available())
     mps_native_matmul_optimized = bool(
         available["mps"] and _native_packed_matmul_available()
@@ -98,22 +192,26 @@ def backend_capabilities(backends: BackendAvailability | None = None) -> Backend
     return {
         "cpu": {
             "available": bool(available["cpu"]),
-            "claim_status": "reference_only",
-            "optimized": False,
+            "claim_status": "partial_optimized"
+            if cpu_optimized_stages is not None
+            else "reference_only",
+            "optimized": cpu_optimized_stages is not None,
             "full_fusion": False,
-            "implemented_stage": None,
-            "optimized_stage": None,
+            "implemented_stage": _CPU_IMPLEMENTED_STAGE,
+            "optimized_stage": cpu_optimized_stages,
             "weight_dequant_optimized": False,
             "weight_pack_optimized": False,
             "lowbit_unpack_optimized": False,
             "weight_quant_optimized": False,
             "adaln_quant_optimized": False,
-            "adaln_dequant_optimized": False,
+            "adaln_dequant_optimized": cpu_native_adaln_optimized,
             "device_types": ["cpu"],
-            "implementation": "torch_reference",
-            "package_format": "torch_reference",
-            "hf_kernel_builder_compliant": False,
-            "notes": "Correctness baseline using the reference PyTorch path.",
+            "implementation": cpu_implementation,
+            "package_format": "native_kernel_package_torch_stable_abi"
+            if cpu_optimized_stages is not None
+            else "torch_reference",
+            "hf_kernel_builder_compliant": cpu_optimized_stages is not None,
+            "notes": " ".join(cpu_notes),
         },
         "mps": {
             "available": bool(available["mps"]),

--- a/src/orbitquant/kernels/native_packed_matmul.py
+++ b/src/orbitquant/kernels/native_packed_matmul.py
@@ -85,6 +85,94 @@ def load_native_packed_matmul_kernel() -> Any:
     return _load_native_packed_matmul_kernel()
 
 
+def native_packed_matmul_device_available(device_type: str) -> bool:
+    if device_type not in {"cpu", "cuda", "mps"}:
+        raise ValueError(f"unknown device type {device_type!r}")
+    kernel = _load_native_packed_matmul_kernel()
+    supports_device = getattr(kernel, "supports_device", None)
+    if callable(supports_device):
+        return bool(supports_device(device_type))
+    # Kernel variants built before CPU support did not expose capability
+    # introspection. They were CUDA- or Metal-only, never CPU variants.
+    return device_type in {"cuda", "mps"}
+
+
+def native_cpu_activation_available() -> bool:
+    kernel = _load_native_packed_matmul_kernel()
+    supports_cpu_activation = getattr(kernel, "supports_cpu_activation", None)
+    return callable(supports_cpu_activation) and bool(supports_cpu_activation())
+
+
+def native_cpu_adaln_available() -> bool:
+    kernel = _load_native_packed_matmul_kernel()
+    supports_cpu_adaln = getattr(kernel, "supports_cpu_adaln", None)
+    return callable(supports_cpu_adaln) and bool(supports_cpu_adaln())
+
+
+def quantize_activations_with_native_cpu_kernel(
+    x: torch.Tensor,
+    permutation: torch.Tensor,
+    signs: torch.Tensor,
+    centroids: torch.Tensor,
+    boundaries: torch.Tensor,
+    *,
+    eps: float,
+    inv_sqrt_block: float,
+    block_size: int,
+) -> torch.Tensor:
+    if x.device.type != "cpu":
+        raise RuntimeError("native CPU activation quantization requires CPU tensors")
+    kernel = _load_native_packed_matmul_kernel()
+    operation = getattr(kernel, "quantize_activations_cpu", None)
+    if not callable(operation) or not native_cpu_activation_available():
+        raise RuntimeError(
+            "the loaded native packed matmul package does not provide the CPU "
+            "activation pipeline. Build a current CPU variant or use the reference "
+            "activation backend."
+        )
+    return operation(
+        x,
+        permutation,
+        signs,
+        centroids,
+        boundaries,
+        eps=eps,
+        inv_sqrt_block=inv_sqrt_block,
+        block_size=block_size,
+    )
+
+
+def matmul_packed_adaln_int4_with_native_cpu_kernel(
+    x: torch.Tensor,
+    packed_weight: torch.Tensor,
+    scales: torch.Tensor,
+    *,
+    out_features: int,
+    in_features: int,
+    group_size: int,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if x.device.type != "cpu":
+        raise RuntimeError("native packed AdaLN requires CPU tensors")
+    kernel = _load_native_packed_matmul_kernel()
+    operation = getattr(kernel, "matmul_packed_adaln_int4_cpu", None)
+    if not callable(operation) or not native_cpu_adaln_available():
+        raise RuntimeError(
+            "the loaded native packed matmul package does not provide the CPU "
+            "AdaLN INT4 group kernel. Build a current CPU variant or use "
+            "runtime_mode='dequant_bf16'."
+        )
+    return operation(
+        x,
+        packed_weight,
+        scales,
+        out_features=out_features,
+        in_features=in_features,
+        group_size=group_size,
+        bias=bias,
+    )
+
+
 def native_packed_w4a4_available() -> bool:
     kernel = _load_native_packed_matmul_kernel()
     return callable(getattr(kernel, "matmul_packed_w4a4_int8", None))
@@ -114,14 +202,22 @@ def matmul_packed_weight_with_native_kernel(
     block_n: int = 64,
     block_k: int = 128,
 ) -> torch.Tensor:
-    if x.device.type not in {"cuda", "mps"}:
+    if x.device.type not in {"cpu", "cuda", "mps"}:
         raise RuntimeError(
-            f"native_packed_matmul runtime requires CUDA or MPS input tensors; got {x.device.type}."
+            "native_packed_matmul runtime requires CPU, CUDA, or MPS input tensors; "
+            f"got {x.device.type}."
         )
     if x.shape[-1] != in_features:
         raise ValueError(f"expected input last dimension {in_features}, got {x.shape[-1]}")
 
     kernel = _load_native_packed_matmul_kernel()
+    if not native_packed_matmul_device_available(x.device.type):
+        raise RuntimeError(
+            "the loaded native packed matmul package does not contain a "
+            f"{x.device.type.upper()} backend. Install or build a compatible variant, "
+            "or use runtime_mode='dequant_bf16'. "
+            f"{_runtime_variant_hint()}"
+        )
     centroids = codebook if isinstance(codebook, torch.Tensor) else codebook.centroids
     return kernel.matmul_packed_weight(
         x,

--- a/src/orbitquant/layers.py
+++ b/src/orbitquant/layers.py
@@ -13,6 +13,9 @@ from orbitquant.rotations import RPBHRotation, get_rpbh_rotation
 
 _PACKED_MATMUL_PROBE_MISSING = object()
 _NATIVE_PACKED_MATMUL_LOAD_ERROR: object | Exception | None = _PACKED_MATMUL_PROBE_MISSING
+_NATIVE_CPU_PACKED_MATMUL_LOAD_ERROR: object | Exception | None = (
+    _PACKED_MATMUL_PROBE_MISSING
+)
 _TRITON_PACKED_MATMUL_IMPORT_ERROR: object | Exception | None = _PACKED_MATMUL_PROBE_MISSING
 
 
@@ -119,18 +122,38 @@ def _triton_packed_matmul_import_error() -> Exception | None:
     return None
 
 
+def _native_cpu_packed_matmul_load_error() -> Exception | None:
+    global _NATIVE_CPU_PACKED_MATMUL_LOAD_ERROR
+    if _NATIVE_CPU_PACKED_MATMUL_LOAD_ERROR is not _PACKED_MATMUL_PROBE_MISSING:
+        return _NATIVE_CPU_PACKED_MATMUL_LOAD_ERROR
+    try:
+        from orbitquant.kernels.native_packed_matmul import (
+            native_packed_matmul_device_available,
+        )
+
+        if not native_packed_matmul_device_available("cpu"):
+            raise RuntimeError("the loaded native package has no CPU backend")
+    except Exception as exc:
+        _NATIVE_CPU_PACKED_MATMUL_LOAD_ERROR = exc
+        return exc
+    _NATIVE_CPU_PACKED_MATMUL_LOAD_ERROR = None
+    return None
+
+
 def _clear_packed_matmul_probe_cache() -> None:
+    global _NATIVE_CPU_PACKED_MATMUL_LOAD_ERROR
     global _NATIVE_PACKED_MATMUL_LOAD_ERROR, _TRITON_PACKED_MATMUL_IMPORT_ERROR
     _NATIVE_PACKED_MATMUL_LOAD_ERROR = _PACKED_MATMUL_PROBE_MISSING
+    _NATIVE_CPU_PACKED_MATMUL_LOAD_ERROR = _PACKED_MATMUL_PROBE_MISSING
     _TRITON_PACKED_MATMUL_IMPORT_ERROR = _PACKED_MATMUL_PROBE_MISSING
 
 
 class OrbitQuantLinear(nn.Module):
     """Linear layer with OrbitQuant-packed rotated weights.
 
-    The default runtime uses packed low-bit matmul on CUDA/MPS when the native
-    or Triton kernels are available. The explicit ``dequant_bf16`` mode keeps
-    the compatibility/debug reference path.
+    The default runtime uses packed low-bit matmul on CPU/CUDA/MPS when the
+    native or Triton kernels are available. The explicit ``dequant_bf16`` mode
+    keeps the compatibility/debug reference path.
     """
 
     def __init__(
@@ -330,7 +353,7 @@ class OrbitQuantLinear(nn.Module):
             row_norms = torch.empty(
                 spec.out_features, dtype=torch.bfloat16, device=layer.weight.device
             )
-        return cls(
+        empty = cls(
             in_features=spec.in_features,
             out_features=spec.out_features,
             config=config,
@@ -341,6 +364,11 @@ class OrbitQuantLinear(nn.Module):
             row_norms=row_norms,
             debug_weight=debug_weight,
         )
+        # Hugging Face streaming loaders may replace non-persistent buffers while
+        # moving an empty module skeleton out of meta initialization. Rebuild these
+        # deterministic RPBH/codebook constants on the first real forward.
+        empty._derived_constants_valid = False
+        return empty
 
     def clear_dequantized_cache(self) -> None:
         self._dequantized_weight_cache = None
@@ -414,9 +442,9 @@ class OrbitQuantLinear(nn.Module):
             )
 
     def _validate_native_packed_matmul_input(self, x: torch.Tensor) -> None:
-        if x.device.type not in {"cuda", "mps"}:
+        if x.device.type not in {"cpu", "cuda", "mps"}:
             raise RuntimeError(
-                "native_packed_matmul runtime requires CUDA or MPS input tensors; "
+                "native_packed_matmul runtime requires CPU, CUDA, or MPS input tensors; "
                 f"got {x.device.type}."
             )
 
@@ -442,6 +470,18 @@ class OrbitQuantLinear(nn.Module):
         except (ImportError, RuntimeError):
             return False
         return True
+
+    def _native_cpu_activation_available(self, x: torch.Tensor) -> bool:
+        if x.device.type != "cpu":
+            return False
+        try:
+            from orbitquant.kernels.native_packed_matmul import (
+                native_cpu_activation_available,
+            )
+
+            return native_cpu_activation_available()
+        except (ImportError, RuntimeError):
+            return False
 
     def _native_w4_activation_available(self, x: torch.Tensor) -> bool:
         if (
@@ -550,6 +590,8 @@ class OrbitQuantLinear(nn.Module):
     def _resolve_auto_fused_runtime(self, x: torch.Tensor) -> str:
         device_type = x.device.type
         if device_type == "cpu":
+            if _native_cpu_packed_matmul_load_error() is None:
+                return "native_packed_matmul"
             return "dequant_bf16"
         if device_type == "cuda":
             native_error = _native_packed_matmul_load_error()
@@ -810,6 +852,23 @@ class OrbitQuantLinear(nn.Module):
             rotated_x = (
                 self.rotation.apply_to_activations(work / (norms + self.activation_eps)) * norms
             ).to(x.dtype)
+        elif runtime_mode == "native_packed_matmul" and self._native_cpu_activation_available(x):
+            from orbitquant.kernels.native_packed_matmul import (
+                quantize_activations_with_native_cpu_kernel,
+            )
+
+            activation_constants = self._activation_kernel_constant_tensors(x.device)
+            self.last_activation_kernel_backend = "native_cpu"
+            rotated_x = quantize_activations_with_native_cpu_kernel(
+                x,
+                activation_constants["permutation"],
+                activation_constants["signs"],
+                activation_constants["centroids"],
+                activation_constants["boundaries"],
+                eps=self.activation_eps,
+                inv_sqrt_block=self.rotation.normalization,
+                block_size=self.rotation.block_size,
+            )
         else:
             self.last_activation_kernel_backend = select_backend(
                 x.device, requested=self.activation_kernel_backend

--- a/src/orbitquant/layers.py
+++ b/src/orbitquant/layers.py
@@ -10,6 +10,7 @@ from orbitquant.kernels import quantize_activations_kernel, select_backend
 from orbitquant.linear_adapters import canonical_linear_weight, linear_module_spec
 from orbitquant.packing import pack_lowbit, unpack_lowbit
 from orbitquant.rotations import RPBHRotation, get_rpbh_rotation
+from orbitquant.streaming import accelerate_hook_offloads, iter_aligned_row_tiles
 
 _PACKED_MATMUL_PROBE_MISSING = object()
 _NATIVE_PACKED_MATMUL_LOAD_ERROR: object | Exception | None = _PACKED_MATMUL_PROBE_MISSING
@@ -91,6 +92,95 @@ def _quantize_weight_pack(
     return pack_lowbit(weight_indices, bits=bits, validate=False)
 
 
+def _quantize_weight_bounded(
+    weight: torch.Tensor,
+    *,
+    rotation: RPBHRotation,
+    codebook,
+    bits: int,
+    eps: float,
+    row_tile_size: int,
+    quantization_device: torch.device | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize a matrix with workspace bounded by one aligned row tile."""
+
+    if weight.ndim != 2:
+        raise ValueError("weight must be a matrix")
+    out_features, in_features = weight.shape
+    output_device = weight.device
+    work_device = output_device if quantization_device is None else quantization_device
+    packed = torch.empty(
+        _packed_length(out_features * in_features, bits),
+        dtype=torch.uint8,
+        device=output_device,
+    )
+    row_norms_output = torch.empty(
+        out_features,
+        dtype=torch.bfloat16,
+        device=output_device,
+    )
+    packed_offset = 0
+
+    for row_start, row_end in iter_aligned_row_tiles(
+        out_features,
+        in_features,
+        bits,
+        row_tile_size,
+    ):
+        tile = weight[row_start:row_end].to(device=work_device)
+        if tile.is_cuda:
+            from orbitquant.kernels.triton_cuda import row_norms_with_triton
+
+            row_norms = row_norms_with_triton(tile, eps=eps)
+            quantization_weight = tile
+        else:
+            quantization_weight = tile.to(torch.float32)
+            row_norms = quantization_weight.norm(dim=-1)
+        packed_tile = _quantize_weight_pack(
+            quantization_weight,
+            row_norms,
+            rotation=rotation,
+            codebook=codebook,
+            bits=bits,
+            eps=eps,
+        )
+        packed_end = packed_offset + packed_tile.numel()
+        packed[packed_offset:packed_end].copy_(packed_tile.to(device=output_device))
+        row_norms_output[row_start:row_end].copy_(
+            row_norms.to(device=output_device, dtype=torch.bfloat16)
+        )
+        packed_offset = packed_end
+
+    if packed_offset != packed.numel():
+        raise RuntimeError(
+            f"row-tiled packing wrote {packed_offset} bytes, expected {packed.numel()}"
+        )
+    return packed, row_norms_output
+
+
+def _rotate_weight_bounded(
+    weight: torch.Tensor,
+    *,
+    rotation: RPBHRotation,
+    row_tile_size: int,
+    quantization_device: torch.device | None = None,
+) -> torch.Tensor:
+    output_device = weight.device
+    work_device = output_device if quantization_device is None else quantization_device
+    rotated = torch.empty(weight.shape, dtype=torch.float32, device=output_device)
+    for row_start, row_end in iter_aligned_row_tiles(
+        weight.shape[0],
+        weight.shape[1],
+        8,
+        row_tile_size,
+    ):
+        tile = weight[row_start:row_end].to(device=work_device, dtype=torch.float32)
+        rotated[row_start:row_end].copy_(
+            rotation.apply_to_weight(tile).to(device=output_device)
+        )
+    return rotated
+
+
 def _native_packed_matmul_load_error() -> Exception | None:
     global _NATIVE_PACKED_MATMUL_LOAD_ERROR
     if _NATIVE_PACKED_MATMUL_LOAD_ERROR is not _PACKED_MATMUL_PROBE_MISSING:
@@ -132,6 +222,11 @@ class OrbitQuantLinear(nn.Module):
     or Triton kernels are available. The explicit ``dequant_bf16`` mode keeps
     the compatibility/debug reference path.
     """
+
+    def __setattr__(self, name, value):
+        super().__setattr__(name, value)
+        if name == "_hf_hook" and accelerate_hook_offloads(self):
+            self.clear_dequantized_cache()
 
     def __init__(
         self,
@@ -207,11 +302,13 @@ class OrbitQuantLinear(nn.Module):
             self.bias = nn.Parameter(bias.detach().clone(), requires_grad=False)
 
         if packed_weight_indices is not None:
-            self.register_buffer("packed_weight_indices", packed_weight_indices)
+            self.packed_weight_indices = nn.Parameter(
+                packed_weight_indices, requires_grad=False
+            )
         else:
             self.packed_weight_indices = None
         if row_norms is not None:
-            self.register_buffer("row_norms", row_norms)
+            self.row_norms = nn.Parameter(row_norms, requires_grad=False)
         else:
             self.row_norms = None
         if debug_weight is not None:
@@ -245,52 +342,77 @@ class OrbitQuantLinear(nn.Module):
         source_weight = canonical_linear_weight(layer).detach()
         source_bias = getattr(layer, "bias", None)
         bias = None if source_bias is None else source_bias.detach()
+        return cls.from_weight(
+            source_weight,
+            bias=bias,
+            in_features=spec.in_features,
+            out_features=spec.out_features,
+            source_weight_layout=spec.weight_layout,
+            config=config,
+            module_name=module_name,
+        )
+
+    @classmethod
+    def from_weight(
+        cls,
+        weight: torch.Tensor,
+        *,
+        bias: torch.Tensor | None,
+        in_features: int,
+        out_features: int,
+        source_weight_layout: str,
+        config: OrbitQuantConfig,
+        module_name: str,
+        quantization_device: torch.device | None = None,
+    ) -> OrbitQuantLinear:
+        expected_shape = (out_features, in_features)
+        if tuple(weight.shape) != expected_shape:
+            raise ValueError(
+                f"expected canonical weight shape {expected_shape}, got {tuple(weight.shape)}"
+            )
         rotation = get_rpbh_rotation(
-            dim=spec.in_features, seed=config.rotation_seed, block_size=config.block_size
+            dim=in_features, seed=config.rotation_seed, block_size=config.block_size
         )
 
         if config.runtime_mode == "debug_no_quant":
-            weight = source_weight.to(torch.float32)
-            rotated_weight = rotation.apply_to_weight(weight)
+            rotated_weight = _rotate_weight_bounded(
+                weight,
+                rotation=rotation,
+                row_tile_size=config.weight_row_tile_size,
+                quantization_device=quantization_device,
+            )
             return cls(
-                in_features=spec.in_features,
-                out_features=spec.out_features,
+                in_features=in_features,
+                out_features=out_features,
                 config=config,
                 module_name=module_name,
-                source_weight_layout=spec.weight_layout,
+                source_weight_layout=source_weight_layout,
                 bias=bias,
                 packed_weight_indices=None,
                 row_norms=None,
                 debug_weight=rotated_weight,
             )
 
-        if source_weight.is_cuda:
-            from orbitquant.kernels.triton_cuda import row_norms_with_triton
-
-            row_norms = row_norms_with_triton(source_weight, eps=config.activation_eps)
-            quantization_weight = source_weight
-        else:
-            quantization_weight = source_weight.to(torch.float32)
-            row_norms = quantization_weight.norm(dim=-1)
-        codebook = get_codebook(spec.in_features, config.weight_bits, config.codebook_version)
-        packed = _quantize_weight_pack(
-            quantization_weight,
-            row_norms,
+        codebook = get_codebook(in_features, config.weight_bits, config.codebook_version)
+        packed, row_norms = _quantize_weight_bounded(
+            weight,
             rotation=rotation,
             codebook=codebook,
             bits=config.weight_bits,
             eps=config.activation_eps,
+            row_tile_size=config.weight_row_tile_size,
+            quantization_device=quantization_device,
         )
 
         return cls(
-            in_features=spec.in_features,
-            out_features=spec.out_features,
+            in_features=in_features,
+            out_features=out_features,
             config=config,
             module_name=module_name,
-            source_weight_layout=spec.weight_layout,
+            source_weight_layout=source_weight_layout,
             bias=bias,
             packed_weight_indices=packed,
-            row_norms=row_norms.to(torch.bfloat16),
+            row_norms=row_norms,
             debug_weight=None,
         )
 
@@ -345,6 +467,16 @@ class OrbitQuantLinear(nn.Module):
     def clear_dequantized_cache(self) -> None:
         self._dequantized_weight_cache = None
         self._dequantized_weight_cache_key = None
+
+    def _remember_dequantized_weight(
+        self,
+        weight: torch.Tensor,
+        cache_key: tuple[str, torch.dtype],
+    ) -> torch.Tensor:
+        if not accelerate_hook_offloads(self):
+            self._dequantized_weight_cache = weight.detach()
+            self._dequantized_weight_cache_key = cache_key
+        return weight
 
     def _apply(self, fn, recurse: bool = True):
         result = super()._apply(fn, recurse=recurse)
@@ -579,16 +711,15 @@ class OrbitQuantLinear(nn.Module):
     def _dequantize_weight(self, *, device: torch.device, dtype: torch.dtype) -> torch.Tensor:
         cache_key = (str(device), dtype)
         if (
-            self._dequantized_weight_cache is not None
+            not accelerate_hook_offloads(self)
+            and self._dequantized_weight_cache is not None
             and self._dequantized_weight_cache_key == cache_key
         ):
             return self._dequantized_weight_cache
 
         if self.debug_weight is not None:
             weight = self.debug_weight.to(device=device, dtype=dtype)
-            self._dequantized_weight_cache = weight.detach()
-            self._dequantized_weight_cache_key = cache_key
-            return weight
+            return self._remember_dequantized_weight(weight, cache_key)
         if self.packed_weight_indices is None or self.row_norms is None:
             raise RuntimeError("OrbitQuantLinear is missing quantized weight buffers")
 
@@ -610,9 +741,7 @@ class OrbitQuantLinear(nn.Module):
                     in_features=self.in_features,
                 )
                 dequantized = weight.to(dtype=dtype)
-                self._dequantized_weight_cache = dequantized.detach()
-                self._dequantized_weight_cache_key = cache_key
-                return dequantized
+                return self._remember_dequantized_weight(dequantized, cache_key)
         if device.type == "cuda":
             try:
                 from orbitquant.kernels.triton_cuda import dequantize_packed_weight_with_triton
@@ -629,9 +758,7 @@ class OrbitQuantLinear(nn.Module):
                     device=device,
                 )
                 dequantized = weight.to(dtype=dtype)
-                self._dequantized_weight_cache = dequantized.detach()
-                self._dequantized_weight_cache_key = cache_key
-                return dequantized
+                return self._remember_dequantized_weight(dequantized, cache_key)
 
         flat = unpack_lowbit(
             self.packed_weight_indices,
@@ -643,9 +770,7 @@ class OrbitQuantLinear(nn.Module):
         row_norms = self.row_norms.to(device=device, dtype=torch.float32)
         weight = row_norms[:, None] * centroids[indices]
         dequantized = weight.to(dtype=dtype)
-        self._dequantized_weight_cache = dequantized.detach()
-        self._dequantized_weight_cache_key = cache_key
-        return dequantized
+        return self._remember_dequantized_weight(dequantized, cache_key)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         self._ensure_derived_constants(x.device)

--- a/src/orbitquant/modeling.py
+++ b/src/orbitquant/modeling.py
@@ -302,7 +302,8 @@ def quantize_linear_modules(
 
 
 def prepare_prequantized_linear_modules(
-    model: torch.nn.Module, config: OrbitQuantConfig
+    model: torch.nn.Module,
+    config: OrbitQuantConfig,
 ) -> QuantizationSummary:
     decisions = classify_linear_modules(model, config)
     summary = QuantizationSummary()
@@ -313,14 +314,18 @@ def prepare_prequantized_linear_modules(
             continue
         if decision.action == "orbitquant":
             replacement = OrbitQuantLinear.empty_from_linear(
-                module, config=config, module_name=name
+                module,
+                config=config,
+                module_name=name,
             )
             parent, child_name = _parent_and_child(model, name)
             _set_child(parent, child_name, replacement)
             summary.quantized_modules.append(name)
         elif decision.action == "adaln_int4_rtn":
             replacement = RTNInt4Linear.empty_from_linear(
-                module, config=config, module_name=name
+                module,
+                config=config,
+                module_name=name,
             )
             parent, child_name = _parent_and_child(model, name)
             _set_child(parent, child_name, replacement)

--- a/src/orbitquant/quantizer.py
+++ b/src/orbitquant/quantizer.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import re
 from typing import Any
 
 import torch
 
 from orbitquant.adaln import RTNInt4Linear
+from orbitquant.checkpoint_streaming import (
+    StreamingCheckpoint,
+    build_diffusers_streaming_conversion,
+    build_transformers_streaming_checkpoint,
+)
 from orbitquant.config import OrbitQuantConfig
 from orbitquant.layers import OrbitQuantLinear
 from orbitquant.modeling import (
@@ -14,10 +20,22 @@ from orbitquant.modeling import (
     quantize_linear_modules,
 )
 from orbitquant.policies import classify_linear_modules
+from orbitquant.streaming import release_cpu_tensor_pages
 
 _ORBITQUANT_STATE_TENSORS = {"packed_weight_indices", "row_norms", "debug_weight", "bias"}
 _RTN_INT4_STATE_TENSORS = {"packed_weight", "scales", "bias"}
 _MISSING = object()
+
+
+def _require_safetensors(checkpoint_files: list[Any], *, framework: str) -> None:
+    unsupported = [str(path) for path in checkpoint_files if not str(path).endswith(".safetensors")]
+    if unsupported:
+        raise RuntimeError(
+            f"OrbitQuant bounded-memory {framework} conversion requires safetensors "
+            f"checkpoints; unsupported files: {unsupported}. Convert the source checkpoint "
+            "to safetensors or load it without an OrbitQuant quantization_config and use the "
+            "explicit post-load helper without a bounded-memory guarantee."
+        )
 
 
 def _hf_base_classes() -> tuple[type, ...]:
@@ -159,7 +177,23 @@ class OrbitQuantizer(*_hf_base_classes()):
         self._transformers_orbit_module_names: list[str] = []
         self._transformers_adaln_module_names: list[str] = []
         self._transformers_base_model_prefix = ""
+        self._transformers_preconverted_checkpoint = False
+        self._transformers_streaming_checkpoint: StreamingCheckpoint | None = None
+        self._diffusers_streaming_quantization = False
+        self._diffusers_model: Any | None = None
+        self._diffusers_loaded_keys: list[str] | None = None
+        self._diffusers_checkpoint_files: list[Any] = []
+        self._diffusers_packed_state: dict[str, torch.Tensor] | None = None
+        self._diffusers_replaced_source_keys: set[str] = set()
+        self.released_source_tensor_bytes = 0
+        self.source_page_release_failures = 0
         self.quantization_device = quantization_device
+
+    def release_source_tensor(self, tensor: torch.Tensor) -> None:
+        if release_cpu_tensor_pages(tensor):
+            self.released_source_tensor_bytes += tensor.numel() * tensor.element_size()
+        elif tensor.device.type == "cpu":
+            self.source_page_release_failures += 1
 
     def _quantization_device_from_kwargs(self, kwargs: dict[str, Any]) -> torch.device | None:
         explicit_device = _normalise_quantization_device(kwargs.get("quantization_device"))
@@ -213,7 +247,7 @@ class OrbitQuantizer(*_hf_base_classes()):
         *args: Any,
         **kwargs: Any,
     ) -> bool:
-        if not self.pre_quantized:
+        if not self.pre_quantized and not self._diffusers_streaming_quantization:
             return False
         try:
             module, tensor_name = _module_and_tensor_name(model, param_name)
@@ -234,7 +268,7 @@ class OrbitQuantizer(*_hf_base_classes()):
         unexpected_keys: list[str] | None = None,
         **kwargs: Any,
     ) -> None:
-        if self.pre_quantized:
+        if self.pre_quantized or self._diffusers_streaming_quantization:
             module, tensor_name = _module_and_tensor_name(model, param_name)
             if not _is_prequantized_state_tensor(module, tensor_name):
                 raise ValueError(f"{param_name} is not an OrbitQuant pre-quantized tensor")
@@ -269,6 +303,57 @@ class OrbitQuantizer(*_hf_base_classes()):
         )
         raise RuntimeError(msg)
 
+    @property
+    def supports_parallel_loading(self) -> bool:
+        return self.pre_quantized
+
+    def maybe_update_loaded_keys(
+        self,
+        loaded_keys: list[str],
+        checkpoint_files: list[Any],
+    ) -> list[str]:
+        if self.pre_quantized:
+            return loaded_keys
+        _require_safetensors(checkpoint_files, framework="Diffusers")
+        self._diffusers_loaded_keys = loaded_keys
+        self._diffusers_checkpoint_files = list(checkpoint_files)
+        return loaded_keys
+
+    def _diffusers_streaming_key_mapping(self) -> dict[str, list[str]]:
+        mapping: dict[str, list[str]] = {}
+        for name in self._transformers_orbit_module_names:
+            outputs = (
+                [f"{name}.debug_weight"]
+                if self.quantization_config.runtime_mode == "debug_no_quant"
+                else [f"{name}.packed_weight_indices", f"{name}.row_norms"]
+            )
+            mapping[f"{name}.weight"] = outputs
+        for name in self._transformers_adaln_module_names:
+            mapping[f"{name}.weight"] = [f"{name}.packed_weight", f"{name}.scales"]
+        return mapping
+
+    def _update_diffusers_loaded_keys(self) -> None:
+        if self._diffusers_loaded_keys is None:
+            return
+        mapping = self._diffusers_streaming_key_mapping()
+        updated: list[str] = []
+        for key in self._diffusers_loaded_keys:
+            updated.extend(mapping.get(key, [key]))
+        self._diffusers_loaded_keys[:] = updated
+
+    def maybe_update_state_dict(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+        if not self._diffusers_streaming_quantization:
+            return state_dict
+        if self._diffusers_model is None:
+            raise RuntimeError("Diffusers streaming conversion has no prepared model skeleton")
+
+        for source_key in self._diffusers_replaced_source_keys:
+            state_dict.pop(source_key, None)
+        if self._diffusers_packed_state is not None:
+            state_dict.update(self._diffusers_packed_state)
+            self._diffusers_packed_state = None
+        return state_dict
+
     def check_quantized_param_shape(
         self,
         param_name: str,
@@ -292,7 +377,10 @@ class OrbitQuantizer(*_hf_base_classes()):
         return state_or_model, {}
 
     def get_weight_conversions(self) -> list[Any]:
-        if not self._transformers_streaming_quantization:
+        if (
+            not self._transformers_streaming_quantization
+            or self._transformers_preconverted_checkpoint
+        ):
             return []
         from transformers.core_model_loading import WeightConverter
 
@@ -337,14 +425,22 @@ class OrbitQuantizer(*_hf_base_classes()):
 
     def _process_model_before_weight_loading(self, model: Any, *args: Any, **kwargs: Any) -> Any:
         model.quantization_config = self.quantization_config
+        checkpoint_files = kwargs.get("checkpoint_files")
         self._transformers_postload_quantization = (
-            not self.pre_quantized and "checkpoint_files" in kwargs
+            not self.pre_quantized and checkpoint_files is not None
         )
         self._transformers_streaming_quantization = self._transformers_postload_quantization
+        if self._transformers_streaming_quantization:
+            _require_safetensors(checkpoint_files, framework="Transformers")
+        self._diffusers_streaming_quantization = (
+            not self.pre_quantized
+            and not self._transformers_streaming_quantization
+            and bool(self._diffusers_checkpoint_files)
+        )
         self._transformers_orbit_module_names = []
         self._transformers_adaln_module_names = []
         self._transformers_base_model_prefix = str(getattr(model, "base_model_prefix", "") or "")
-        if self._transformers_streaming_quantization:
+        if self._transformers_streaming_quantization or self._diffusers_streaming_quantization:
             decisions = classify_linear_modules(model, self.quantization_config)
             self._transformers_orbit_module_names = [
                 name for name, decision in decisions.items() if decision.action == "orbitquant"
@@ -352,12 +448,68 @@ class OrbitQuantizer(*_hf_base_classes()):
             self._transformers_adaln_module_names = [
                 name for name, decision in decisions.items() if decision.action == "adaln_int4_rtn"
             ]
-        if self.pre_quantized or self._transformers_streaming_quantization:
-            prepare_prequantized_linear_modules(model, self.quantization_config)
+        if self._transformers_streaming_quantization:
+            streaming_checkpoint = build_transformers_streaming_checkpoint(
+                model,
+                self.quantization_config,
+                checkpoint_files,
+                orbit_module_names=self._transformers_orbit_module_names,
+                adaln_module_names=self._transformers_adaln_module_names,
+                base_model_prefix=self._transformers_base_model_prefix,
+                quantization_device=self.quantization_device,
+            )
+            checkpoint_files.append(str(streaming_checkpoint.packed_file))
+            self._transformers_streaming_checkpoint = streaming_checkpoint
+            self._transformers_preconverted_checkpoint = True
+            self.released_source_tensor_bytes = streaming_checkpoint.source_tensor_bytes
+            ignored_source_keys = set(
+                getattr(model, "_keys_to_ignore_on_load_unexpected", None) or ()
+            )
+            ignored_source_keys.update(
+                rf"^{re.escape(key)}$" for key in streaming_checkpoint.replaced_source_keys
+            )
+            for name in (
+                self._transformers_orbit_module_names
+                + self._transformers_adaln_module_names
+            ):
+                ignored_source_keys.add(rf"^{re.escape(f'{name}.weight')}$")
+                if self._transformers_base_model_prefix:
+                    ignored_source_keys.add(
+                        rf"^{re.escape(f'{self._transformers_base_model_prefix}.{name}.weight')}$"
+                    )
+            model._keys_to_ignore_on_load_unexpected = ignored_source_keys
+        if self._diffusers_streaming_quantization:
+            conversion = build_diffusers_streaming_conversion(
+                model,
+                self.quantization_config,
+                self._diffusers_checkpoint_files,
+                orbit_module_names=self._transformers_orbit_module_names,
+                adaln_module_names=self._transformers_adaln_module_names,
+                quantization_device=self.quantization_device,
+            )
+            self._diffusers_packed_state = conversion.packed_state
+            self._diffusers_replaced_source_keys = set(conversion.replaced_source_keys)
+            self.released_source_tensor_bytes = conversion.source_tensor_bytes
+        if (
+            self.pre_quantized
+            or self._transformers_streaming_quantization
+            or self._diffusers_streaming_quantization
+        ):
+            prepare_prequantized_linear_modules(
+                model,
+                self.quantization_config,
+            )
+        if self._diffusers_streaming_quantization:
+            self._diffusers_model = model
+            self._update_diffusers_loaded_keys()
         return model
 
     def _process_model_after_weight_loading(self, model: Any, *args: Any, **kwargs: Any) -> Any:
-        if not self.pre_quantized and not self._transformers_streaming_quantization:
+        if (
+            not self.pre_quantized
+            and not self._transformers_streaming_quantization
+            and not self._diffusers_streaming_quantization
+        ):
             quantize_linear_modules(
                 model,
                 self.quantization_config,
@@ -371,6 +523,19 @@ class OrbitQuantizer(*_hf_base_classes()):
             self._transformers_orbit_module_names = []
             self._transformers_adaln_module_names = []
             self._transformers_base_model_prefix = ""
+            self._transformers_preconverted_checkpoint = False
+            if self._transformers_streaming_checkpoint is not None:
+                self._transformers_streaming_checkpoint.directory.cleanup()
+                self._transformers_streaming_checkpoint = None
+        if self._diffusers_streaming_quantization:
+            self._diffusers_streaming_quantization = False
+            self._diffusers_model = None
+            self._diffusers_loaded_keys = None
+            self._diffusers_checkpoint_files = []
+            self._diffusers_packed_state = None
+            self._diffusers_replaced_source_keys = set()
+            self._transformers_orbit_module_names = []
+            self._transformers_adaln_module_names = []
         return model
 
     def _dequantize(self, model: Any) -> Any:

--- a/src/orbitquant/quantizer.py
+++ b/src/orbitquant/quantizer.py
@@ -20,7 +20,6 @@ from orbitquant.modeling import (
     quantize_linear_modules,
 )
 from orbitquant.policies import classify_linear_modules
-from orbitquant.streaming import release_cpu_tensor_pages
 
 _ORBITQUANT_STATE_TENSORS = {"packed_weight_indices", "row_norms", "debug_weight", "bias"}
 _RTN_INT4_STATE_TENSORS = {"packed_weight", "scales", "bias"}
@@ -190,10 +189,8 @@ class OrbitQuantizer(*_hf_base_classes()):
         self.quantization_device = quantization_device
 
     def release_source_tensor(self, tensor: torch.Tensor) -> None:
-        if release_cpu_tensor_pages(tensor):
+        if tensor.device.type == "cpu":
             self.released_source_tensor_bytes += tensor.numel() * tensor.element_size()
-        elif tensor.device.type == "cpu":
-            self.source_page_release_failures += 1
 
     def _quantization_device_from_kwargs(self, kwargs: dict[str, Any]) -> torch.device | None:
         explicit_device = _normalise_quantization_device(kwargs.get("quantization_device"))

--- a/src/orbitquant/streaming.py
+++ b/src/orbitquant/streaming.py
@@ -1,13 +1,8 @@
 from __future__ import annotations
 
-import ctypes
-import mmap
-import os
 from collections.abc import Iterator
 from math import gcd
 from typing import Any
-
-import torch
 
 
 def iter_aligned_row_tiles(
@@ -45,25 +40,7 @@ def accelerate_hook_offloads(module: Any) -> bool:
     )
 
 
-def release_cpu_tensor_pages(tensor: torch.Tensor) -> bool:
-    """Drop clean CPU pages after the checkpoint tensor's final use."""
-
-    if tensor.device.type != "cpu" or tensor.numel() == 0:
-        return False
-    page_size = int(os.sysconf("SC_PAGE_SIZE"))
-    start = int(tensor.data_ptr())
-    aligned_start = start - (start % page_size)
-    end = start + tensor.numel() * tensor.element_size()
-    aligned_length = ((end - aligned_start + page_size - 1) // page_size) * page_size
-    madvise = ctypes.CDLL(None, use_errno=True).madvise
-    madvise.argtypes = (ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int)
-    madvise.restype = ctypes.c_int
-    advice = int(getattr(mmap, "MADV_DONTNEED", 4))
-    return madvise(ctypes.c_void_p(aligned_start), aligned_length, advice) == 0
-
-
 __all__ = [
     "accelerate_hook_offloads",
     "iter_aligned_row_tiles",
-    "release_cpu_tensor_pages",
 ]

--- a/src/orbitquant/streaming.py
+++ b/src/orbitquant/streaming.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import ctypes
+import mmap
+import os
+from collections.abc import Iterator
+from math import gcd
+from typing import Any
+
+import torch
+
+
+def iter_aligned_row_tiles(
+    row_count: int,
+    values_per_row: int,
+    bits: int,
+    max_rows: int,
+) -> Iterator[tuple[int, int]]:
+    """Yield row tiles whose non-final packed payloads end on byte boundaries."""
+
+    if row_count < 0:
+        raise ValueError("row_count must be non-negative")
+    if values_per_row <= 0:
+        raise ValueError("values_per_row must be positive")
+    if bits <= 0 or bits > 8:
+        raise ValueError("bits must be in [1, 8]")
+    if max_rows <= 0:
+        raise ValueError("max_rows must be positive")
+
+    row_alignment = 8 // gcd(8, values_per_row * bits)
+    tile_rows = max(row_alignment, max_rows - (max_rows % row_alignment))
+    for start in range(0, row_count, tile_rows):
+        yield start, min(start + tile_rows, row_count)
+
+
+def accelerate_hook_offloads(module: Any) -> bool:
+    hook = getattr(module, "_hf_hook", None)
+    if hook is None:
+        return False
+    if bool(getattr(hook, "offload", False)):
+        return True
+    return any(
+        bool(getattr(child_hook, "offload", False))
+        for child_hook in getattr(hook, "hooks", ())
+    )
+
+
+def release_cpu_tensor_pages(tensor: torch.Tensor) -> bool:
+    """Drop clean CPU pages after the checkpoint tensor's final use."""
+
+    if tensor.device.type != "cpu" or tensor.numel() == 0:
+        return False
+    page_size = int(os.sysconf("SC_PAGE_SIZE"))
+    start = int(tensor.data_ptr())
+    aligned_start = start - (start % page_size)
+    end = start + tensor.numel() * tensor.element_size()
+    aligned_length = ((end - aligned_start + page_size - 1) // page_size) * page_size
+    madvise = ctypes.CDLL(None, use_errno=True).madvise
+    madvise.argtypes = (ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int)
+    madvise.restype = ctypes.c_int
+    advice = int(getattr(mmap, "MADV_DONTNEED", 4))
+    return madvise(ctypes.c_void_p(aligned_start), aligned_length, advice) == 0
+
+
+__all__ = [
+    "accelerate_hook_offloads",
+    "iter_aligned_row_tiles",
+    "release_cpu_tensor_pages",
+]

--- a/src/orbitquant/transformers_ops.py
+++ b/src/orbitquant/transformers_ops.py
@@ -15,6 +15,11 @@ class OrbitQuantWeightQuantize(ConversionOps):
     def __init__(self, hf_quantizer: Any) -> None:
         self.hf_quantizer = hf_quantizer
 
+    def __deepcopy__(self, memo: dict[int, Any]) -> OrbitQuantWeightQuantize:
+        # Transformers clones each WeightConverter per target. This operation is
+        # stateless and must keep the live quantizer for release accounting.
+        return self
+
     @property
     def reverse_op(self) -> OrbitQuantWeightQuantize:
         return self
@@ -46,24 +51,22 @@ class OrbitQuantWeightQuantize(ConversionOps):
         module = model.get_submodule(module_name)
 
         _, values = next(iter(input_dict.items()))
-        weight = values[0] if isinstance(values, list) else values
-        weight = self.hf_quantizer.move_tensor_for_quantization(weight)
+        source_weight = values[0] if isinstance(values, list) else values
+        weight = source_weight
         if module.source_weight_layout == "in_out":
-            weight = weight.transpose(0, 1).contiguous()
-        proxy = torch.nn.Linear(
-            module.in_features,
-            module.out_features,
-            bias=False,
-            device="meta",
-        )
-        proxy.weight = torch.nn.Parameter(weight, requires_grad=False)
+            weight = weight.transpose(0, 1)
 
         results: dict[str, torch.Tensor] = {}
         if isinstance(module, OrbitQuantLinear):
-            quantized = OrbitQuantLinear.from_linear(
-                proxy,
+            quantized = OrbitQuantLinear.from_weight(
+                weight,
+                bias=None,
+                in_features=module.in_features,
+                out_features=module.out_features,
+                source_weight_layout=module.source_weight_layout,
                 config=self.hf_quantizer.quantization_config,
                 module_name=module_name,
+                quantization_device=self.hf_quantizer.quantization_device,
             )
             if quantized.debug_weight is not None:
                 debug_key = f"{module_name}.debug_weight"
@@ -80,10 +83,15 @@ class OrbitQuantWeightQuantize(ConversionOps):
                     missing_keys.discard(row_norms_key)
             module.clear_dequantized_cache()
         elif isinstance(module, RTNInt4Linear):
-            quantized_rtn = RTNInt4Linear.from_linear(
-                proxy,
+            quantized_rtn = RTNInt4Linear.from_weight(
+                weight,
+                bias=None,
+                in_features=module.in_features,
+                out_features=module.out_features,
+                source_weight_layout=module.source_weight_layout,
                 config=self.hf_quantizer.quantization_config,
                 module_name=module_name,
+                quantization_device=self.hf_quantizer.quantization_device,
             )
             packed_key = f"{module_name}.packed_weight"
             scales_key = f"{module_name}.scales"
@@ -97,4 +105,5 @@ class OrbitQuantWeightQuantize(ConversionOps):
                 f"expected OrbitQuantLinear or RTNInt4Linear at {module_name}, "
                 f"got {type(module).__name__}"
             )
+        self.hf_quantizer.release_source_tensor(source_weight)
         return results

--- a/tests/test_adaln_rtn.py
+++ b/tests/test_adaln_rtn.py
@@ -1,5 +1,6 @@
 import pytest
 import torch
+from torch.nn import functional as F
 
 from orbitquant.adaln import (
     RTNInt4Linear,
@@ -7,6 +8,27 @@ from orbitquant.adaln import (
 )
 from orbitquant.config import OrbitQuantConfig
 from orbitquant.kernels import available_backends
+
+
+def _independent_packed_adaln_weight(layer: RTNInt4Linear) -> torch.Tensor:
+    count = layer.out_features * layer.num_groups * layer.group_size
+    packed = layer.packed_weight.detach().cpu()
+    unsigned = torch.tensor(
+        [
+            int(packed[index // 2]) & 15
+            if index % 2 == 0
+            else (int(packed[index // 2]) >> 4) & 15
+            for index in range(count)
+        ],
+        dtype=torch.int16,
+    )
+    signed = unsigned.sub(8).float().reshape(
+        layer.out_features,
+        layer.num_groups,
+        layer.group_size,
+    )
+    weight = signed * layer.scales.detach().cpu().float()[..., None]
+    return weight.reshape(layer.out_features, -1)[:, : layer.in_features].to(torch.bfloat16)
 
 
 def test_int4_rtn_linear_preserves_shape_and_freezes_parameters():
@@ -52,6 +74,79 @@ def test_int4_rtn_casts_fp32_inputs_to_paper_bf16_activation_path():
     assert actual.dtype == torch.bfloat16
     assert actual.shape == (2, 3, 9)
     assert torch.isfinite(actual).all()
+
+
+def test_int4_rtn_explicit_reference_mode_materializes_debug_cache():
+    torch.manual_seed(3)
+    source = torch.nn.Linear(65, 9)
+    x = torch.randn(2, 3, 65, dtype=torch.bfloat16)
+    config = OrbitQuantConfig(runtime_mode="dequant_bf16")
+    quantized = RTNInt4Linear.from_linear(
+        source,
+        config=config,
+        module_name="block.modulation",
+    )
+
+    expected = F.linear(
+        x,
+        _independent_packed_adaln_weight(quantized),
+        source.bias.detach().to(torch.bfloat16),
+    )
+    actual = quantized(x)
+
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+    assert quantized.last_effective_runtime_mode == "dequant_bf16"
+    assert quantized._dequantized_weight_cache is not None
+
+
+def test_int4_rtn_native_cpu_matches_independent_reference_without_dense_cache():
+    try:
+        import orbitquant_packed_matmul
+    except Exception:
+        pytest.skip("native packed matmul kernel package is not importable")
+    if not orbitquant_packed_matmul.supports_cpu_adaln():
+        pytest.skip("the importable native package has no CPU AdaLN kernel")
+
+    torch.manual_seed(5)
+    source = torch.nn.Linear(65, 9)
+    x = torch.randn(2, 3, 65, dtype=torch.bfloat16)
+    config = OrbitQuantConfig(runtime_mode="native_packed_matmul")
+    quantized = RTNInt4Linear.from_linear(
+        source,
+        config=config,
+        module_name="block.modulation",
+    )
+    expected = F.linear(
+        x,
+        _independent_packed_adaln_weight(quantized),
+        source.bias.detach().to(torch.bfloat16),
+    )
+
+    actual = quantized(x)
+
+    torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
+    assert quantized.last_effective_runtime_mode == "native_packed_adaln_int4"
+    assert quantized._dequantized_weight_cache is None
+    assert quantized._dequantized_weight_cache_key is None
+
+
+def test_int4_rtn_explicit_native_mode_fails_loud_without_current_package(monkeypatch):
+    import orbitquant.kernels.native_packed_matmul as native_module
+
+    monkeypatch.setattr(native_module, "native_cpu_adaln_available", lambda: False)
+    source = torch.nn.Linear(16, 8)
+    config = OrbitQuantConfig(
+        adaln_group_size=8,
+        runtime_mode="native_packed_matmul",
+    )
+    quantized = RTNInt4Linear.from_linear(
+        source,
+        config=config,
+        module_name="block.modulation",
+    )
+
+    with pytest.raises(RuntimeError, match="has no packed AdaLN INT4 kernel"):
+        quantized(torch.randn(2, 16))
 
 
 def test_int4_rtn_rejects_non_positive_group_size():

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -39,7 +39,10 @@ def test_github_actions_cpu_unit_workflow_exists():
     assert "windows-native-cpu:" in text
     assert "runs-on: windows-2025" in text
     assert "--rev d43de01d0b43285d8e5061ca4380c2bd1c40ae3b" in text
+    assert "--debug" in text
     assert "prepare_wheel_project.py" in text
+    assert 'CMAKE_GENERATOR = "Visual Studio 17 2022"' in text
+    assert "Get-CimInstance Win32_Processor" in text
     assert "bdist_wheel --py-limited-api=cp39" in text
     assert '"-cp39-abi3-win_amd64\\.whl$"' in text
     assert "torch==2.12.1 pytest" in text

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -36,6 +36,14 @@ def test_github_actions_cpu_unit_workflow_exists():
     assert "dist/*.whl" in text
     assert "orbitquant-0.1.0-py3-none-any.whl" not in text
     assert "orbitquant --version" in text
+    assert "windows-native-cpu:" in text
+    assert "runs-on: windows-2025" in text
+    assert "--rev d43de01d0b43285d8e5061ca4380c2bd1c40ae3b" in text
+    assert "prepare_wheel_project.py" in text
+    assert "bdist_wheel --py-limited-api=cp39" in text
+    assert '"-cp39-abi3-win_amd64\\.whl$"' in text
+    assert "torch==2.12.1 pytest" in text
+    assert "-m kernels_ci" in text
 
 
 def test_package_version_matches_import_version():
@@ -272,7 +280,8 @@ def test_native_packed_matmul_kernel_package_stays_kernel_builder_abi3_compliant
         "pybind11": re.compile(r"pybind11|PYBIND11|py::"),
         "torch extension header": re.compile(r"torch/extension\.h"),
         "hardcoded torch op namespace": re.compile(
-            r"TORCH_LIBRARY\(|TORCH_LIBRARY_FRAGMENT|TORCH_LIBRARY_IMPL|PyInit"
+            r"TORCH_LIBRARY\(|TORCH_LIBRARY_FRAGMENT|"
+            r"(?<!STABLE_)TORCH_LIBRARY_IMPL|PyInit"
         ),
         "setuptools extension build": re.compile(
             r"CUDAExtension|BuildExtension|cpp_extension\.load|load_inline"
@@ -296,7 +305,8 @@ def test_native_packed_matmul_kernel_package_stays_kernel_builder_abi3_compliant
     assert build_config["general"]["name"] == "orbitquant-packed-matmul"
     assert "_" not in build_config["general"]["name"]
     assert build_config["general"]["license"] == "Apache-2.0"
-    assert build_config["general"]["backends"] == ["cuda", "metal"]
+    assert build_config["general"]["backends"] == ["cpu", "cuda", "metal"]
+    assert build_config["torch"]["stable-abi"] == {"cpu": "2.11"}
     assert build_config["general"]["upstream"] == "https://github.com/iamwavecut/OrbitQuant"
     assert (
         build_config["general"]["source"]

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -41,7 +41,8 @@ def test_github_actions_cpu_unit_workflow_exists():
     assert "--rev d43de01d0b43285d8e5061ca4380c2bd1c40ae3b" in text
     assert "--debug" in text
     assert "prepare_wheel_project.py" in text
-    assert 'CMAKE_GENERATOR = "Visual Studio 17 2022"' in text
+    assert "uses: actions/cache@v6.1.0" in text
+    assert 'CMAKE_GENERATOR = "Visual Studio 18 2026"' in text
     assert "Get-CimInstance Win32_Processor" in text
     assert "bdist_wheel --py-limited-api=cp39" in text
     assert '"-cp39-abi3-win_amd64\\.whl$"' in text

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -905,6 +905,11 @@ def test_cli_compare_native_runs_original_and_quantized_side_by_side(
     capsys,
     tmp_path,
 ):
+    monkeypatch.setattr(
+        "orbitquant.layers._native_cpu_packed_matmul_load_error",
+        lambda: RuntimeError("reference-path test"),
+    )
+
     class TinyPipeline:
         def __init__(self, color="red"):
             self.color = color

--- a/tests/test_diffusers_modelmixin_integration.py
+++ b/tests/test_diffusers_modelmixin_integration.py
@@ -1,4 +1,6 @@
+import gc
 import json
+import weakref
 
 import pytest
 import torch
@@ -35,20 +37,83 @@ class TinyDiffusersTransformer(diffusers.ModelMixin, diffusers.ConfigMixin):
         return self.proj_out(self.transformer_blocks[0]["attn"]["to_q"](x))
 
 
-def test_diffusers_modelmixin_from_pretrained_quantizes_on_load(tmp_path):
+def test_diffusers_modelmixin_from_pretrained_quantizes_on_load(tmp_path, monkeypatch):
     register_hf_quantizers()
     model = TinyDiffusersTransformer()
+    config = OrbitQuantConfig(block_size=8, weight_row_tile_size=2)
+    expected = OrbitQuantLinear.from_linear(
+        model.transformer_blocks[0]["attn"]["to_q"],
+        config=config,
+        module_name="transformer_blocks.0.attn.to_q",
+    )
     model.save_pretrained(tmp_path)
+
+    def fail_post_load_quantization(*args, **kwargs):
+        raise AssertionError("Diffusers load fell back to post-load quantization")
+
+    monkeypatch.setattr(
+        "orbitquant.quantizer.quantize_linear_modules",
+        fail_post_load_quantization,
+    )
 
     loaded = TinyDiffusersTransformer.from_pretrained(
         tmp_path,
-        quantization_config=OrbitQuantConfig(block_size=8),
+        quantization_config=config,
     )
 
-    assert isinstance(loaded.transformer_blocks[0]["attn"]["to_q"], OrbitQuantLinear)
+    quantized = loaded.transformer_blocks[0]["attn"]["to_q"]
+    assert isinstance(quantized, OrbitQuantLinear)
+    assert torch.equal(quantized.packed_weight_indices, expected.packed_weight_indices)
+    assert torch.equal(quantized.row_norms, expected.row_norms)
+    assert loaded.hf_quantizer.released_source_tensor_bytes > 0
+    assert loaded.hf_quantizer.source_page_release_failures == 0
     assert isinstance(loaded.proj_out, torch.nn.Linear)
     x = torch.randn(2, 3, 16)
     assert torch.isfinite(loaded(x)).all()
+
+
+def test_diffusers_streaming_sharded_safetensors_releases_source_weights(
+    tmp_path,
+    monkeypatch,
+):
+    register_hf_quantizers()
+    model = TinyDiffusersTransformer()
+    model.save_pretrained(tmp_path, max_shard_size="1KB")
+    assert (tmp_path / "diffusion_pytorch_model.safetensors.index.json").is_file()
+    source_refs = []
+    original_from_weight = OrbitQuantLinear.from_weight.__func__
+
+    def recording_from_weight(cls, weight, **kwargs):
+        source_refs.append(weakref.ref(weight))
+        return original_from_weight(cls, weight, **kwargs)
+
+    monkeypatch.setattr(
+        OrbitQuantLinear,
+        "from_weight",
+        classmethod(recording_from_weight),
+    )
+
+    loaded = TinyDiffusersTransformer.from_pretrained(
+        tmp_path,
+        quantization_config=OrbitQuantConfig(block_size=8, weight_row_tile_size=2),
+    )
+    gc.collect()
+
+    assert source_refs
+    assert all(ref() is None for ref in source_refs)
+    assert isinstance(loaded.transformer_blocks[0]["attn"]["to_q"], OrbitQuantLinear)
+
+
+def test_diffusers_on_the_fly_bounded_mode_rejects_pickle_checkpoint(tmp_path):
+    register_hf_quantizers()
+    TinyDiffusersTransformer().save_pretrained(tmp_path, safe_serialization=False)
+
+    with pytest.raises(RuntimeError, match="requires safetensors checkpoints"):
+        TinyDiffusersTransformer.from_pretrained(
+            tmp_path,
+            quantization_config=OrbitQuantConfig(block_size=8),
+            use_safetensors=False,
+        )
 
 
 def test_diffusers_modelmixin_save_pretrained_round_trips_pre_quantized_model(

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -15,6 +15,12 @@ def test_readme_documents_the_universal_public_contract():
     assert "quantize_model" in readme
     assert "save_pretrained" in readme
     assert "snapshot_download" in readme
+    assert "build_diffusers_pipeline_quantization_config" in readme
+    assert "enable_model_cpu_offload" in readme
+    assert "enable_sequential_cpu_offload" in readme
+    assert "requires safetensors" in normalized
+    assert "RSS separately from mmap virtual size" in normalized
+    assert "weight_row_tile_size" not in readme
     assert 'runtime_mode="auto_fused"' in readme
     assert 'runtime_mode="dequant_bf16"' in readme
     assert "does not guarantee a quality-preserving bit setting" in normalized

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -114,6 +114,9 @@ def test_backend_selection_is_explicit_and_fails_loud_for_unavailable_backends()
 def test_backend_capabilities_report_partial_and_fallback_kernel_status(monkeypatch):
     monkeypatch.setattr(dispatch_module, "_mps_metal_available", lambda: False)
     monkeypatch.setattr(dispatch_module, "_native_packed_matmul_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_packed_matmul_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_activation_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_adaln_available", lambda: False)
     capabilities = backend_capabilities(
         backends={"cpu": True, "mps": True, "triton_cuda": True}
     )
@@ -121,7 +124,10 @@ def test_backend_capabilities_report_partial_and_fallback_kernel_status(monkeypa
     assert capabilities["cpu"]["available"] is True
     assert capabilities["cpu"]["claim_status"] == "reference_only"
     assert capabilities["cpu"]["optimized"] is False
-    assert capabilities["cpu"]["implemented_stage"] is None
+    assert capabilities["cpu"]["implemented_stage"] == (
+        "activation_norm_rpbh_quant_rescale,packed_weight_matmul,"
+        "adaln_rtn_packed_matmul"
+    )
     assert capabilities["cpu"]["optimized_stage"] is None
     assert capabilities["cpu"]["weight_dequant_optimized"] is False
     assert capabilities["cpu"]["weight_pack_optimized"] is False
@@ -173,6 +179,9 @@ def test_backend_capabilities_report_partial_and_fallback_kernel_status(monkeypa
 def test_backend_capabilities_report_mps_metal_partial_kernel(monkeypatch):
     monkeypatch.setattr(dispatch_module, "_mps_metal_available", lambda: True)
     monkeypatch.setattr(dispatch_module, "_native_packed_matmul_available", lambda: True)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_packed_matmul_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_activation_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_adaln_available", lambda: False)
 
     capabilities = backend_capabilities(
         backends={"cpu": True, "mps": True, "triton_cuda": False}
@@ -227,6 +236,9 @@ def test_backend_capabilities_report_mps_metal_partial_kernel(monkeypatch):
 def test_backend_capabilities_report_mps_shader_without_native_matmul(monkeypatch):
     monkeypatch.setattr(dispatch_module, "_mps_metal_available", lambda: True)
     monkeypatch.setattr(dispatch_module, "_native_packed_matmul_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_packed_matmul_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_activation_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_adaln_available", lambda: False)
 
     capabilities = backend_capabilities(
         backends={"cpu": True, "mps": True, "triton_cuda": False}
@@ -253,6 +265,9 @@ def test_backend_capabilities_report_mps_shader_without_native_matmul(monkeypatc
 def test_backend_capabilities_report_mps_native_matmul_without_shader(monkeypatch):
     monkeypatch.setattr(dispatch_module, "_mps_metal_available", lambda: False)
     monkeypatch.setattr(dispatch_module, "_native_packed_matmul_available", lambda: True)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_packed_matmul_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_activation_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_adaln_available", lambda: False)
 
     capabilities = backend_capabilities(
         backends={"cpu": True, "mps": True, "triton_cuda": False}
@@ -264,6 +279,73 @@ def test_backend_capabilities_report_mps_native_matmul_without_shader(monkeypatc
     assert capabilities["mps"]["package_format"] == "native_kernel_package"
     assert capabilities["mps"]["optimized_stage"] == "packed_weight_matmul"
     assert capabilities["mps"]["weight_dequant_optimized"] is False
+
+
+def test_backend_capabilities_label_cpu_native_matmul_as_partial_not_fused(monkeypatch):
+    monkeypatch.setattr(dispatch_module, "_mps_metal_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_packed_matmul_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_packed_matmul_available", lambda: True)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_activation_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_adaln_available", lambda: False)
+
+    capabilities = backend_capabilities(
+        backends={"cpu": True, "mps": False, "triton_cuda": False}
+    )
+
+    assert capabilities["cpu"]["claim_status"] == "partial_optimized"
+    assert capabilities["cpu"]["optimized"] is True
+    assert capabilities["cpu"]["full_fusion"] is False
+    assert capabilities["cpu"]["optimized_stage"] == "packed_weight_matmul"
+    assert capabilities["cpu"]["implementation"] == (
+        "native_exact_packed_matmul+torch_activation_reference"
+    )
+    assert capabilities["cpu"]["hf_kernel_builder_compliant"] is True
+
+
+def test_backend_capabilities_report_native_cpu_activation_and_matmul(monkeypatch):
+    monkeypatch.setattr(dispatch_module, "_mps_metal_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_packed_matmul_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_packed_matmul_available", lambda: True)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_activation_available", lambda: True)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_adaln_available", lambda: False)
+
+    capabilities = backend_capabilities(
+        backends={"cpu": True, "mps": False, "triton_cuda": False}
+    )
+
+    assert capabilities["cpu"]["claim_status"] == "partial_optimized"
+    assert capabilities["cpu"]["optimized"] is True
+    assert capabilities["cpu"]["full_fusion"] is False
+    assert capabilities["cpu"]["optimized_stage"] == (
+        "activation_norm_rpbh_quant_rescale,packed_weight_matmul"
+    )
+    assert capabilities["cpu"]["implementation"] == (
+        "native_exact_activation+native_exact_packed_matmul"
+    )
+    assert capabilities["cpu"]["hf_kernel_builder_compliant"] is True
+
+
+def test_backend_capabilities_report_complete_native_cpu_kernel_surface(monkeypatch):
+    monkeypatch.setattr(dispatch_module, "_mps_metal_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_packed_matmul_available", lambda: False)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_packed_matmul_available", lambda: True)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_activation_available", lambda: True)
+    monkeypatch.setattr(dispatch_module, "_native_cpu_adaln_available", lambda: True)
+
+    capabilities = backend_capabilities(
+        backends={"cpu": True, "mps": False, "triton_cuda": False}
+    )
+
+    assert capabilities["cpu"]["optimized_stage"] == (
+        "activation_norm_rpbh_quant_rescale,packed_weight_matmul,"
+        "adaln_rtn_packed_matmul"
+    )
+    assert capabilities["cpu"]["adaln_quant_optimized"] is False
+    assert capabilities["cpu"]["adaln_dequant_optimized"] is True
+    assert capabilities["cpu"]["implementation"] == (
+        "native_exact_activation+native_exact_packed_matmul+native_packed_adaln_int4"
+    )
+    assert "without a full floating-point cache" in capabilities["cpu"]["notes"]
 
 
 def test_backend_selection_accepts_injected_availability_for_gpu_paths():

--- a/tests/test_model_card.py
+++ b/tests/test_model_card.py
@@ -59,6 +59,10 @@ def test_model_card_renders_rotation_and_codebook_metadata():
     assert "snapshot_download" in card
     assert "load_quantized_pipeline_from_artifact" in card
     assert "pipe.enable_model_cpu_offload(device=\"cuda\")" in card
+    assert "### Convert the source checkpoint on load" in card
+    assert "build_diffusers_pipeline_quantization_config" in card
+    assert "pipe.enable_sequential_cpu_offload()" in card
+    assert "requires a safetensors source checkpoint" in card
     assert "    device=\"cuda\"," not in card
     assert "load_quantized_pipeline_component" not in card
     assert "component=\"transformer\"" not in card
@@ -217,7 +221,7 @@ def test_model_card_renders_imported_vbench_release_metrics():
 def test_model_card_contains_install_command_not_workflow_log_language():
     card = render_model_card(_manifest_for_model("black-forest-labs/FLUX.1-schnell"))
 
-    assert 'pip install "orbitquant[hf,kernels]>=0.2.0"' in card
+    assert 'pip install "orbitquant[hf,kernels]>=0.3.1"' in card
     assert "git+https://github.com/iamwavecut/OrbitQuant.git" not in card
     for forbidden in (
         "reports/",

--- a/tests/test_model_card.py
+++ b/tests/test_model_card.py
@@ -221,7 +221,7 @@ def test_model_card_renders_imported_vbench_release_metrics():
 def test_model_card_contains_install_command_not_workflow_log_language():
     card = render_model_card(_manifest_for_model("black-forest-labs/FLUX.1-schnell"))
 
-    assert 'pip install "orbitquant[hf,kernels]>=0.3.1"' in card
+    assert 'pip install "orbitquant[hf,kernels]>=0.4.0"' in card
     assert "git+https://github.com/iamwavecut/OrbitQuant.git" not in card
     for forbidden in (
         "reports/",

--- a/tests/test_native_kernel_package.py
+++ b/tests/test_native_kernel_package.py
@@ -17,19 +17,44 @@ def _kernel_source_files() -> list[Path]:
     ]
 
 
-def test_kernel_builder_manifest_targets_cuda_and_metal() -> None:
+def test_kernel_builder_manifest_targets_cpu_cuda_and_metal() -> None:
     config = tomllib.loads((KERNEL_ROOT / "build.toml").read_text(encoding="utf-8"))
 
     assert config["general"]["name"] == "orbitquant-packed-matmul"
     assert config["general"]["edition"] == 5
     assert config["general"]["license"] == "Apache-2.0"
-    assert config["general"]["backends"] == ["cuda", "metal"]
+    assert config["general"]["backends"] == ["cpu", "cuda", "metal"]
     assert config["general"]["hub"]["repo-id"] == "WaveCut/orbitquant-packed-matmul"
     assert config["torch"]["src"] == [
         "torch-ext/torch_binding.cpp",
         "torch-ext/torch_binding.h",
     ]
     kernels = config["kernel"]
+    assert config["torch"]["stable-abi"] == {"cpu": "2.11"}
+    assert kernels["packed_matmul_cpu"]["backend"] == "cpu"
+    assert kernels["packed_matmul_cpu"]["depends"] == ["torch"]
+    assert kernels["packed_matmul_cpu"]["src"] == [
+        "orbitquant_packed_matmul_cpu/cpu_isa.cpp",
+        "orbitquant_packed_matmul_cpu/cpu_kernel_args.h",
+        "orbitquant_packed_matmul_cpu/cpu_threads.cpp",
+        "orbitquant_packed_matmul_cpu/cpu_threads.h",
+        "orbitquant_packed_matmul_cpu/packed_adaln_cpu.cpp",
+        "orbitquant_packed_matmul_cpu/packed_matmul_cpu.cpp",
+        "orbitquant_packed_matmul_cpu/packed_matmul_cpu.h",
+        "orbitquant_packed_matmul_cpu/packed_matmul_scalar.cpp",
+        "orbitquant_packed_matmul_cpu/packed_matmul_neon.cpp",
+        "orbitquant_packed_matmul_cpu/packed_matmul_x86_avx512.cpp",
+        "orbitquant_packed_matmul_cpu/quantize_activations_cpu.cpp",
+    ]
+    assert kernels["packed_matmul_cpu_x86_avx2"]["backend"] == "cpu"
+    assert kernels["packed_matmul_cpu_x86_avx2"]["depends"] == ["torch"]
+    assert kernels["packed_matmul_cpu_x86_avx2"]["cxx-flags"] == [
+        "$<$<CXX_COMPILER_ID:MSVC>:/arch:AVX2>"
+    ]
+    assert kernels["packed_matmul_cpu_x86_avx2"]["src"] == [
+        "orbitquant_packed_matmul_cpu/cpu_msvc_avx2.cpp",
+        "orbitquant_packed_matmul_cpu/packed_matmul_x86.cpp",
+    ]
     assert kernels["packed_matmul_cuda"]["backend"] == "cuda"
     assert kernels["packed_matmul_cuda"]["depends"] == ["torch"]
     assert kernels["packed_matmul_metal"]["backend"] == "metal"
@@ -41,8 +66,13 @@ def test_kernel_builder_binding_uses_abi3_safe_registration_pattern() -> None:
     header = (KERNEL_ROOT / "torch-ext/torch_binding.h").read_text(encoding="utf-8")
 
     assert "TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops)" in binding
+    assert "STABLE_TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops)" in binding
+    assert "STABLE_TORCH_LIBRARY_IMPL_EXPAND" in binding
+    assert "TORCH_BOX(&matmul_packed_weight)" in binding
+    assert "TORCH_BOX(&matmul_packed_adaln_int4_cpu)" in binding
     assert "REGISTER_EXTENSION(TORCH_EXTENSION_NAME)" in binding
     assert "torch/torch.h" in header
+    assert "torch/csrc/stable/tensor.h" in header
 
     combined = "\n".join(
         path.read_text(encoding="utf-8")
@@ -57,7 +87,7 @@ def test_kernel_builder_binding_uses_abi3_safe_registration_pattern() -> None:
         "py::",
         "TORCH_LIBRARY(",
         "TORCH_LIBRARY_FRAGMENT",
-        "TORCH_LIBRARY_IMPL",
+        "TORCH_LIBRARY_IMPL(",
         "PyInit",
         "torch.ops.",
         "import orbitquant",
@@ -109,6 +139,33 @@ def test_kernel_sources_expose_the_current_runtime_contract() -> None:
     metal_source = (KERNEL_ROOT / "orbitquant_packed_matmul_metal/packed_matmul.metal").read_text(
         encoding="utf-8"
     )
+    cpu_source = (KERNEL_ROOT / "orbitquant_packed_matmul_cpu/packed_matmul_cpu.cpp").read_text(
+        encoding="utf-8"
+    )
+    cpu_isa_source = (
+        KERNEL_ROOT / "orbitquant_packed_matmul_cpu/cpu_isa.cpp"
+    ).read_text(encoding="utf-8")
+    cpu_msvc_avx2_source = (
+        KERNEL_ROOT / "orbitquant_packed_matmul_cpu/cpu_msvc_avx2.cpp"
+    ).read_text(encoding="utf-8")
+    cpu_threads_source = (
+        KERNEL_ROOT / "orbitquant_packed_matmul_cpu/cpu_threads.cpp"
+    ).read_text(encoding="utf-8")
+    cpu_neon_source = (
+        KERNEL_ROOT / "orbitquant_packed_matmul_cpu/packed_matmul_neon.cpp"
+    ).read_text(encoding="utf-8")
+    cpu_avx2_source = (
+        KERNEL_ROOT / "orbitquant_packed_matmul_cpu/packed_matmul_x86.cpp"
+    ).read_text(encoding="utf-8")
+    cpu_avx512_source = (
+        KERNEL_ROOT / "orbitquant_packed_matmul_cpu/packed_matmul_x86_avx512.cpp"
+    ).read_text(encoding="utf-8")
+    cpu_activation_source = (
+        KERNEL_ROOT / "orbitquant_packed_matmul_cpu/quantize_activations_cpu.cpp"
+    ).read_text(encoding="utf-8")
+    cpu_adaln_source = (
+        KERNEL_ROOT / "orbitquant_packed_matmul_cpu/packed_adaln_cpu.cpp"
+    ).read_text(encoding="utf-8")
 
     for token in (
         "packed_weight_indices",
@@ -137,6 +194,34 @@ def test_kernel_sources_expose_the_current_runtime_contract() -> None:
     assert "threadgroup float *shared" in metal_source
     assert "threadgroup_barrier(mem_flags::mem_threadgroup)" in metal_source
     assert "params.block_k" in metal_source
+    assert "torch::headeronly::ScalarType" in cpu_source
+    assert "packed_matmul_neon_available" in cpu_source
+    assert "vfmaq_f32" in cpu_neon_source
+    assert "packed_matmul_scalar_range" in cpu_neon_source
+    assert "ORBITQUANT_CPU_ISA" in cpu_source
+    assert "packed_matmul_x86_avx2_available" in cpu_source
+    assert "_mm256_permutevar8x32_ps" in cpu_avx2_source
+    assert "runtime_has_avx2_fma_f16c" in cpu_isa_source
+    assert "__cpuidex" in cpu_isa_source
+    assert "activation_fwht_msvc_avx2" in cpu_msvc_avx2_source
+    assert "packed_adaln_msvc_avx2_range" in cpu_msvc_avx2_source
+    assert "_mm512_permutexvar_ps" in cpu_avx512_source
+    assert "_mm512_permutexvar_epi16" in cpu_avx512_source
+    assert "_mm512_dpbf16_ps" in cpu_avx512_source
+    assert '__builtin_cpu_supports("avx512bf16")' in cpu_avx512_source
+    assert "kPrimaryRowTile = 8" in cpu_avx512_source
+    assert "quantize_lookup_avx2" in cpu_activation_source
+    assert "quantize_lookup_avx512" in cpu_activation_source
+    assert "_mm512_mask_add_epi32" in cpu_activation_source
+    assert "select_activation_isa" in cpu_activation_source
+    assert "packed_adaln_scalar_range" in cpu_adaln_source
+    assert "packed_adaln_neon_range" in cpu_adaln_source
+    assert "packed_adaln_avx2_range" in cpu_adaln_source
+    assert "packed_adaln_avx512_range" in cpu_adaln_source
+    assert "_mm512_dpbf16_ps" in cpu_adaln_source
+    assert "sched_getaffinity" in cpu_threads_source
+    assert "physical_package_id" in cpu_threads_source
+    assert "hw.perflevel0.physicalcpu" in cpu_threads_source
 
 
 def test_cuda_kernel_uses_wmma_for_supported_bf16_and_fp16_low_bit_modes() -> None:
@@ -183,8 +268,16 @@ def test_kernel_benchmark_reports_reference_comparison() -> None:
     assert "reference_weight" in benchmark_source
     assert "materialize_reference_weight" in benchmark_source
     assert "packed_seconds_per_iter" in benchmark_source
+    assert 'choices=["cpu", "cuda", "mps"]' in benchmark_source
+    assert "packed_first_call_seconds" in benchmark_source
+    assert "packed_hot_median_seconds" in benchmark_source
+    assert "packed_hot_p95_seconds" in benchmark_source
     assert "predequantized_f_linear_seconds_per_iter" in benchmark_source
+    assert "predequantized_hot_median_seconds" in benchmark_source
+    assert "predequantized_hot_p95_seconds" in benchmark_source
     assert "dequantize_then_f_linear_seconds_per_iter" in benchmark_source
+    assert "dequantize_then_hot_median_seconds" in benchmark_source
+    assert "dequantize_then_hot_p95_seconds" in benchmark_source
     assert "packed_weight_indices_bytes" in benchmark_source
     assert "row_norms_bytes" in benchmark_source
     assert "centroid_bytes" in benchmark_source
@@ -196,3 +289,4 @@ def test_kernel_benchmark_reports_reference_comparison() -> None:
     assert "reference_seconds_per_iter" in benchmark_source
     assert "packed_vs_reference_speedup" in benchmark_source
     assert "max_abs_error" in benchmark_source
+    assert "relative_rmse" in benchmark_source

--- a/tests/test_native_packed_matmul.py
+++ b/tests/test_native_packed_matmul.py
@@ -9,10 +9,17 @@ import orbitquant.kernels.native_packed_matmul as native_module
 from orbitquant.codebooks import get_codebook
 
 
-def test_native_packed_matmul_rejects_cpu_before_loading_kernel():
+def test_native_packed_matmul_rejects_variant_without_cpu_backend(monkeypatch):
     codebook = get_codebook(dim=16, bits=4)
+    fake_kernel = SimpleNamespace(
+        matmul_packed_weight=lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("unsupported CPU variant must not be invoked")
+        ),
+        supports_device=lambda device_type: device_type == "mps",
+    )
+    monkeypatch.setattr(native_module, "_NATIVE_KERNEL", fake_kernel)
 
-    with pytest.raises(RuntimeError, match="requires CUDA or MPS input tensors"):
+    with pytest.raises(RuntimeError, match="does not contain a CPU backend"):
         native_module.matmul_packed_weight_with_native_kernel(
             torch.randn(2, 16),
             torch.empty(56, dtype=torch.uint8),
@@ -21,6 +28,39 @@ def test_native_packed_matmul_rejects_cpu_before_loading_kernel():
             bits=4,
             out_features=7,
             in_features=16,
+        )
+
+
+def test_native_device_capability_treats_legacy_variants_as_accelerator_only(monkeypatch):
+    fake_legacy_kernel = SimpleNamespace(matmul_packed_weight=lambda *args, **kwargs: None)
+    monkeypatch.setattr(native_module, "_NATIVE_KERNEL", fake_legacy_kernel)
+
+    assert native_module.native_packed_matmul_device_available("cpu") is False
+    assert native_module.native_packed_matmul_device_available("mps") is True
+
+
+def test_native_cpu_adaln_availability_requires_capability_operation(monkeypatch):
+    fake_kernel = SimpleNamespace(
+        supports_cpu_adaln=lambda: True,
+        matmul_packed_adaln_int4_cpu=lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(native_module, "_NATIVE_KERNEL", fake_kernel)
+
+    assert native_module.native_cpu_adaln_available() is True
+
+
+def test_native_cpu_adaln_bridge_rejects_legacy_variant(monkeypatch):
+    fake_kernel = SimpleNamespace(matmul_packed_adaln_int4_cpu=lambda *args, **kwargs: None)
+    monkeypatch.setattr(native_module, "_NATIVE_KERNEL", fake_kernel)
+
+    with pytest.raises(RuntimeError, match="does not provide the CPU AdaLN"):
+        native_module.matmul_packed_adaln_int4_with_native_cpu_kernel(
+            torch.randn(2, 8, dtype=torch.bfloat16),
+            torch.empty(32, dtype=torch.uint8),
+            torch.ones(4, 1, dtype=torch.bfloat16),
+            out_features=4,
+            in_features=8,
+            group_size=8,
         )
 
 

--- a/tests/test_offload_integration.py
+++ b/tests/test_offload_integration.py
@@ -1,0 +1,102 @@
+import pytest
+import torch
+
+from orbitquant import OrbitQuantConfig, build_diffusers_pipeline_quantization_config
+from orbitquant.layers import OrbitQuantLinear
+
+diffusers = pytest.importorskip("diffusers")
+configuration_utils = pytest.importorskip("diffusers.configuration_utils")
+pytest.importorskip("accelerate")
+
+
+class TinyOffloadTransformer(diffusers.ModelMixin, diffusers.ConfigMixin):
+    config_name = "config.json"
+
+    @configuration_utils.register_to_config
+    def __init__(self, hidden_size: int = 16):
+        super().__init__()
+        self.transformer_blocks = torch.nn.ModuleList(
+            [
+                torch.nn.ModuleDict(
+                    {
+                        "attn": torch.nn.ModuleDict(
+                            {"to_q": torch.nn.Linear(hidden_size, hidden_size)}
+                        )
+                    }
+                )
+            ]
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.transformer_blocks[0]["attn"]["to_q"](x)
+
+
+# Make the synthetic component discoverable through the same public Diffusers
+# library lookup used by real pipeline components.
+TinyOffloadTransformer.__module__ = "diffusers"
+diffusers.TinyOffloadTransformer = TinyOffloadTransformer
+
+
+class TinyOffloadPipeline(diffusers.DiffusionPipeline):
+    model_cpu_offload_seq = "transformer"
+
+    def __init__(self, transformer: TinyOffloadTransformer):
+        super().__init__()
+        self.register_modules(transformer=transformer)
+
+    def __call__(self, x: torch.Tensor) -> torch.Tensor:
+        output = self.transformer(x)
+        self.maybe_free_model_hooks()
+        return output
+
+
+def _streaming_pipeline(tmp_path):
+    source = TinyOffloadPipeline(TinyOffloadTransformer())
+    source.save_pretrained(tmp_path)
+    quantization_config = build_diffusers_pipeline_quantization_config(
+        OrbitQuantConfig(
+            block_size=8,
+            runtime_mode="debug_no_activation_quant",
+            activation_kernel_backend="cpu",
+            weight_row_tile_size=2,
+        ),
+        components="transformer",
+    )
+    return TinyOffloadPipeline.from_pretrained(
+        tmp_path,
+        quantization_config=quantization_config,
+        torch_dtype=torch.bfloat16,
+    )
+
+
+def _quantized_linear(pipe):
+    return pipe.transformer.transformer_blocks[0]["attn"]["to_q"]
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="MPS is not available")
+def test_streaming_pipeline_model_cpu_offload_repeats_without_pinned_weight_cache(tmp_path):
+    pipe = _streaming_pipeline(tmp_path)
+    assert isinstance(_quantized_linear(pipe), OrbitQuantLinear)
+    pipe.enable_model_cpu_offload(device="mps")
+
+    for _ in range(2):
+        output = pipe(torch.randn(2, 3, 16, dtype=torch.bfloat16))
+        linear = _quantized_linear(pipe)
+        assert torch.isfinite(output).all()
+        assert linear.packed_weight_indices.device.type == "cpu"
+        assert linear._dequantized_weight_cache is None
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="MPS is not available")
+def test_streaming_pipeline_sequential_cpu_offload_repeats_and_offloads_packed_state(tmp_path):
+    pipe = _streaming_pipeline(tmp_path)
+    assert isinstance(_quantized_linear(pipe), OrbitQuantLinear)
+    pipe.enable_sequential_cpu_offload(device="mps")
+
+    for _ in range(2):
+        output = pipe(torch.randn(2, 3, 16, dtype=torch.bfloat16))
+        linear = _quantized_linear(pipe)
+        assert torch.isfinite(output).all()
+        assert linear.packed_weight_indices.device.type == "meta"
+        assert linear.row_norms.device.type == "meta"
+        assert linear._dequantized_weight_cache is None

--- a/tests/test_orbit_linear.py
+++ b/tests/test_orbit_linear.py
@@ -226,8 +226,19 @@ def test_orbit_linear_records_last_effective_runtime_and_activation_backend():
 
     quantized(x)
 
-    assert quantized.last_effective_runtime_mode == "dequant_bf16"
-    assert quantized.last_activation_kernel_backend == "cpu"
+    expected_runtime = (
+        "native_packed_matmul"
+        if layers_module._native_cpu_packed_matmul_load_error() is None
+        else "dequant_bf16"
+    )
+    assert quantized.last_effective_runtime_mode == expected_runtime
+    expected_activation_backend = (
+        "native_cpu"
+        if expected_runtime == "native_packed_matmul"
+        and quantized._native_cpu_activation_available(x)
+        else "cpu"
+    )
+    assert quantized.last_activation_kernel_backend == expected_activation_backend
     assert quantized.last_forward_device_type == "cpu"
 
 
@@ -267,7 +278,13 @@ def test_orbit_linear_caches_dequantized_weight(monkeypatch):
     torch.manual_seed(2)
     source = torch.nn.Linear(16, 7)
     x = torch.randn(2, 5, 16)
-    config = OrbitQuantConfig(weight_bits=4, activation_bits=4, rotation_seed=11, block_size=8)
+    config = OrbitQuantConfig(
+        weight_bits=4,
+        activation_bits=4,
+        rotation_seed=11,
+        block_size=8,
+        runtime_mode="dequant_bf16",
+    )
     quantized = OrbitQuantLinear.from_linear(source, config=config, module_name="block.ff.linear")
     calls = 0
     original_unpack = layers_module.unpack_lowbit
@@ -489,9 +506,7 @@ def test_orbit_linear_triton_packed_matmul_runtime_avoids_weight_dequant_cache(m
     ]
 
 
-def test_orbit_linear_native_packed_matmul_runtime_rejects_cpu_before_quantization(
-    monkeypatch,
-):
+def test_orbit_linear_native_packed_matmul_runtime_accepts_cpu_input():
     torch.manual_seed(5)
     source = torch.nn.Linear(16, 7)
     config = OrbitQuantConfig(
@@ -505,17 +520,7 @@ def test_orbit_linear_native_packed_matmul_runtime_rejects_cpu_before_quantizati
     quantized = OrbitQuantLinear.from_linear(source, config=config, module_name="block.ff.linear")
     x = torch.randn(2, 5, 16)
 
-    def fail_activation_quantization(*args, **kwargs):
-        raise AssertionError("device validation should run before activation quantization")
-
-    monkeypatch.setattr(
-        layers_module,
-        "quantize_activations_kernel",
-        fail_activation_quantization,
-    )
-
-    with pytest.raises(RuntimeError, match="requires CUDA or MPS input tensors"):
-        quantized(x)
+    quantized._validate_native_packed_matmul_input(x)
 
 
 def test_orbit_linear_native_packed_matmul_runtime_avoids_weight_dequant_cache(monkeypatch):
@@ -862,9 +867,11 @@ def test_orbit_linear_native_packed_matmul_mps_matches_dequant_bf16(monkeypatch)
     if not torch.backends.mps.is_available():
         pytest.skip("MPS backend is not available")
     try:
-        import orbitquant_packed_matmul  # noqa: F401
+        import orbitquant_packed_matmul
     except Exception:
         pytest.skip("native packed matmul kernel package is not importable")
+    if not orbitquant_packed_matmul.supports_device("mps"):
+        pytest.skip("the importable native packed matmul variant has no MPS backend")
 
     import orbitquant.kernels.native_packed_matmul as native_module
 
@@ -901,18 +908,22 @@ def test_orbit_linear_native_packed_matmul_mps_matches_dequant_bf16(monkeypatch)
 def test_orbit_linear_auto_fused_native_packed_matmul_matches_reference_without_dequant(
     monkeypatch,
 ):
-    if torch.cuda.is_available():
-        device = torch.device("cuda")
-        dtype = torch.bfloat16
-    elif torch.backends.mps.is_available():
-        device = torch.device("mps")
-        dtype = torch.float32
-    else:
-        pytest.skip("CUDA or MPS backend is required")
     try:
-        import orbitquant_packed_matmul  # noqa: F401
+        import orbitquant_packed_matmul
     except Exception:
         pytest.skip("native packed matmul kernel package is not importable")
+
+    if torch.cuda.is_available() and orbitquant_packed_matmul.supports_device("cuda"):
+        device = torch.device("cuda")
+        dtype = torch.bfloat16
+    elif torch.backends.mps.is_available() and orbitquant_packed_matmul.supports_device("mps"):
+        device = torch.device("mps")
+        dtype = torch.float32
+    elif orbitquant_packed_matmul.supports_device("cpu"):
+        device = torch.device("cpu")
+        dtype = torch.float32
+    else:
+        pytest.skip("the importable native packed matmul variant has no runnable backend")
 
     import orbitquant.kernels.native_packed_matmul as native_module
 
@@ -935,6 +946,7 @@ def test_orbit_linear_auto_fused_native_packed_matmul_matches_reference_without_
     packed = copy.deepcopy(reference).to(device)
     packed.runtime_mode = "auto_fused"
     monkeypatch.setattr(native_module, "_NATIVE_KERNEL", None)
+    layers_module._clear_packed_matmul_probe_cache()
 
     def fail_dequantize_weight(*args, **kwargs):
         raise AssertionError("auto_fused native runtime materialized dequantized weights")

--- a/tests/test_paper_reference_oracle.py
+++ b/tests/test_paper_reference_oracle.py
@@ -119,20 +119,30 @@ def test_rpbh_matches_independent_dense_equation_9_oracle():
 
 
 @pytest.mark.parametrize(
-    ("weight_bits", "activation_bits", "with_bias"),
+    ("weight_bits", "activation_bits", "with_bias", "runtime_mode"),
     [
-        (4, 4, True),
-        (3, 3, False),
-        (2, 4, True),
-        (2, 3, False),
-        (4, 6, True),
+        (4, 4, True, "dequant_bf16"),
+        (3, 3, False, "dequant_bf16"),
+        (2, 4, True, "dequant_bf16"),
+        (2, 3, False, "dequant_bf16"),
+        (4, 6, True, "dequant_bf16"),
+        (4, 4, True, "native_packed_matmul"),
     ],
 )
 def test_reference_runtime_matches_independent_algorithm_1_oracle(
     weight_bits: int,
     activation_bits: int,
     with_bias: bool,
+    runtime_mode: str,
 ):
+    if runtime_mode == "native_packed_matmul":
+        try:
+            import orbitquant_packed_matmul
+        except Exception:
+            pytest.skip("native packed matmul kernel package is not importable")
+        if not orbitquant_packed_matmul.supports_device("cpu"):
+            pytest.skip("the importable native packed matmul variant has no CPU backend")
+
     torch.manual_seed(202)
     source = torch.nn.Linear(24, 5, bias=with_bias)
     with torch.no_grad():
@@ -144,7 +154,7 @@ def test_reference_runtime_matches_independent_algorithm_1_oracle(
         activation_bits=activation_bits,
         rotation_seed=29,
         block_size="paper",
-        runtime_mode="dequant_bf16",
+        runtime_mode=runtime_mode,
         activation_kernel_backend="cpu",
     )
     layer = OrbitQuantLinear.from_linear(
@@ -229,7 +239,7 @@ def test_adaln_group64_rtn_matches_independent_weight_only_contract():
         source.bias.copy_(torch.tensor([-0.25, 0.0, 0.5]))
     layer = RTNInt4Linear.from_linear(
         source,
-        config=OrbitQuantConfig(),
+        config=OrbitQuantConfig(runtime_mode="dequant_bf16"),
         module_name="transformer_blocks.0.norm1.linear",
     )
 

--- a/tests/test_quantizer_adapter.py
+++ b/tests/test_quantizer_adapter.py
@@ -1,7 +1,9 @@
 from collections import OrderedDict
+from pathlib import Path
 
 import pytest
 import torch
+from safetensors.torch import save_file
 
 from orbitquant.adaln import RTNInt4Linear
 from orbitquant.config import OrbitQuantConfig
@@ -228,7 +230,10 @@ def test_quantizer_defaults_to_auto_quantization_device(monkeypatch):
     assert seen_values == ["auto"]
 
 
-def test_transformers_streaming_conversion_moves_weight_to_quantization_device(monkeypatch):
+def test_transformers_streaming_conversion_passes_tile_quantization_device(
+    tmp_path,
+    monkeypatch,
+):
     pytest.importorskip("transformers")
     from orbitquant.transformers_ops import OrbitQuantWeightQuantize
 
@@ -238,17 +243,27 @@ def test_transformers_streaming_conversion_moves_weight_to_quantization_device(m
         pre_quantized=False,
         quantization_device="cpu",
     )
-    quantizer._process_model_before_weight_loading(model, checkpoint_files=["dummy.safetensors"])
-    seen_weights = []
+    checkpoint = tmp_path / "model.safetensors"
+    save_file(
+        {
+            "transformer_blocks.0.attn.to_q.weight": model.transformer_blocks[0][
+                "attn"
+            ]["to_q"].weight
+        },
+        checkpoint,
+    )
+    quantizer._process_model_before_weight_loading(model, checkpoint_files=[checkpoint])
+    seen_calls = []
+    original_from_weight = OrbitQuantLinear.from_weight.__func__
 
-    def fake_move_tensor_for_quantization(tensor):
-        seen_weights.append(tensor)
-        return tensor
+    def recording_from_weight(cls, weight, **kwargs):
+        seen_calls.append((weight.device, kwargs["quantization_device"]))
+        return original_from_weight(cls, weight, **kwargs)
 
     monkeypatch.setattr(
-        quantizer,
-        "move_tensor_for_quantization",
-        fake_move_tensor_for_quantization,
+        OrbitQuantLinear,
+        "from_weight",
+        classmethod(recording_from_weight),
     )
     op = OrbitQuantWeightQuantize(quantizer)
 
@@ -258,16 +273,15 @@ def test_transformers_streaming_conversion_moves_weight_to_quantization_device(m
         model=model,
     )
 
-    assert seen_weights
+    assert seen_calls == [(torch.device("cpu"), torch.device("cpu"))]
     assert set(results) == {
         "transformer_blocks.0.attn.to_q.packed_weight_indices",
         "transformer_blocks.0.attn.to_q.row_norms",
     }
 
 
-def test_transformers_streaming_quantizer_declares_and_clears_weight_conversions():
+def test_transformers_streaming_quantizer_builds_and_cleans_bounded_packed_shard(tmp_path):
     pytest.importorskip("transformers.core_model_loading")
-    from orbitquant.transformers_ops import OrbitQuantWeightQuantize
 
     model = TinyQuantizerTransformer()
     model.transformer_blocks[0]["modulation"] = torch.nn.Linear(16, 32)
@@ -279,24 +293,40 @@ def test_transformers_streaming_quantizer_declares_and_clears_weight_conversions
 
     assert quantizer.get_weight_conversions() == []
 
-    quantizer._process_model_before_weight_loading(model, checkpoint_files=["dummy.safetensors"])
-    conversions = quantizer.get_weight_conversions()
-    targets = {tuple(conversion.target_patterns): conversion for conversion in conversions}
+    checkpoint = tmp_path / "model.safetensors"
+    save_file(
+        {
+            "transformer_blocks.0.attn.to_q.weight": model.transformer_blocks[0][
+                "attn"
+            ]["to_q"].weight,
+            "transformer_blocks.0.modulation.weight": model.transformer_blocks[0][
+                "modulation"
+            ].weight,
+        },
+        checkpoint,
+    )
+    checkpoint_files = [checkpoint]
+    quantizer._process_model_before_weight_loading(
+        model,
+        checkpoint_files=checkpoint_files,
+    )
+    packed_checkpoint = checkpoint_files[-1]
 
-    assert set(targets) == {
-        ("transformer_blocks.0.attn.to_q.packed_weight_indices",),
-        ("transformer_blocks.0.modulation.packed_weight",),
-    }
-    for conversion in conversions:
-        assert conversion.source_patterns[0].endswith(".weight")
-        assert len(conversion.operations) == 1
-        assert isinstance(conversion.operations[0], OrbitQuantWeightQuantize)
+    assert quantizer.get_weight_conversions() == []
+    assert len(checkpoint_files) == 2
+    assert packed_checkpoint.endswith("orbitquant-streaming.safetensors")
+    assert Path(packed_checkpoint).is_file()
+    assert isinstance(model.transformer_blocks[0]["attn"]["to_q"], OrbitQuantLinear)
+    assert isinstance(model.transformer_blocks[0]["modulation"], RTNInt4Linear)
+    assert any(
+        "transformer_blocks\\.0\\.attn\\.to_q\\.weight" in pattern
+        for pattern in model._keys_to_ignore_on_load_unexpected
+    )
 
-    model._weight_conversions = conversions
     quantizer._process_model_after_weight_loading(model)
 
-    assert not hasattr(model, "_weight_conversions")
     assert quantizer.get_weight_conversions() == []
+    assert not Path(packed_checkpoint).exists()
 
 
 def test_pre_quantized_skeleton_accepts_packed_state_dict_strictly():

--- a/tests/test_streaming_quantization.py
+++ b/tests/test_streaming_quantization.py
@@ -1,0 +1,67 @@
+import pytest
+import torch
+
+from orbitquant.adaln import (
+    _quantize_adaln_weight_bounded,
+    _quantize_adaln_weight_reference,
+)
+from orbitquant.codebooks import get_codebook
+from orbitquant.layers import _quantize_weight_bounded, _quantize_weight_pack
+from orbitquant.rotations import get_rpbh_rotation
+from orbitquant.streaming import iter_aligned_row_tiles
+
+
+@pytest.mark.parametrize("bits", [2, 3, 4, 6])
+def test_row_tiled_orbitquant_matches_full_matrix_reference_with_padding(bits):
+    torch.manual_seed(bits)
+    weight = torch.randn(19, 18, dtype=torch.bfloat16)
+    rotation = get_rpbh_rotation(18, seed=7, block_size="paper")
+    codebook = get_codebook(18, bits, algorithm_version=2)
+    reference_weight = weight.to(torch.float32)
+    reference_norms = reference_weight.norm(dim=-1)
+    expected = _quantize_weight_pack(
+        reference_weight,
+        reference_norms,
+        rotation=rotation,
+        codebook=codebook,
+        bits=bits,
+        eps=1e-10,
+    )
+
+    actual, actual_norms = _quantize_weight_bounded(
+        weight,
+        rotation=rotation,
+        codebook=codebook,
+        bits=bits,
+        eps=1e-10,
+        row_tile_size=3,
+    )
+
+    assert actual.numel() == (weight.numel() * bits + 7) // 8
+    assert torch.equal(actual, expected)
+    assert torch.equal(actual_norms, reference_norms.to(torch.bfloat16))
+
+
+def test_row_tiles_align_non_final_payloads_to_byte_boundaries():
+    tiles = list(iter_aligned_row_tiles(19, values_per_row=18, bits=3, max_rows=3))
+
+    assert tiles == [(0, 4), (4, 8), (8, 12), (12, 16), (16, 19)]
+    assert all((end - start) * 18 * 3 % 8 == 0 for start, end in tiles[:-1])
+
+
+def test_row_tiled_adaln_matches_full_matrix_reference_with_group_padding():
+    torch.manual_seed(11)
+    weight = torch.randn(19, 18, dtype=torch.bfloat16)
+    expected_packed, expected_scales = _quantize_adaln_weight_reference(
+        weight,
+        group_size=7,
+    )
+
+    actual_packed, actual_scales = _quantize_adaln_weight_bounded(
+        weight,
+        group_size=7,
+        row_tile_size=3,
+    )
+
+    assert torch.equal(actual_packed, expected_packed)
+    assert torch.equal(actual_scales, expected_scales.to(torch.bfloat16))

--- a/tests/test_transformers_pretrained_integration.py
+++ b/tests/test_transformers_pretrained_integration.py
@@ -62,8 +62,15 @@ def test_transformers_pretrained_from_pretrained_quantizes_on_load(tmp_path):
     assert isinstance(loaded.transformer_blocks[0]["attn"]["to_q"], OrbitQuantLinear)
     assert isinstance(loaded.transformer_blocks[0]["modulation"], RTNInt4Linear)
     assert isinstance(loaded.proj_out, torch.nn.Linear)
+    quantized = loaded.transformer_blocks[0]["attn"]["to_q"]
+    assert not quantized._derived_constants_valid
     x = torch.randn(2, 3, 16)
     assert torch.isfinite(loaded(x)).all()
+    assert quantized._derived_constants_valid
+    assert torch.equal(
+        torch.unique(quantized._rotation_signs),
+        torch.tensor([-1, 1], dtype=torch.int8),
+    )
 
 
 def test_transformers_pretrained_streams_full_precision_weight_into_packed_tensors(
@@ -98,8 +105,14 @@ def test_transformers_pretrained_streams_full_precision_weight_into_packed_tenso
     assert quantized.row_norms is not None
     assert modulation.packed_weight is not None
     assert modulation.scales is not None
+    assert not quantized._derived_constants_valid
     x = torch.randn(2, 3, 16)
     assert torch.isfinite(loaded(x)).all()
+    assert quantized._derived_constants_valid
+    assert torch.equal(
+        torch.unique(quantized._rotation_signs),
+        torch.tensor([-1, 1], dtype=torch.int8),
+    )
 
 
 def test_transformers_pretrained_save_pretrained_round_trips_pre_quantized_model(

--- a/tests/test_transformers_pretrained_integration.py
+++ b/tests/test_transformers_pretrained_integration.py
@@ -1,4 +1,6 @@
+import gc
 import json
+import weakref
 
 import pytest
 import torch
@@ -71,7 +73,14 @@ def test_transformers_pretrained_streams_full_precision_weight_into_packed_tenso
     monkeypatch,
 ):
     register_hf_quantizers()
-    model = TinyTransformersModel(TinyTransformersConfig())
+    hidden_size = 128
+    model = TinyTransformersModel(TinyTransformersConfig(hidden_size=hidden_size))
+    config = OrbitQuantConfig(block_size=8, weight_row_tile_size=2)
+    expected = OrbitQuantLinear.from_linear(
+        model.transformer_blocks[0]["attn"]["to_q"],
+        config=config,
+        module_name="transformer_blocks.0.attn.to_q",
+    )
     model.save_pretrained(tmp_path)
 
     def fail_post_load_quantization(*args, **kwargs):
@@ -84,7 +93,7 @@ def test_transformers_pretrained_streams_full_precision_weight_into_packed_tenso
 
     loaded, loading_info = TinyTransformersModel.from_pretrained(
         tmp_path,
-        quantization_config=OrbitQuantConfig(block_size=8),
+        quantization_config=config,
         output_loading_info=True,
     )
 
@@ -96,10 +105,112 @@ def test_transformers_pretrained_streams_full_precision_weight_into_packed_tenso
     assert isinstance(modulation, RTNInt4Linear)
     assert quantized.packed_weight_indices is not None
     assert quantized.row_norms is not None
+    assert torch.equal(quantized.packed_weight_indices, expected.packed_weight_indices)
+    assert torch.equal(quantized.row_norms, expected.row_norms)
     assert modulation.packed_weight is not None
     assert modulation.scales is not None
-    x = torch.randn(2, 3, 16)
+    assert loaded.hf_quantizer.released_source_tensor_bytes > 0
+    assert loaded.hf_quantizer.source_page_release_failures == 0
+    x = torch.randn(2, 3, hidden_size)
     assert torch.isfinite(loaded(x)).all()
+
+
+def test_transformers_pretrained_streams_sharded_safetensors(tmp_path, monkeypatch):
+    register_hf_quantizers()
+    model = TinyTransformersModel(TinyTransformersConfig())
+    model.save_pretrained(tmp_path, max_shard_size="1KB")
+    assert (tmp_path / "model.safetensors.index.json").is_file()
+
+    def fail_post_load_quantization(*args, **kwargs):
+        raise AssertionError("Transformers load fell back to post-load quantization")
+
+    monkeypatch.setattr(
+        "orbitquant.quantizer.quantize_linear_modules",
+        fail_post_load_quantization,
+    )
+    source_refs = []
+    original_from_weight = OrbitQuantLinear.from_weight.__func__
+
+    def recording_from_weight(cls, weight, **kwargs):
+        source_refs.append(weakref.ref(weight))
+        return original_from_weight(cls, weight, **kwargs)
+
+    monkeypatch.setattr(
+        OrbitQuantLinear,
+        "from_weight",
+        classmethod(recording_from_weight),
+    )
+
+    loaded, loading_info = TinyTransformersModel.from_pretrained(
+        tmp_path,
+        quantization_config=OrbitQuantConfig(block_size=8, weight_row_tile_size=2),
+        output_loading_info=True,
+    )
+
+    assert not loading_info["missing_keys"]
+    assert not loading_info["unexpected_keys"]
+    assert isinstance(loaded.transformer_blocks[0]["attn"]["to_q"], OrbitQuantLinear)
+    gc.collect()
+    assert source_refs
+    assert all(ref() is None for ref in source_refs)
+
+
+def test_transformers_streaming_respects_auto_device_map_and_max_memory(tmp_path):
+    register_hf_quantizers()
+    TinyTransformersModel(TinyTransformersConfig()).save_pretrained(tmp_path)
+
+    loaded = TinyTransformersModel.from_pretrained(
+        tmp_path,
+        quantization_config=OrbitQuantConfig(block_size=8),
+        device_map="auto",
+        max_memory={"cpu": "64MB"},
+    )
+
+    quantized = loaded.transformer_blocks[0]["attn"]["to_q"]
+    assert quantized.packed_weight_indices.device.type == "cpu"
+    assert quantized.row_norms.device.type == "cpu"
+    assert loaded.proj_out.weight.device.type == "cpu"
+
+
+def test_transformers_streaming_respects_disk_offload_for_packed_state(tmp_path):
+    register_hf_quantizers()
+    source_dir = tmp_path / "source"
+    offload_dir = tmp_path / "offload"
+    TinyTransformersModel(TinyTransformersConfig()).save_pretrained(source_dir)
+
+    loaded = TinyTransformersModel.from_pretrained(
+        source_dir,
+        quantization_config=OrbitQuantConfig(
+            block_size=8,
+            runtime_mode="debug_no_activation_quant",
+            activation_kernel_backend="cpu",
+        ),
+        device_map={"transformer_blocks": "disk", "proj_out": "cpu"},
+        offload_folder=offload_dir,
+    )
+    quantized = loaded.transformer_blocks[0]["attn"]["to_q"]
+
+    assert quantized.packed_weight_indices.device.type == "meta"
+    assert quantized.row_norms.device.type == "meta"
+    assert hasattr(quantized, "_hf_hook")
+    assert torch.isfinite(loaded(torch.randn(2, 3, 16))).all()
+    assert quantized.packed_weight_indices.device.type == "meta"
+    assert quantized._dequantized_weight_cache is None
+
+
+def test_transformers_on_the_fly_bounded_mode_rejects_pickle_checkpoint(tmp_path):
+    register_hf_quantizers()
+    model = TinyTransformersModel(TinyTransformersConfig())
+    model.save_pretrained(tmp_path)
+    torch.save(model.state_dict(), tmp_path / "pytorch_model.bin")
+    (tmp_path / "model.safetensors").unlink()
+
+    with pytest.raises(RuntimeError, match="requires safetensors checkpoints"):
+        TinyTransformersModel.from_pretrained(
+            tmp_path,
+            quantization_config=OrbitQuantConfig(block_size=8),
+            use_safetensors=False,
+        )
 
 
 def test_transformers_pretrained_save_pretrained_round_trips_pre_quantized_model(

--- a/tests/test_universal_transformers.py
+++ b/tests/test_universal_transformers.py
@@ -118,6 +118,7 @@ def test_gpt2_conv1d_quantize_save_and_prequantized_restore(tmp_path):
     assert isinstance(quantized.transformer.h[0].attn.c_attn, OrbitQuantLinear)
     assert quantized.transformer.h[0].attn.c_attn.source_weight_layout == "in_out"
     assert isinstance(quantized.lm_head, torch.nn.Linear)
+    assert quantized.lm_head.weight is quantized.transformer.wte.weight
     assert torch.isfinite(logits).all()
 
     quantized.save_pretrained(quantized_dir)

--- a/uv.lock
+++ b/uv.lock
@@ -1109,6 +1109,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "psutil" },
     { name = "pytest" },
     { name = "pytest-xdist" },
     { name = "ruff" },
@@ -1139,6 +1140,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.0" },
     { name = "packaging", specifier = ">=24.0" },
     { name = "pillow", marker = "extra == 'eval'", specifier = ">=11.0" },
+    { name = "psutil", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.8" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12" },

--- a/uv.lock
+++ b/uv.lock
@@ -1095,7 +1095,7 @@ wheels = [
 
 [[package]]
 name = "orbitquant"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "huggingface-hub" },


### PR DESCRIPTION
## What changed

- add true safetensors checkpoint-level, row-tiled OrbitQuant conversion for Transformers and Diffusers
- preserve official low-memory/device-map/offload paths and make Accelerate model/sequential CPU offload work across repeated cycles
- add bounded-memory measurement tooling, compatibility gates, artifact round-trip coverage, and concise public recipes
- merge the completed cross-platform packed CPU kernel branch
- prepare version 0.4.0 and model-card generation for on-the-fly conversion

## Why

The existing post-load `staging_mode="streaming"` reduced staging VRAM only after a full source model had already loaded. This change converts source tensors directly from safetensors shards into packed state so the full BF16/FP16 transformer is never resident alongside the quantized model.

## User impact

Compatible Hugging Face model IDs can now be passed directly to standard Transformers or Diffusers `from_pretrained` calls with `OrbitQuantConfig`. Guaranteed bounded-memory conversion requires safetensors; pickle checkpoints fail with an actionable error rather than silently claiming streaming.

## Validation

- `uv run pytest -q -ra -o addopts=''`: 496 passed, 42 explicit CUDA/Triton/native-platform skips
- `uv run ruff check .`: passed
- `bash scripts/run_paper_methodology_checks.sh`: passed; paper oracle and four inventory contracts unchanged
- Transformers 5.13 current/release and Transformers 5.14.dev + Diffusers 0.40.dev compatibility gates: passed
- clean wheel and sdist installs: passed
- public `google/vit-base-patch16-224` wheel smoke: 72 packed modules, 339,738,624 source bytes streamed, 0 page-release failures
- measured peak RSS: baseline BF16 739,950,592 B; on-the-fly streaming 457,834,496 B; prequantized 347,422,720 B (VMS reported separately)
