### PR TITLE
Fix Windows native CPU CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,14 +141,10 @@ jobs:
             }
           }
           $python = "$env:GITHUB_WORKSPACE\.venv\Scripts\python.exe"
-          $ninja = "$env:GITHUB_WORKSPACE\.venv\Scripts\ninja.exe"
-          if (-not (Test-Path $ninja)) {
-            throw "venv Ninja executable was not found: $ninja"
-          }
-          $env:Path = "$(Split-Path $ninja);$env:Path"
           cl.exe 2>&1 | Select-Object -First 3
-          & $ninja --version
-          $env:CMAKE_GENERATOR = "Ninja"
+          $nmake = Get-Command nmake.exe -ErrorAction Stop
+          Write-Host "Using NMake: $($nmake.Source)"
+          $env:CMAKE_GENERATOR = "NMake Makefiles"
           $env:CMAKE_ARGS = "-DGPU_LANG=CPU"
           $env:MAX_JOBS = "2"
           & $python setup.py bdist_wheel --py-limited-api=cp39

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,12 +140,17 @@ jobs:
               Set-Item -Path "Env:$($parts[0])" -Value $parts[1]
             }
           }
+          $python = "$env:GITHUB_WORKSPACE\.venv\Scripts\python.exe"
+          $ninja = "$env:GITHUB_WORKSPACE\.venv\Scripts\ninja.exe"
+          if (-not (Test-Path $ninja)) {
+            throw "venv Ninja executable was not found: $ninja"
+          }
+          $env:Path = "$(Split-Path $ninja);$env:Path"
           cl.exe 2>&1 | Select-Object -First 3
-          ninja --version
+          & $ninja --version
           $env:CMAKE_GENERATOR = "Ninja"
           $env:CMAKE_ARGS = "-DGPU_LANG=CPU"
           $env:MAX_JOBS = "2"
-          $python = "$env:GITHUB_WORKSPACE\.venv\Scripts\python.exe"
           & $python setup.py bdist_wheel --py-limited-api=cp39
 
       - name: Verify wheel tag and metadata

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,12 +143,10 @@ jobs:
           $python = "$env:GITHUB_WORKSPACE\.venv\Scripts\python.exe"
           cl.exe 2>&1 | Select-Object -First 3
           $nmake = Get-Command nmake.exe -ErrorAction Stop
-          $nmakeCopy = "$env:RUNNER_TEMP\nmake.exe"
-          Copy-Item -LiteralPath $nmake.Source -Destination $nmakeCopy -Force
-          Write-Host "Using NMake: $nmakeCopy"
+          Write-Host "Using NMake: $($nmake.Source)"
           $env:CMAKE_GENERATOR = "NMake Makefiles"
-          $env:CMAKE_ARGS = `
-            "-DGPU_LANG=CPU -DCMAKE_MAKE_PROGRAM:FILEPATH=$nmakeCopy"
+          $env:CMAKE_ARGS = "-DGPU_LANG=CPU"
+          $env:ORBITQUANT_CMAKE_MAKE_PROGRAM = $nmake.Source
           $env:MAX_JOBS = "2"
           & $python setup.py bdist_wheel --py-limited-api=cp39
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
           $env:ORBITQUANT_CMAKE_MAKE_PROGRAM = $nmake.Source
           $env:ORBITQUANT_BUILD_TEMP = "$env:RUNNER_TEMP\orbitquant-native-build"
           $env:MAX_JOBS = "2"
-          & $python setup.py bdist_wheel --py-limited-api=cp39
+          & $python setup.py build_ext bdist_wheel --py-limited-api=cp39
 
       - name: Verify wheel tag and metadata
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,7 @@ jobs:
           $env:CMAKE_GENERATOR = "NMake Makefiles"
           $env:CMAKE_ARGS = "-DGPU_LANG=CPU"
           $env:ORBITQUANT_CMAKE_MAKE_PROGRAM = $nmake.Source
+          $env:ORBITQUANT_BUILD_TEMP = "$env:RUNNER_TEMP\orbitquant-native-build"
           $env:MAX_JOBS = "2"
           & $python setup.py bdist_wheel --py-limited-api=cp39
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,9 +143,12 @@ jobs:
           $python = "$env:GITHUB_WORKSPACE\.venv\Scripts\python.exe"
           cl.exe 2>&1 | Select-Object -First 3
           $nmake = Get-Command nmake.exe -ErrorAction Stop
-          Write-Host "Using NMake: $($nmake.Source)"
+          $nmakeCopy = "$env:RUNNER_TEMP\nmake.exe"
+          Copy-Item -LiteralPath $nmake.Source -Destination $nmakeCopy -Force
+          Write-Host "Using NMake: $nmakeCopy"
           $env:CMAKE_GENERATOR = "NMake Makefiles"
-          $env:CMAKE_ARGS = "-DGPU_LANG=CPU"
+          $env:CMAKE_ARGS = `
+            "-DGPU_LANG=CPU -DCMAKE_MAKE_PROGRAM:FILEPATH=$nmakeCopy"
           $env:MAX_JOBS = "2"
           & $python setup.py bdist_wheel --py-limited-api=cp39
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,9 +72,9 @@ jobs:
           uv sync --extra dev
           uv pip install --python .venv\Scripts\python.exe cmake ninja setuptools wheel
 
