### PR TITLE
Verify x86 native CPU wheels on Windows and manylinux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,7 +305,7 @@ jobs:
             --python "$python" \
             --index https://download.pytorch.org/whl/cpu \
             --index-strategy unsafe-best-match \
-            torch==2.12.1 pytest
+            . torch==2.12.1 pytest
           uv pip install --python "$python" wheelhouse/*.whl --no-deps
           "$python" -m pytest \
             tests/test_native_packed_matmul.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,3 +200,121 @@ jobs:
         with:
           name: orbitquant-packed-matmul-windows-cpu
           path: native-kernels/orbitquant-packed-matmul/dist/*.whl
+
+  manylinux-native-cpu:
+    name: manylinux x86_64 native CPU
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.0
+
+      - name: Install test dependencies
+        run: uv sync --extra dev
+
+      - name: Restore pinned kernel-builder
+        id: manylinux-kernel-builder-cache
+        uses: actions/cache/restore@v6.1.0
+        with:
+          path: ${{ runner.temp }}/kernel-builder
+          key: kernel-builder-linux-d43de01d0b43285d8e5061ca4380c2bd1c40ae3b
+
+      - name: Install pinned kernel-builder
+        if: steps.manylinux-kernel-builder-cache.outputs.cache-hit != 'true'
+        run: |
+          cargo install \
+            --git https://github.com/huggingface/kernels \
+            --rev d43de01d0b43285d8e5061ca4380c2bd1c40ae3b \
+            --locked \
+            --debug \
+            --root "$RUNNER_TEMP/kernel-builder" \
+            hf-kernel-builder
+
+      - name: Save pinned kernel-builder
+        if: steps.manylinux-kernel-builder-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6.1.0
+        with:
+          path: ${{ runner.temp }}/kernel-builder
+          key: kernel-builder-linux-d43de01d0b43285d8e5061ca4380c2bd1c40ae3b
+
+      - name: Generate native build project
+        shell: bash
+        run: |
+          kernel_root="native-kernels/orbitquant-packed-matmul"
+          builder="$RUNNER_TEMP/kernel-builder/bin/kernel-builder"
+          "$builder" check-config "$kernel_root"
+          "$builder" create-pyproject --unique-id manylinux_ci -f "$kernel_root"
+          uv run python \
+            "$kernel_root/scripts/prepare_wheel_project.py" \
+            "$kernel_root" \
+            --version 0.1.0
+
+      - name: Build manylinux 2.28 ABI3 wheel
+        env:
+          CIBW_ARCHS_LINUX: x86_64
+          CIBW_BUILD: cp312-manylinux_x86_64
+          CIBW_ENVIRONMENT_LINUX: >-
+            CMAKE_ARGS=-DGPU_LANG=CPU
+            MAX_JOBS=2
+            ORBITQUANT_BUILD_TEMP=/tmp/oq-native-build
+            PIP_INDEX_URL=https://download.pytorch.org/whl/cpu
+            PIP_EXTRA_INDEX_URL=https://pypi.org/simple
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: >-
+            auditwheel repair
+            --exclude libc10.so
+            --exclude libtorch_cpu.so
+            --exclude libtorch.so
+            -w {dest_dir} {wheel}
+          CIBW_TEST_COMMAND: >-
+            python -m pytest {package}/tests/test_packed_matmul.py
+            -m kernels_ci -ra
+          CIBW_TEST_REQUIRES: numpy pytest torch==2.12.1
+        run: |
+          uv run --with cibuildwheel==4.1.0 \
+            python -m cibuildwheel \
+            native-kernels/orbitquant-packed-matmul \
+            --output-dir wheelhouse
+
+      - name: Verify wheel tag, metadata, and size
+        shell: bash
+        run: |
+          wheel=$(find wheelhouse -maxdepth 1 -name '*.whl' -print -quit)
+          test -n "$wheel"
+          case "$(basename "$wheel")" in
+            *-cp39-abi3-manylinux_2_28_x86_64.whl) ;;
+            *) echo "unexpected native CPU wheel: $wheel" >&2; exit 1 ;;
+          esac
+          test "$(stat -c %s "$wheel")" -lt 1048576
+          uv run python -c "import pathlib, zipfile; p=next(pathlib.Path('wheelhouse').glob('*.whl')); z=zipfile.ZipFile(p); names=z.namelist(); m=z.read(next(n for n in names if n.endswith('.dist-info/METADATA'))).decode(); assert 'Requires-Dist: torch>=2.11' in m; assert any(n.endswith('/_ops.py') for n in names); assert not any('/libtorch' in n or '/libc10' in n for n in names); print(p.name); print(m)"
+
+      - name: Clean-install integration tests
+        shell: bash
+        run: |
+          smoke="$RUNNER_TEMP/orbitquant-manylinux-smoke"
+          uv venv "$smoke" --python 3.12
+          python="$smoke/bin/python"
+          uv pip install \
+            --python "$python" \
+            --index https://download.pytorch.org/whl/cpu \
+            --index-strategy unsafe-best-match \
+            torch==2.12.1 pytest
+          uv pip install --python "$python" wheelhouse/*.whl --no-deps
+          "$python" -m pytest \
+            tests/test_native_packed_matmul.py \
+            tests/test_adaln_rtn.py \
+            tests/test_paper_reference_oracle.py \
+            -ra
+
+      - name: Upload manylinux native CPU wheel
+        uses: actions/upload-artifact@v6.0.0
+        with:
+          name: orbitquant-packed-matmul-manylinux-cpu
+          path: wheelhouse/*.whl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,7 +289,7 @@ jobs:
           wheel=$(find wheelhouse -maxdepth 1 -name '*.whl' -print -quit)
           test -n "$wheel"
           case "$(basename "$wheel")" in
-            *-cp39-abi3-manylinux_2_28_x86_64.whl) ;;
+            *-cp39-abi3-*manylinux_2_28_x86_64.whl) ;;
             *) echo "unexpected native CPU wheel: $wheel" >&2; exit 1 ;;
           esac
           test "$(stat -c %s "$wheel")" -lt 1048576

--- a/docs/kernel-audit.md
+++ b/docs/kernel-audit.md
@@ -35,7 +35,7 @@ Other explicit modes are `native_packed_matmul`, `triton_packed_matmul`,
 | --- | --- | --- |
 | CUDA | Optimized packed inference | Native RPBH/quantization, chunked packed-weight decode plus CUTLASS INT8 matmul, direct packed CUDA MMA fallback, and generic Triton packed fallback |
 | MPS/Metal | Optimized packed inference | Native Metal packed matmul and Metal activation quantization stages |
-| CPU | Hardware-verified native source build; platform wheels pending | Runtime ISA dispatch across scalar, AVX2/FMA, AVX-512/BF16, and ARM64 NEON; exact packed activation, packed low-bit matmul, and packed INT4 group-64 AdaLN |
+| CPU | Hardware-verified native source and CI wheel builds; wheel publication pending | Runtime ISA dispatch across scalar, AVX2/FMA, AVX-512/BF16, and ARM64 NEON; exact packed activation, packed low-bit matmul, and packed INT4 group-64 AdaLN |
 | Vulkan | Unverified | No runtime backend |
 | ROCm | Unsupported | No release backend |
 | XPU | Unsupported | No release backend |
@@ -92,8 +92,9 @@ PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True python generate.py
 The generated `setup.py` and CMake files come from `kernel-builder` and must not
 be committed. This development build targets the current host toolchain. Use the
 Nix build for a redistributable variant and run `kernel-builder check-abi` before
-distributing it. A local Ubuntu 24.04 build can be ABI3 at the Python boundary
-while still depending on a GLIBC version newer than `manylinux_2_28`.
+distributing it. The Linux wheel CI builds inside `manylinux_2_28`, repairs the
+result with `auditwheel`, and runs strict `abi3audit`; an ordinary local Ubuntu
+build can still depend on a newer GLIBC.
 
 To load the local build through Hugging Face `kernels` instead of importing it
 through `PYTHONPATH`, map the kernel repository to the same generated variant
@@ -127,6 +128,18 @@ maximum error `1.526e-5`. Packed weights and row norms occupied 1,179,648 bytes
 versus 4,718,592 bytes for BF16 weights, and the native layer retained no
 dequantized-weight cache.
 
+A second x86_64 profile used a Secure Cloud AMD EPYC 9654 host with GCC 13.3,
+Torch 2.12.1+cpu, and the two SMT threads `36,132` of one physical core. For a
+W4A4 packed matmul with 32 rows and a 1536x1536 projection, the hot median was
+1.4928 ms, p95 was 1.5151 ms, and first call was 1.9775 ms. Materializing the
+weight and then calling `F.linear` measured 6.6373 ms median and 7.0199 ms p95,
+so the packed path was 4.51x faster than that explicit reference. A resident
+BF16 `F.linear` remained faster at 0.7823 ms; the packed kernel is selected to
+retain the memory advantage, not to claim superiority over a permanently dense
+weight. The packed payload, row norms, and centroids occupied 1,182,784 bytes
+versus 4,718,592 bytes for BF16, with relative RMSE `6.546e-6` and maximum error
+`0.03125`. Disassembly confirmed `vpermw` lookup and `vdpbf16ps` accumulation.
+
 AdaLN uses an exact signed INT4 group-64 lookup with BF16 scales and
 activations. The realistic modulation shape below is 3072 input channels and
 18432 output channels. Timings are 21 post-warmup calls with
@@ -149,8 +162,25 @@ spatial-token row counts.
 The same x86_64 stable-ABI 2.11 binary built against Torch 2.13 loaded and ran
 under Torch 2.12.1. This verifies the current LibTorch Stable ABI boundary for
 those two runtimes; it does not make the wheel independent of the platform
-GLIBC, C++ runtime, or CPU ISA. Linux and Windows wheel policy remains pending,
-and Windows CPU execution is not yet verified.
+GLIBC, C++ runtime, or CPU ISA.
+
+CI run `29162193254` separately verified installable Python 3.9 ABI3 wheels on
+Linux and Windows. The 101,453-byte Linux wheel has both
+`manylinux_2_24_x86_64` and `manylinux_2_28_x86_64` tags, passed strict
+`abi3audit` with a computed Python 3.9 baseline, and has SHA-256
+`5cd19321e11281e03b9b1126f40571ad2c1e956060fc0bc5173c90628045d4df`.
+Inside the manylinux container, 73 native tests passed and 33 CUDA/MPS tests
+were skipped; a separate clean environment with OrbitQuant 0.4.0 and Torch
+2.12.1+cpu passed 33 integration/oracle tests with two CUDA/Triton skips.
+
+The 53,178-byte Windows wheel has the `cp39-abi3-win_amd64` tag and SHA-256
+`cf200774d7388496ce3b7f554dd3e757eca470d99ef9986fe7a7bb0ea1e0e297`.
+It was built with MSVC 14.51 on Windows Server 2025 and executed on an AMD EPYC
+9V74 runner with two cores and four logical processors. Its clean native suite
+passed 73 tests with 33 CUDA/MPS skips, and the OrbitQuant integration/oracle
+suite passed 33 tests with two CUDA/Triton skips. Both wheels include only the
+extension, Python loader, and metadata rather than bundled LibTorch libraries.
+They are verified CI artifacts, not yet published platform packages.
 
 The ARM64 native CPU path was separately built on an Apple M2 Max. At 32 rows
 and dimension 1536, the full native W4A4 layer measured about 1.20 ms versus

--- a/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
+++ b/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
@@ -32,6 +32,14 @@ def main() -> None:
 
     setup = args.project / "setup.py"
     setup_text = setup.read_text(encoding="utf-8")
+    shutil_import = "from shutil import which, move\n"
+    if setup_text.count(shutil_import) != 1:
+        raise RuntimeError("generated setup must contain one shutil import")
+    setup_text = setup_text.replace(
+        shutil_import,
+        "from shutil import copy2, move, which\n",
+        1,
+    )
     ninja_path = 'ninja_executable_path = Path(ninja.BIN_DIR) / "ninja"'
     if setup_text.count(ninja_path) != 1:
         raise RuntimeError("generated setup must contain one Ninja executable path")
@@ -87,6 +95,33 @@ def main() -> None:
         windows_multi_config,
         '        if sys.platform == "win32" and (extdir / cfg).is_dir():\n'
         "            # Move the dylib one folder up for discovery.",
+        1,
+    )
+    build_call = (
+        "        subprocess.run(\n"
+        '            ["cmake", "--build", str(build_temp), *build_args], '
+        "cwd=build_temp, check=True\n"
+        "        )\n"
+    )
+    if setup_text.count(build_call) != 1:
+        raise RuntimeError("generated setup must contain one wheel CMake build call")
+    setup_text = setup_text.replace(
+        build_call,
+        build_call
+        + "\n"
+        + '        package_name = ext.name.split(".", 1)[0]\n'
+        + "        generated_ops = (\n"
+        + '            Path(ext.sourcedir) / "torch-ext" / package_name / "_ops.py"\n'
+        + "        )\n"
+        + '        copy2(generated_ops, extdir / "_ops.py")\n',
+        1,
+    )
+    zip_safe = "    zip_safe=False,\n"
+    if setup_text.count(zip_safe) != 1:
+        raise RuntimeError("generated setup must contain one zip-safe option")
+    setup_text = setup_text.replace(
+        zip_safe,
+        '    options={"bdist_wheel": {"py_limited_api": "cp39"}},\n' + zip_safe,
         1,
     )
     setup.write_text(setup_text, encoding="utf-8")

--- a/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
+++ b/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
@@ -30,6 +30,25 @@ def main() -> None:
     )
     pyproject.write_text(text, encoding="utf-8")
 
+    cmake = args.project / "CMakeLists.txt"
+    cmake_text = cmake.read_text(encoding="utf-8")
+    for required in (False, True):
+        marker = " REQUIRED" if required else ""
+        development = (
+            f"find_package(Python3{marker} COMPONENTS Development "
+            "Development.SABIModule Interpreter)"
+        )
+        if cmake_text.count(development) != 1:
+            raise RuntimeError(
+                "generated CMake must contain one Python development lookup"
+            )
+        cmake_text = cmake_text.replace(
+            development,
+            f"find_package(Python3{marker} COMPONENTS Development.SABIModule Interpreter)",
+            1,
+        )
+    cmake.write_text(cmake_text, encoding="utf-8")
+
     setup = args.project / "setup.py"
     setup_text = setup.read_text(encoding="utf-8")
     shutil_import = "from shutil import which, move\n"

--- a/native-kernels/orbitquant-packed-matmul/tests/test_packed_matmul.py
+++ b/native-kernels/orbitquant-packed-matmul/tests/test_packed_matmul.py
@@ -67,7 +67,13 @@ def _runnable_cpu_isas() -> list[str]:
     isas = ["scalar"]
     if machine in {"x86_64", "amd64"} and capability in {"AVX2", "AVX512"}:
         isas.append("avx2")
-    if machine in {"x86_64", "amd64"} and capability == "AVX512":
+    if (
+        machine in {"x86_64", "amd64"}
+        and capability == "AVX512"
+        and platform.system() != "Windows"
+    ):
+        # The MSVC wheel currently ships the separately compiled AVX2 TU; the
+        # AVX-512 implementation uses GCC/Clang per-function target attributes.
         isas.append("avx512")
     if machine in {"aarch64", "arm64"}:
         isas.append("neon")

--- a/tests/test_native_kernel_package.py
+++ b/tests/test_native_kernel_package.py
@@ -87,7 +87,7 @@ def test_wheel_project_preparation_injects_build_tool_argv_hook(tmp_path) -> Non
     (project / "setup.py").write_text(
         """import os
 from pathlib import Path
-from shutil import which
+from shutil import which, move
 
 def is_sccache_available() -> bool:
     return which("sccache") is not None
@@ -107,11 +107,19 @@ class Build:
         build_temp = Path(self.build_temp) / ext.name
         extdir = Path("output")
         cfg = "Release"
+        build_args = []
+        subprocess.run(
+            ["cmake", "--build", str(build_temp), *build_args], cwd=build_temp, check=True
+        )
         if sys.platform == "win32":
             # Move the dylib one folder up for discovery.
             for filename in os.listdir(extdir / cfg):
                 move(extdir / cfg / filename, extdir / filename)
         return build_temp
+
+setup(
+    zip_safe=False,
+)
 """,
         encoding="utf-8",
     )
@@ -135,6 +143,8 @@ class Build:
     assert 'sys.platform == "win32" and (extdir / cfg).is_dir()' in prepared_setup
     assert 'return os.name != "nt" and which("ccache") is not None' in prepared_setup
     assert 'Path(ninja.BIN_DIR) / ("ninja.exe" if os.name == "nt" else "ninja")' in prepared_setup
+    assert 'copy2(generated_ops, extdir / "_ops.py")' in prepared_setup
+    assert 'options={"bdist_wheel": {"py_limited_api": "cp39"}}' in prepared_setup
     prepared_project = tomllib.loads(
         (project / "pyproject.toml").read_text(encoding="utf-8")
     )

--- a/tests/test_native_kernel_package.py
+++ b/tests/test_native_kernel_package.py
@@ -84,6 +84,12 @@ def test_wheel_project_preparation_injects_build_tool_argv_hook(tmp_path) -> Non
         '[project]\nversion = "0.1.0"\nrequires-python = ">=3.9"\n',
         encoding="utf-8",
     )
+    (project / "CMakeLists.txt").write_text(
+        "find_package(Python3 COMPONENTS Development Development.SABIModule Interpreter)\n"
+        "find_package(Python3 REQUIRED COMPONENTS Development "
+        "Development.SABIModule Interpreter)\n",
+        encoding="utf-8",
+    )
     (project / "setup.py").write_text(
         """import os
 from pathlib import Path
@@ -150,6 +156,9 @@ setup(
     )
     assert prepared_project["project"]["version"] == "0.4.0"
     assert prepared_project["project"]["dependencies"] == ["torch>=2.11"]
+    prepared_cmake = (project / "CMakeLists.txt").read_text(encoding="utf-8")
+    assert "COMPONENTS Development.SABIModule Interpreter" in prepared_cmake
+    assert "COMPONENTS Development Development.SABIModule" not in prepared_cmake
 
 
 def test_kernel_builder_binding_uses_abi3_safe_registration_pattern() -> None:


### PR DESCRIPTION
## Summary

- keep the MSVC wheel on its compiled scalar/AVX2 runtime matrix instead of forcing the GCC/Clang-only AVX-512 implementation
- make standard PEP 517 builds emit a cp39 ABI3 wheel containing the generated operator loader
- build, audit, clean-install, and test a compact manylinux 2.28 x86_64 CPU wheel in CI

## Existing x86 hardware evidence

The packed W4A4 path was measured on an AMD EPYC 9654 RunPod CPU: 1.493 ms hot median for rows=32, dim=1536 versus 6.637 ms for explicit dequantization plus linear (4.51x), with 0.2507x BF16 weight bytes and 6.55e-6 relative RMSE. AVX-512/BF16 instructions (`vpermw`, `vdpbf16ps`) were confirmed in disassembly.

## Local verification

- `uv run pytest tests/test_native_kernel_package.py tests/test_native_packed_matmul.py tests/test_adaln_rtn.py tests/test_paper_reference_oracle.py -ra` — 42 passed, 4 skipped (native package unavailable locally and CUDA/Triton only)
- `uv run ruff check .`
- `git diff --check`

The PR remains draft until both Windows Server 2025/MSVC and manylinux wheel jobs pass from clean installs.