-      - name: Cache pinned kernel-builder
+      - name: Restore pinned kernel-builder
         id: kernel-builder-cache
-        uses: actions/cache@v6.1.0
+        uses: actions/cache/restore@v6.1.0
         with:
           path: ${{ runner.temp }}\kernel-builder
           key: kernel-builder-windows-d43de01d0b43285d8e5061ca4380c2bd1c40ae3b
@@ -90,6 +90,13 @@ jobs:
             --debug `
             --root "$env:RUNNER_TEMP\kernel-builder" `
             hf-kernel-builder
+
+      - name: Save pinned kernel-builder
+        if: steps.kernel-builder-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6.1.0
+        with:
+          path: ${{ runner.temp }}\kernel-builder
+          key: kernel-builder-windows-d43de01d0b43285d8e5061ca4380c2bd1c40ae3b
 
       - name: Generate native build project
         shell: pwsh
@@ -134,6 +141,7 @@ jobs:
             }
           }
           cl.exe 2>&1 | Select-Object -First 3
+          ninja --version
           $env:CMAKE_GENERATOR = "Ninja"
           $env:CMAKE_ARGS = "-DGPU_LANG=CPU"
           $env:MAX_JOBS = "2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,8 +111,30 @@ jobs:
             Select-Object Name, NumberOfCores, NumberOfLogicalProcessors | `
             Format-List
           cmake --version
-          $env:CMAKE_GENERATOR = "Visual Studio 18 2026"
-          $env:CMAKE_GENERATOR_PLATFORM = "x64"
+          $vswhere = `
+            "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsRoot = & $vswhere `
+            -latest `
+            -products * `
+            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+            -property installationPath
+          if (-not $vsRoot) {
+            throw "MSVC x86_64 tools were not found"
+          }
+          $vsDevCmd = Join-Path $vsRoot "Common7\Tools\VsDevCmd.bat"
+          $envDump = cmd.exe /d /s /c `
+            "call `"$vsDevCmd`" -arch=x64 -host_arch=x64 >nul && set"
+          if ($LASTEXITCODE -ne 0) {
+            throw "failed to initialize the MSVC x86_64 environment"
+          }
+          foreach ($line in $envDump) {
+            $parts = $line -split "=", 2
+            if ($parts.Length -eq 2) {
+              Set-Item -Path "Env:$($parts[0])" -Value $parts[1]
+            }
+          }
+          cl.exe 2>&1 | Select-Object -First 3
+          $env:CMAKE_GENERATOR = "Ninja"
           $env:CMAKE_ARGS = "-DGPU_LANG=CPU"
           $env:MAX_JOBS = "2"
           $python = "$env:GITHUB_WORKSPACE\.venv\Scripts\python.exe"

--- a/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
+++ b/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
@@ -30,6 +30,19 @@ def main() -> None:
     )
     pyproject.write_text(text, encoding="utf-8")
 
+    setup = args.project / "setup.py"
+    setup_text = setup.read_text(encoding="utf-8")
+    ninja_path = 'ninja_executable_path = Path(ninja.BIN_DIR) / "ninja"'
+    if setup_text.count(ninja_path) != 1:
+        raise RuntimeError("generated setup must contain one Ninja executable path")
+    setup_text = setup_text.replace(
+        ninja_path,
+        "ninja_executable_path = Path(ninja.BIN_DIR) / "
+        '("ninja.exe" if os.name == "nt" else "ninja")',
+        1,
+    )
+    setup.write_text(setup_text, encoding="utf-8")
+
 
 if __name__ == "__main__":
     main()

--- a/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
+++ b/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
@@ -41,6 +41,17 @@ def main() -> None:
         '("ninja.exe" if os.name == "nt" else "ninja")',
         1,
     )
+    for cache_tool in ("sccache", "ccache"):
+        availability = f'return which("{cache_tool}") is not None'
+        if setup_text.count(availability) != 1:
+            raise RuntimeError(
+                f"generated setup must contain one {cache_tool} availability check"
+            )
+        setup_text = setup_text.replace(
+            availability,
+            f'return os.name != "nt" and which("{cache_tool}") is not None',
+            1,
+        )
     setup.write_text(setup_text, encoding="utf-8")
 
 

--- a/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
+++ b/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
@@ -67,6 +67,16 @@ def main() -> None:
         + '        cmake_args.append(f"-DCMAKE_MAKE_PROGRAM:FILEPATH={cmake_make_program}")\n',
         1,
     )
+    build_temp = "        build_temp = Path(self.build_temp) / ext.name"
+    if setup_text.count(build_temp) != 1:
+        raise RuntimeError("generated setup must contain one extension build temp")
+    setup_text = setup_text.replace(
+        build_temp,
+        '        build_temp_root = os.environ.get("ORBITQUANT_BUILD_TEMP", '
+        "self.build_temp)\n"
+        "        build_temp = (Path(build_temp_root) / ext.name).resolve()",
+        1,
+    )
     setup.write_text(setup_text, encoding="utf-8")
 
 

--- a/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
+++ b/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
@@ -37,7 +37,7 @@ def main() -> None:
         raise RuntimeError("generated setup must contain one Ninja executable path")
     setup_text = setup_text.replace(
         ninja_path,
-        "ninja_executable_path = Path(ninja.BIN_DIR) / "
+        'ninja_executable_path = which("ninja") or Path(ninja.BIN_DIR) / '
         '("ninja.exe" if os.name == "nt" else "ninja")',
         1,
     )

--- a/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
+++ b/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
@@ -37,7 +37,7 @@ def main() -> None:
         raise RuntimeError("generated setup must contain one Ninja executable path")
     setup_text = setup_text.replace(
         ninja_path,
-        'ninja_executable_path = which("ninja") or Path(ninja.BIN_DIR) / '
+        'ninja_executable_path = Path(ninja.BIN_DIR) / '
         '("ninja.exe" if os.name == "nt" else "ninja")',
         1,
     )

--- a/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
+++ b/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
@@ -77,6 +77,18 @@ def main() -> None:
         "        build_temp = (Path(build_temp_root) / ext.name).resolve()",
         1,
     )
+    windows_multi_config = (
+        '        if sys.platform == "win32":\n'
+        "            # Move the dylib one folder up for discovery."
+    )
+    if setup_text.count(windows_multi_config) != 1:
+        raise RuntimeError("generated setup must contain one Windows output move")
+    setup_text = setup_text.replace(
+        windows_multi_config,
+        '        if sys.platform == "win32" and (extdir / cfg).is_dir():\n'
+        "            # Move the dylib one folder up for discovery.",
+        1,
+    )
     setup.write_text(setup_text, encoding="utf-8")
 
 

--- a/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
+++ b/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
@@ -52,6 +52,21 @@ def main() -> None:
             f'return os.name != "nt" and which("{cache_tool}") is not None',
             1,
         )
+    cmake_args_hook = (
+        '    if "CMAKE_ARGS" in os.environ:\n'
+        '        cmake_args += [item for item in os.environ["CMAKE_ARGS"].split(" ") '
+        "if item]\n"
+    )
+    if setup_text.count(cmake_args_hook) != 1:
+        raise RuntimeError("generated setup must contain one CMAKE_ARGS hook")
+    setup_text = setup_text.replace(
+        cmake_args_hook,
+        cmake_args_hook
+        + '    cmake_make_program = os.environ.get("ORBITQUANT_CMAKE_MAKE_PROGRAM")\n'
+        + "    if cmake_make_program:\n"
+        + '        cmake_args.append(f"-DCMAKE_MAKE_PROGRAM:FILEPATH={cmake_make_program}")\n',
+        1,
+    )
     setup.write_text(setup_text, encoding="utf-8")
 
 

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -41,8 +41,12 @@ def test_github_actions_cpu_unit_workflow_exists():
     assert "--rev d43de01d0b43285d8e5061ca4380c2bd1c40ae3b" in text
     assert "--debug" in text
     assert "prepare_wheel_project.py" in text
-    assert "uses: actions/cache@v6.1.0" in text
-    assert 'CMAKE_GENERATOR = "Visual Studio 18 2026"' in text
+    assert "uses: actions/cache/restore@v6.1.0" in text
+    assert "uses: actions/cache/save@v6.1.0" in text
+    assert "vswhere.exe" in text
+    assert "VsDevCmd.bat" in text
+    assert "ninja --version" in text
+    assert 'CMAKE_GENERATOR = "Ninja"' in text
     assert "Get-CimInstance Win32_Processor" in text
     assert "bdist_wheel --py-limited-api=cp39" in text
     assert '"-cp39-abi3-win_amd64\\.whl$"' in text

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -46,8 +46,7 @@ def test_github_actions_cpu_unit_workflow_exists():
     assert "vswhere.exe" in text
     assert "VsDevCmd.bat" in text
     assert "Get-Command nmake.exe -ErrorAction Stop" in text
-    assert "Copy-Item -LiteralPath $nmake.Source" in text
-    assert "-DCMAKE_MAKE_PROGRAM:FILEPATH=$nmakeCopy" in text
+    assert "ORBITQUANT_CMAKE_MAKE_PROGRAM = $nmake.Source" in text
     assert 'CMAKE_GENERATOR = "NMake Makefiles"' in text
     assert "Get-CimInstance Win32_Processor" in text
     assert "bdist_wheel --py-limited-api=cp39" in text

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -50,6 +50,7 @@ def test_github_actions_cpu_unit_workflow_exists():
     assert 'ORBITQUANT_BUILD_TEMP = "$env:RUNNER_TEMP\\orbitquant-native-build"' in text
     assert 'CMAKE_GENERATOR = "NMake Makefiles"' in text
     assert "Get-CimInstance Win32_Processor" in text
+    assert "setup.py build_ext bdist_wheel" in text
     assert "bdist_wheel --py-limited-api=cp39" in text
     assert '"-cp39-abi3-win_amd64\\.whl$"' in text
     assert "torch==2.12.1 pytest" in text

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -47,6 +47,7 @@ def test_github_actions_cpu_unit_workflow_exists():
     assert "VsDevCmd.bat" in text
     assert "Get-Command nmake.exe -ErrorAction Stop" in text
     assert "ORBITQUANT_CMAKE_MAKE_PROGRAM = $nmake.Source" in text
+    assert 'ORBITQUANT_BUILD_TEMP = "$env:RUNNER_TEMP\\orbitquant-native-build"' in text
     assert 'CMAKE_GENERATOR = "NMake Makefiles"' in text
     assert "Get-CimInstance Win32_Processor" in text
     assert "bdist_wheel --py-limited-api=cp39" in text

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -46,6 +46,8 @@ def test_github_actions_cpu_unit_workflow_exists():
     assert "vswhere.exe" in text
     assert "VsDevCmd.bat" in text
     assert "Get-Command nmake.exe -ErrorAction Stop" in text
+    assert "Copy-Item -LiteralPath $nmake.Source" in text
+    assert "-DCMAKE_MAKE_PROGRAM:FILEPATH=$nmakeCopy" in text
     assert 'CMAKE_GENERATOR = "NMake Makefiles"' in text
     assert "Get-CimInstance Win32_Processor" in text
     assert "bdist_wheel --py-limited-api=cp39" in text

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -45,10 +45,8 @@ def test_github_actions_cpu_unit_workflow_exists():
     assert "uses: actions/cache/save@v6.1.0" in text
     assert "vswhere.exe" in text
     assert "VsDevCmd.bat" in text
-    assert 'ninja = "$env:GITHUB_WORKSPACE\\.venv\\Scripts\\ninja.exe"' in text
-    assert 'env:Path = "$(Split-Path $ninja);$env:Path"' in text
-    assert "& $ninja --version" in text
-    assert 'CMAKE_GENERATOR = "Ninja"' in text
+    assert "Get-Command nmake.exe -ErrorAction Stop" in text
+    assert 'CMAKE_GENERATOR = "NMake Makefiles"' in text
     assert "Get-CimInstance Win32_Processor" in text
     assert "bdist_wheel --py-limited-api=cp39" in text
     assert '"-cp39-abi3-win_amd64\\.whl$"' in text

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -45,7 +45,9 @@ def test_github_actions_cpu_unit_workflow_exists():
     assert "uses: actions/cache/save@v6.1.0" in text
     assert "vswhere.exe" in text
     assert "VsDevCmd.bat" in text
-    assert "ninja --version" in text
+    assert 'ninja = "$env:GITHUB_WORKSPACE\\.venv\\Scripts\\ninja.exe"' in text
+    assert 'env:Path = "$(Split-Path $ninja);$env:Path"' in text
+    assert "& $ninja --version" in text
     assert 'CMAKE_GENERATOR = "Ninja"' in text
     assert "Get-CimInstance Win32_Processor" in text
     assert "bdist_wheel --py-limited-api=cp39" in text

--- a/tests/test_native_kernel_package.py
+++ b/tests/test_native_kernel_package.py
@@ -70,6 +70,7 @@ def test_wheel_project_preparation_keeps_windows_ninja_executable() -> None:
     assert 'ninja_executable_path = Path(ninja.BIN_DIR)' in script
     assert 'which("ninja")' not in script
     assert '"ninja.exe" if os.name == "nt" else "ninja"' in script
+    assert 'os.name != "nt" and which("{cache_tool}") is not None' in script
 
 
 def test_kernel_builder_binding_uses_abi3_safe_registration_pattern() -> None:

--- a/tests/test_native_kernel_package.py
+++ b/tests/test_native_kernel_package.py
@@ -67,7 +67,8 @@ def test_wheel_project_preparation_keeps_windows_ninja_executable() -> None:
     )
 
     assert 'dependencies = ["torch>=2.11"]' in script
-    assert 'which("ninja") or Path(ninja.BIN_DIR)' in script
+    assert 'ninja_executable_path = Path(ninja.BIN_DIR)' in script
+    assert 'which("ninja")' not in script
     assert '"ninja.exe" if os.name == "nt" else "ninja"' in script
 
 

--- a/tests/test_native_kernel_package.py
+++ b/tests/test_native_kernel_package.py
@@ -101,6 +101,11 @@ def make_args():
         cmake_args += [item for item in os.environ["CMAKE_ARGS"].split(" ") if item]
     ninja_executable_path = Path(ninja.BIN_DIR) / "ninja"
     return cmake_args, ninja_executable_path
+
+class Build:
+    def build_extension(self, ext):
+        build_temp = Path(self.build_temp) / ext.name
+        return build_temp
 """,
         encoding="utf-8",
     )
@@ -119,6 +124,8 @@ def make_args():
     prepared_setup = (project / "setup.py").read_text(encoding="utf-8")
     ast.parse(prepared_setup)
     assert 'os.environ.get("ORBITQUANT_CMAKE_MAKE_PROGRAM")' in prepared_setup
+    assert 'os.environ.get("ORBITQUANT_BUILD_TEMP", self.build_temp)' in prepared_setup
+    assert "build_temp = (Path(build_temp_root) / ext.name).resolve()" in prepared_setup
     assert 'return os.name != "nt" and which("ccache") is not None' in prepared_setup
     assert 'Path(ninja.BIN_DIR) / ("ninja.exe" if os.name == "nt" else "ninja")' in prepared_setup
     prepared_project = tomllib.loads(

--- a/tests/test_native_kernel_package.py
+++ b/tests/test_native_kernel_package.py
@@ -105,6 +105,12 @@ def make_args():
 class Build:
     def build_extension(self, ext):
         build_temp = Path(self.build_temp) / ext.name
+        extdir = Path("output")
+        cfg = "Release"
+        if sys.platform == "win32":
+            # Move the dylib one folder up for discovery.
+            for filename in os.listdir(extdir / cfg):
+                move(extdir / cfg / filename, extdir / filename)
         return build_temp
 """,
         encoding="utf-8",
@@ -126,6 +132,7 @@ class Build:
     assert 'os.environ.get("ORBITQUANT_CMAKE_MAKE_PROGRAM")' in prepared_setup
     assert 'os.environ.get("ORBITQUANT_BUILD_TEMP", self.build_temp)' in prepared_setup
     assert "build_temp = (Path(build_temp_root) / ext.name).resolve()" in prepared_setup
+    assert 'sys.platform == "win32" and (extdir / cfg).is_dir()' in prepared_setup
     assert 'return os.name != "nt" and which("ccache") is not None' in prepared_setup
     assert 'Path(ninja.BIN_DIR) / ("ninja.exe" if os.name == "nt" else "ninja")' in prepared_setup
     prepared_project = tomllib.loads(

--- a/tests/test_native_kernel_package.py
+++ b/tests/test_native_kernel_package.py
@@ -61,6 +61,16 @@ def test_kernel_builder_manifest_targets_cpu_cuda_and_metal() -> None:
     assert kernels["packed_matmul_metal"]["depends"] == ["torch"]
 
 
+def test_wheel_project_preparation_keeps_windows_ninja_executable() -> None:
+    script = (KERNEL_ROOT / "scripts/prepare_wheel_project.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'dependencies = ["torch>=2.11"]' in script
+    assert 'which("ninja") or Path(ninja.BIN_DIR)' in script
+    assert '"ninja.exe" if os.name == "nt" else "ninja"' in script
+
+
 def test_kernel_builder_binding_uses_abi3_safe_registration_pattern() -> None:
     binding = (KERNEL_ROOT / "torch-ext/torch_binding.cpp").read_text(encoding="utf-8")
     header = (KERNEL_ROOT / "torch-ext/torch_binding.h").read_text(encoding="utf-8")

--- a/tests/test_native_kernel_package.py
+++ b/tests/test_native_kernel_package.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import ast
 import re
+import subprocess
+import sys
 import tomllib
 from pathlib import Path
 
@@ -71,6 +73,59 @@ def test_wheel_project_preparation_keeps_windows_ninja_executable() -> None:
     assert 'which("ninja")' not in script
     assert '"ninja.exe" if os.name == "nt" else "ninja"' in script
     assert 'os.name != "nt" and which("{cache_tool}") is not None' in script
+    assert 'os.environ.get("ORBITQUANT_CMAKE_MAKE_PROGRAM")' in script
+    assert 'cmake_args.append(f"-DCMAKE_MAKE_PROGRAM:FILEPATH=' in script
+
+
+def test_wheel_project_preparation_injects_build_tool_argv_hook(tmp_path) -> None:
+    project = tmp_path / "kernel"
+    project.mkdir()
+    (project / "pyproject.toml").write_text(
+        '[project]\nversion = "0.1.0"\nrequires-python = ">=3.9"\n',
+        encoding="utf-8",
+    )
+    (project / "setup.py").write_text(
+        """import os
+from pathlib import Path
+from shutil import which
+
+def is_sccache_available() -> bool:
+    return which("sccache") is not None
+
+def is_ccache_available() -> bool:
+    return which("ccache") is not None
+
+def make_args():
+    cmake_args = []
+    if "CMAKE_ARGS" in os.environ:
+        cmake_args += [item for item in os.environ["CMAKE_ARGS"].split(" ") if item]
+    ninja_executable_path = Path(ninja.BIN_DIR) / "ninja"
+    return cmake_args, ninja_executable_path
+""",
+        encoding="utf-8",
+    )
+
+    subprocess.run(
+        [
+            sys.executable,
+            KERNEL_ROOT / "scripts/prepare_wheel_project.py",
+            project,
+            "--version",
+            "0.4.0",
+        ],
+        check=True,
+    )
+
+    prepared_setup = (project / "setup.py").read_text(encoding="utf-8")
+    ast.parse(prepared_setup)
+    assert 'os.environ.get("ORBITQUANT_CMAKE_MAKE_PROGRAM")' in prepared_setup
+    assert 'return os.name != "nt" and which("ccache") is not None' in prepared_setup
+    assert 'Path(ninja.BIN_DIR) / ("ninja.exe" if os.name == "nt" else "ninja")' in prepared_setup
+    prepared_project = tomllib.loads(
+        (project / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    assert prepared_project["project"]["version"] == "0.4.0"
+    assert prepared_project["project"]["dependencies"] == ["torch>=2.11"]
 
 
 def test_kernel_builder_binding_uses_abi3_safe_registration_pattern() -> None:


### PR DESCRIPTION
## What changed

- integrate the completed follow-up commits from `feat/cross-platform-packed-kernels`
- initialize the installed MSVC x64 environment through `vswhere`
- use Ninja instead of assuming a Visual Studio generator version
- split kernel-builder cache restore/save so successful installs persist
- preserve generated CPU sources in the wheel preparation step

## Why

PR #2 merged while its non-required Windows job was still running. The previous kernel-branch run showed that hard-coding Visual Studio 18 selected an MSBuild path that was not present on the hosted runner. These follow-up commits are the sibling branch's focused correction.

## Validation

- `uv run pytest -q -ra -o addopts=''`: 497 passed, 42 explicit platform/native skips
- `uv run ruff check .`: passed
- sibling checkout is clean at `9bce535`
