### PR TITLE
Runtime provisioning of native kernel variant wheels

### DIFF
--- a/.github/workflows/build-kernels.yml
+++ b/.github/workflows/build-kernels.yml
@@ -166,7 +166,13 @@ jobs:
           z = zipfile.ZipFile(p)
           names = z.namelist()
           metadata = z.read(next(n for n in names if n.endswith('.dist-info/METADATA'))).decode()
-          assert 'Requires-Dist: ${{ matrix.torch_requirement }}' in metadata, metadata
+          # setuptools normalizes specifier order, so compare specifier sets.
+          def specs(requirement):
+              text = requirement.replace(' ', '')
+              assert text.startswith('torch'), text
+              return set(text[len('torch'):].split(','))
+          line = next(l for l in metadata.splitlines() if l.startswith('Requires-Dist: torch'))
+          assert specs(line.split(':', 1)[1]) == specs('${{ matrix.torch_requirement }}'), line
           assert any(n.endswith('/_ops.py') for n in names)
           print(p.name)
           "
@@ -189,13 +195,15 @@ jobs:
             torch_index: https://download.pytorch.org/whl/cu128
             torch_requirement: "torch>=2.12,<2.13"
             cuda_version: "12.8.1"
+            cuda_feature_tag: "12.8"
             local_tag: cu128torch212
             unique_id: rel_win_cu128_t212
           - variant: torch213-cu130-x86_64-windows
             torch: "2.13.*"
             torch_index: https://download.pytorch.org/whl/cu130
             torch_requirement: "torch>=2.13,<2.14"
-            cuda_version: "13.0.2"
+            cuda_version: "13.0.1"
+            cuda_feature_tag: "13.0"
             local_tag: cu130torch213
             unique_id: rel_win_cu130_t213
     steps:
@@ -211,13 +219,40 @@ jobs:
         uses: astral-sh/setup-uv@v8.3.0
 
       - name: Install CUDA toolkit
-        uses: Jimver/cuda-toolkit@v0.2.28
-        with:
-          cuda: ${{ matrix.cuda_version }}
-          sub-packages: '["nvcc", "cudart", "visual_studio_integration"]'
-          method: network
-          use-github-cache: false
-          use-local-cache: false
+        shell: pwsh
+        run: |
+          $version = "${{ matrix.cuda_version }}"
+          $feature = "${{ matrix.cuda_feature_tag }}"
+          $installer = "$env:RUNNER_TEMP\cuda_network_installer.exe"
+          $url = "https://developer.download.nvidia.com/compute/cuda/$version/network_installers/cuda_${version}_windows_network.exe"
+          Write-Host "Downloading $url"
+          Invoke-WebRequest -Uri $url -OutFile $installer
+          $components = @(
+            "nvcc_$feature",
+            "cudart_$feature",
+            "nvrtc_dev_$feature",
+            "cublas_dev_$feature",
+            "cusparse_dev_$feature",
+            "cusolver_dev_$feature",
+            "cufft_dev_$feature",
+            "curand_dev_$feature",
+            "thrust_$feature",
+            "visual_studio_integration_$feature"
+          )
+          Write-Host "Installing components: $components"
+          $process = Start-Process -Wait -PassThru -FilePath $installer `
+            -ArgumentList (@("-s") + $components)
+          if ($process.ExitCode -ne 0) {
+            throw "CUDA network installer failed with exit code $($process.ExitCode)"
+          }
+          $cudaHome = "$env:ProgramFiles\NVIDIA GPU Computing Toolkit\CUDA\v$feature"
+          if (-not (Test-Path "$cudaHome\bin\nvcc.exe")) {
+            throw "nvcc.exe was not installed under $cudaHome"
+          }
+          Add-Content $env:GITHUB_PATH "$cudaHome\bin"
+          Add-Content $env:GITHUB_ENV "CUDA_PATH=$cudaHome"
+          Add-Content $env:GITHUB_ENV "CUDA_HOME=$cudaHome"
+          & "$cudaHome\bin\nvcc.exe" --version
 
       - name: Install build environment
         shell: pwsh

--- a/.github/workflows/build-kernels.yml
+++ b/.github/workflows/build-kernels.yml
@@ -12,6 +12,12 @@ on:
         description: "Upload built wheels and manifest to the kernels release"
         type: boolean
         default: false
+  # Temporary trigger so the matrix can be exercised from the PR branch before
+  # the workflow lands on the default branch (workflow_dispatch only resolves
+  # workflows that already exist there).
+  pull_request:
+    paths:
+      - ".github/workflows/build-kernels.yml"
 
 env:
   KERNEL_BUILDER_REV: d43de01d0b43285d8e5061ca4380c2bd1c40ae3b

--- a/.github/workflows/build-kernels.yml
+++ b/.github/workflows/build-kernels.yml
@@ -59,6 +59,13 @@ jobs:
             cuda_apt: "12-8"
             local_tag: cu128torch212
             unique_id: rel_cu128_t212
+          - variant: torch212-cxx11-cu130-x86_64-linux
+            torch: "2.12.*"
+            torch_index: https://download.pytorch.org/whl/cu130
+            torch_requirement: "torch>=2.12,<2.13"
+            cuda_apt: "13-0"
+            local_tag: cu130torch212
+            unique_id: rel_cu130_t212
           - variant: torch213-cxx11-cu128-x86_64-linux
             torch: "2.13.*"
             torch_index: https://download.pytorch.org/whl/cu128

--- a/.github/workflows/build-kernels.yml
+++ b/.github/workflows/build-kernels.yml
@@ -320,8 +320,9 @@ jobs:
         run: |
           if ("${{ matrix.nvcc_allow_unsupported }}" -eq "true") {
             # CUDA 13.0 nvcc rejects the MSVC 2026 toolset on windows-2025;
-            # override the version check (the cu128 build passes it natively).
-            $env:CUDAFLAGS = "-allow-unsupported-compiler"
+            # override the version check on every nvcc invocation, including
+            # the CMake compiler-id probe (the cu128 build passes it natively).
+            $env:NVCC_APPEND_FLAGS = "-allow-unsupported-compiler"
           }
           $vswhere = `
             "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"

--- a/.github/workflows/build-kernels.yml
+++ b/.github/workflows/build-kernels.yml
@@ -198,18 +198,10 @@ jobs:
             cuda_feature_tag: "12.8"
             local_tag: cu128torch212
             unique_id: rel_win_cu128_t212
-          - variant: torch213-cu130-x86_64-windows
-            torch: "2.13.*"
-            torch_index: https://download.pytorch.org/whl/cu130
-            torch_requirement: "torch>=2.13,<2.14"
-            cuda_version: "13.0.1"
-            cuda_feature_tag: "13.0"
-            # CUDA 13 repackaged the crt/ headers out of the nvcc component;
-            # install the full toolkit instead of hand-picked components.
-            cuda_full_install: true
-            nvcc_allow_unsupported: true
-            local_tag: cu130torch213
-            unique_id: rel_win_cu130_t213
+          # torch213-cu130 windows is intentionally absent: CUDA 13.0
+          # cudafe++ crashes (ACCESS_VIOLATION) against the MSVC 2026
+          # toolset on windows-2025 even with -allow-unsupported-compiler;
+          # revisit when either the runner toolset or CUDA updates.
     steps:
       - name: Check out repository
         uses: actions/checkout@v7.0.0

--- a/.github/workflows/build-kernels.yml
+++ b/.github/workflows/build-kernels.yml
@@ -96,8 +96,7 @@ jobs:
           sudo dpkg -i cuda-keyring_1.1-1_all.deb
           sudo apt-get update -q
           sudo apt-get install -y -q cuda-nvcc-${{ matrix.cuda_apt }} \
-            cuda-cudart-dev-${{ matrix.cuda_apt }} \
-            libcurand-dev-${{ matrix.cuda_apt }}
+            cuda-cudart-dev-${{ matrix.cuda_apt }}
           echo "/usr/local/cuda-$(echo ${{ matrix.cuda_apt }} | tr '-' '.')/bin" >> "$GITHUB_PATH"
 
       - name: Install build environment
@@ -105,6 +104,7 @@ jobs:
           uv venv .venv --python 3.12
           uv pip install --python .venv/bin/python \
             --index-url ${{ matrix.torch_index }} \
+            --extra-index-url https://pypi.org/simple \
             --index-strategy unsafe-best-match \
             "torch==${{ matrix.torch }}" cmake ninja setuptools wheel numpy
 
@@ -213,7 +213,7 @@ jobs:
         uses: Jimver/cuda-toolkit@v0.2.28
         with:
           cuda: ${{ matrix.cuda_version }}
-          sub-packages: '["nvcc", "cudart", "curand_dev", "visual_studio_integration"]'
+          sub-packages: '["nvcc", "cudart", "visual_studio_integration"]'
           method: network
 
       - name: Install build environment
@@ -222,6 +222,7 @@ jobs:
           uv venv .venv --python 3.12
           uv pip install --python .venv\Scripts\python.exe `
             --index-url ${{ matrix.torch_index }} `
+            --extra-index-url https://pypi.org/simple `
             --index-strategy unsafe-best-match `
             "torch==${{ matrix.torch }}" cmake ninja setuptools wheel numpy
 
@@ -339,7 +340,7 @@ jobs:
         run: |
           uv venv .venv --python 3.12
           uv pip install --python .venv/bin/python \
-            "torch==${{ matrix.torch }}" cmake ninja setuptools wheel numpy
+            "torch==${{ matrix.torch }}" "cmake==3.31.*" ninja setuptools wheel numpy
 
       - name: Restore pinned kernel-builder
         id: kernel-builder-cache
@@ -602,6 +603,7 @@ jobs:
           uv venv .venv --python 3.12
           uv pip install --python .venv\Scripts\python.exe `
             --index-url https://download.pytorch.org/whl/cpu `
+            --extra-index-url https://pypi.org/simple `
             --index-strategy unsafe-best-match `
             "torch==2.12.*" cmake ninja setuptools wheel numpy
 

--- a/.github/workflows/build-kernels.yml
+++ b/.github/workflows/build-kernels.yml
@@ -1,0 +1,748 @@
+name: Build kernels
+
+# Builds the orbitquant-packed-matmul variant wheels that the runtime
+# provisioner (orbitquant.kernels.provision) downloads from the kernels-v1
+# GitHub release. Trigger manually; pass publish=true to upload the wheels and
+# the manifest to the release.
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Upload built wheels and manifest to the kernels release"
+        type: boolean
+        default: false
+
+env:
+  KERNEL_BUILDER_REV: d43de01d0b43285d8e5061ca4380c2bd1c40ae3b
+  KERNELS_RELEASE_TAG: kernels-v1
+
+jobs:
+  linux-cuda:
+    name: ${{ matrix.variant }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: torch29-cxx11-cu126-x86_64-linux
+            torch: "2.9.*"
+            torch_index: https://download.pytorch.org/whl/cu126
+            torch_requirement: "torch>=2.9,<2.10"
+            cuda_apt: "12-6"
+            local_tag: cu126torch29
+            unique_id: rel_cu126_t29
+          - variant: torch29-cxx11-cu128-x86_64-linux
+            torch: "2.9.*"
+            torch_index: https://download.pytorch.org/whl/cu128
+            torch_requirement: "torch>=2.9,<2.10"
+            cuda_apt: "12-8"
+            local_tag: cu128torch29
+            unique_id: rel_cu128_t29
+          - variant: torch212-cxx11-cu126-x86_64-linux
+            torch: "2.12.*"
+            torch_index: https://download.pytorch.org/whl/cu126
+            torch_requirement: "torch>=2.12,<2.13"
+            cuda_apt: "12-6"
+            local_tag: cu126torch212
+            unique_id: rel_cu126_t212
+          - variant: torch212-cxx11-cu128-x86_64-linux
+            torch: "2.12.*"
+            torch_index: https://download.pytorch.org/whl/cu128
+            torch_requirement: "torch>=2.12,<2.13"
+            cuda_apt: "12-8"
+            local_tag: cu128torch212
+            unique_id: rel_cu128_t212
+          - variant: torch213-cxx11-cu128-x86_64-linux
+            torch: "2.13.*"
+            torch_index: https://download.pytorch.org/whl/cu128
+            torch_requirement: "torch>=2.13,<2.14"
+            cuda_apt: "12-8"
+            local_tag: cu128torch213
+            unique_id: rel_cu128_t213
+          - variant: torch213-cxx11-cu130-x86_64-linux
+            torch: "2.13.*"
+            torch_index: https://download.pytorch.org/whl/cu130
+            torch_requirement: "torch>=2.13,<2.14"
+            cuda_apt: "13-0"
+            local_tag: cu130torch213
+            unique_id: rel_cu130_t213
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.0
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          df -h /
+
+      - name: Install CUDA toolkit ${{ matrix.cuda_apt }}
+        run: |
+          wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
+          sudo dpkg -i cuda-keyring_1.1-1_all.deb
+          sudo apt-get update -q
+          sudo apt-get install -y -q cuda-nvcc-${{ matrix.cuda_apt }} \
+            cuda-cudart-dev-${{ matrix.cuda_apt }} \
+            libcurand-dev-${{ matrix.cuda_apt }}
+          echo "/usr/local/cuda-$(echo ${{ matrix.cuda_apt }} | tr '-' '.')/bin" >> "$GITHUB_PATH"
+
+      - name: Install build environment
+        run: |
+          uv venv .venv --python 3.12
+          uv pip install --python .venv/bin/python \
+            --index-url ${{ matrix.torch_index }} \
+            --index-strategy unsafe-best-match \
+            "torch==${{ matrix.torch }}" cmake ninja setuptools wheel numpy
+
+      - name: Restore pinned kernel-builder
+        id: kernel-builder-cache
+        uses: actions/cache/restore@v6.1.0
+        with:
+          path: ${{ runner.temp }}/kernel-builder
+          key: kernel-builder-linux-${{ env.KERNEL_BUILDER_REV }}
+
+      - name: Install pinned kernel-builder
+        if: steps.kernel-builder-cache.outputs.cache-hit != 'true'
+        run: |
+          cargo install \
+            --git https://github.com/huggingface/kernels \
+            --rev "$KERNEL_BUILDER_REV" \
+            --locked \
+            --debug \
+            --root "$RUNNER_TEMP/kernel-builder" \
+            hf-kernel-builder
+
+      - name: Save pinned kernel-builder
+        if: steps.kernel-builder-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6.1.0
+        with:
+          path: ${{ runner.temp }}/kernel-builder
+          key: kernel-builder-linux-${{ env.KERNEL_BUILDER_REV }}
+
+      - name: Generate native build project
+        run: |
+          kernel_root="native-kernels/orbitquant-packed-matmul"
+          builder="$RUNNER_TEMP/kernel-builder/bin/kernel-builder"
+          "$builder" check-config "$kernel_root"
+          "$builder" create-pyproject --unique-id ${{ matrix.unique_id }} -f "$kernel_root"
+          .venv/bin/python "$kernel_root/scripts/prepare_wheel_project.py" \
+            "$kernel_root" \
+            --version "1.0.0+${{ matrix.local_tag }}" \
+            --torch-requirement "${{ matrix.torch_requirement }}"
+
+      - name: Build CUDA wheel
+        working-directory: native-kernels/orbitquant-packed-matmul
+        env:
+          MAX_JOBS: "2"
+          CUDACXX: nvcc
+        run: |
+          nvcc --version
+          python="$GITHUB_WORKSPACE/.venv/bin/python"
+          "$python" setup.py bdist_wheel
+          ls -l dist/
+
+      - name: Verify wheel
+        run: |
+          wheel=$(find native-kernels/orbitquant-packed-matmul/dist -name '*.whl' -print -quit)
+          test -n "$wheel"
+          .venv/bin/python -c "
+          import pathlib, zipfile
+          p = next(pathlib.Path('native-kernels/orbitquant-packed-matmul/dist').glob('*.whl'))
+          z = zipfile.ZipFile(p)
+          names = z.namelist()
+          metadata = z.read(next(n for n in names if n.endswith('.dist-info/METADATA'))).decode()
+          assert 'Requires-Dist: ${{ matrix.torch_requirement }}' in metadata, metadata
+          assert any(n.endswith('/_ops.py') for n in names)
+          print(p.name)
+          "
+
+      - name: Upload variant wheel
+        uses: actions/upload-artifact@v6.0.0
+        with:
+          name: ${{ matrix.variant }}
+          path: native-kernels/orbitquant-packed-matmul/dist/*.whl
+
+  windows-cuda:
+    name: ${{ matrix.variant }} (experimental)
+    runs-on: windows-2025
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: torch212-cu128-x86_64-windows
+            torch: "2.12.*"
+            torch_index: https://download.pytorch.org/whl/cu128
+            torch_requirement: "torch>=2.12,<2.13"
+            cuda_version: "12.8.1"
+            local_tag: cu128torch212
+            unique_id: rel_win_cu128_t212
+          - variant: torch213-cu130-x86_64-windows
+            torch: "2.13.*"
+            torch_index: https://download.pytorch.org/whl/cu130
+            torch_requirement: "torch>=2.13,<2.14"
+            cuda_version: "13.0.2"
+            local_tag: cu130torch213
+            unique_id: rel_win_cu130_t213
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.0
+
+      - name: Install CUDA toolkit
+        uses: Jimver/cuda-toolkit@v0.2.28
+        with:
+          cuda: ${{ matrix.cuda_version }}
+          sub-packages: '["nvcc", "cudart", "curand_dev", "visual_studio_integration"]'
+          method: network
+
+      - name: Install build environment
+        shell: pwsh
+        run: |
+          uv venv .venv --python 3.12
+          uv pip install --python .venv\Scripts\python.exe `
+            --index-url ${{ matrix.torch_index }} `
+            --index-strategy unsafe-best-match `
+            "torch==${{ matrix.torch }}" cmake ninja setuptools wheel numpy
+
+      - name: Restore pinned kernel-builder
+        id: kernel-builder-cache
+        uses: actions/cache/restore@v6.1.0
+        with:
+          path: ${{ runner.temp }}\kernel-builder
+          key: kernel-builder-windows-${{ env.KERNEL_BUILDER_REV }}
+
+      - name: Install pinned kernel-builder
+        if: steps.kernel-builder-cache.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          cargo install `
+            --git https://github.com/huggingface/kernels `
+            --rev $env:KERNEL_BUILDER_REV `
+            --locked `
+            --debug `
+            --root "$env:RUNNER_TEMP\kernel-builder" `
+            hf-kernel-builder
+
+      - name: Save pinned kernel-builder
+        if: steps.kernel-builder-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6.1.0
+        with:
+          path: ${{ runner.temp }}\kernel-builder
+          key: kernel-builder-windows-${{ env.KERNEL_BUILDER_REV }}
+
+      - name: Generate native build project
+        shell: pwsh
+        run: |
+          $kernelRoot = "native-kernels\orbitquant-packed-matmul"
+          $builder = "$env:RUNNER_TEMP\kernel-builder\bin\kernel-builder.exe"
+          & $builder check-config $kernelRoot
+          & $builder create-pyproject --unique-id ${{ matrix.unique_id }} -f $kernelRoot
+          & .venv\Scripts\python.exe `
+            "$kernelRoot\scripts\prepare_wheel_project.py" `
+            $kernelRoot `
+            --version "1.0.0+${{ matrix.local_tag }}" `
+            --torch-requirement "${{ matrix.torch_requirement }}"
+
+      - name: Build CUDA wheel with MSVC
+        shell: pwsh
+        working-directory: native-kernels/orbitquant-packed-matmul
+        run: |
+          $vswhere = `
+            "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsRoot = & $vswhere `
+            -latest `
+            -products * `
+            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+            -property installationPath
+          if (-not $vsRoot) {
+            throw "MSVC x86_64 tools were not found"
+          }
+          $vsDevCmd = Join-Path $vsRoot "Common7\Tools\VsDevCmd.bat"
+          $envDump = cmd.exe /d /s /c `
+            "call `"$vsDevCmd`" -arch=x64 -host_arch=x64 >nul && set"
+          if ($LASTEXITCODE -ne 0) {
+            throw "failed to initialize the MSVC x86_64 environment"
+          }
+          foreach ($line in $envDump) {
+            $parts = $line -split "=", 2
+            if ($parts.Length -eq 2) {
+              Set-Item -Path "Env:$($parts[0])" -Value $parts[1]
+            }
+          }
+          nvcc --version
+          $python = "$env:GITHUB_WORKSPACE\.venv\Scripts\python.exe"
+          $nmake = Get-Command nmake.exe -ErrorAction Stop
+          $env:CMAKE_GENERATOR = "NMake Makefiles"
+          $env:ORBITQUANT_CMAKE_MAKE_PROGRAM = $nmake.Source
+          $env:ORBITQUANT_BUILD_TEMP = "$env:RUNNER_TEMP\orbitquant-native-build"
+          $env:MAX_JOBS = "2"
+          & $python setup.py build_ext bdist_wheel
+          Get-ChildItem dist
+
+      - name: Upload variant wheel
+        uses: actions/upload-artifact@v6.0.0
+        with:
+          name: ${{ matrix.variant }}
+          path: native-kernels/orbitquant-packed-matmul/dist/*.whl
+
+  macos-metal:
+    name: ${{ matrix.variant }}
+    runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: torch212-metal-aarch64-darwin
+            torch: "2.12.*"
+            torch_requirement: "torch>=2.12,<2.13"
+            local_tag: metaltorch212
+            unique_id: rel_metal_t212
+          - variant: torch213-metal-aarch64-darwin
+            torch: "2.13.*"
+            torch_requirement: "torch>=2.13,<2.14"
+            local_tag: metaltorch213
+            unique_id: rel_metal_t213
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.0
+
+      - name: Install build environment
+        run: |
+          uv venv .venv --python 3.12
+          uv pip install --python .venv/bin/python \
+            "torch==${{ matrix.torch }}" cmake ninja setuptools wheel numpy
+
+      - name: Restore pinned kernel-builder
+        id: kernel-builder-cache
+        uses: actions/cache/restore@v6.1.0
+        with:
+          path: ${{ runner.temp }}/kernel-builder
+          key: kernel-builder-macos-${{ env.KERNEL_BUILDER_REV }}
+
+      - name: Install pinned kernel-builder
+        if: steps.kernel-builder-cache.outputs.cache-hit != 'true'
+        run: |
+          cargo install \
+            --git https://github.com/huggingface/kernels \
+            --rev "$KERNEL_BUILDER_REV" \
+            --locked \
+            --debug \
+            --root "$RUNNER_TEMP/kernel-builder" \
+            hf-kernel-builder
+
+      - name: Save pinned kernel-builder
+        if: steps.kernel-builder-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6.1.0
+        with:
+          path: ${{ runner.temp }}/kernel-builder
+          key: kernel-builder-macos-${{ env.KERNEL_BUILDER_REV }}
+
+      - name: Generate native build project
+        run: |
+          kernel_root="native-kernels/orbitquant-packed-matmul"
+          builder="$RUNNER_TEMP/kernel-builder/bin/kernel-builder"
+          "$builder" check-config "$kernel_root"
+          "$builder" create-pyproject --unique-id ${{ matrix.unique_id }} -f "$kernel_root"
+          .venv/bin/python "$kernel_root/scripts/prepare_wheel_project.py" \
+            "$kernel_root" \
+            --version "1.0.0+${{ matrix.local_tag }}" \
+            --torch-requirement "${{ matrix.torch_requirement }}"
+
+      - name: Build Metal wheel
+        working-directory: native-kernels/orbitquant-packed-matmul
+        env:
+          MAX_JOBS: "3"
+        run: |
+          python="$GITHUB_WORKSPACE/.venv/bin/python"
+          "$python" setup.py bdist_wheel
+          ls -l dist/
+
+      - name: Smoke test wheel
+        run: |
+          smoke="$RUNNER_TEMP/orbitquant-metal-smoke"
+          uv venv "$smoke" --python 3.12
+          uv pip install --python "$smoke/bin/python" "torch==${{ matrix.torch }}" pytest numpy
+          wheel=$(find native-kernels/orbitquant-packed-matmul/dist -name '*.whl' -print -quit)
+          uv pip install --python "$smoke/bin/python" "$wheel" --no-deps
+          "$smoke/bin/python" -m pytest \
+            native-kernels/orbitquant-packed-matmul/tests/test_packed_matmul.py \
+            -m kernels_ci -ra
+
+      - name: Upload variant wheel
+        uses: actions/upload-artifact@v6.0.0
+        with:
+          name: ${{ matrix.variant }}
+          path: native-kernels/orbitquant-packed-matmul/dist/*.whl
+
+  macos-cpu:
+    name: torch-stable-abi211-cpu-aarch64-darwin
+    runs-on: macos-15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.0
+
+      - name: Install build environment
+        run: |
+          uv venv .venv --python 3.12
+          uv pip install --python .venv/bin/python \
+            "torch==2.12.*" cmake ninja setuptools wheel numpy
+
+      - name: Restore pinned kernel-builder
+        id: kernel-builder-cache
+        uses: actions/cache/restore@v6.1.0
+        with:
+          path: ${{ runner.temp }}/kernel-builder
+          key: kernel-builder-macos-${{ env.KERNEL_BUILDER_REV }}
+
+      - name: Install pinned kernel-builder
+        if: steps.kernel-builder-cache.outputs.cache-hit != 'true'
+        run: |
+          cargo install \
+            --git https://github.com/huggingface/kernels \
+            --rev "$KERNEL_BUILDER_REV" \
+            --locked \
+            --debug \
+            --root "$RUNNER_TEMP/kernel-builder" \
+            hf-kernel-builder
+
+      - name: Save pinned kernel-builder
+        if: steps.kernel-builder-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6.1.0
+        with:
+          path: ${{ runner.temp }}/kernel-builder
+          key: kernel-builder-macos-${{ env.KERNEL_BUILDER_REV }}
+
+      - name: Generate native build project
+        run: |
+          kernel_root="native-kernels/orbitquant-packed-matmul"
+          builder="$RUNNER_TEMP/kernel-builder/bin/kernel-builder"
+          "$builder" check-config "$kernel_root"
+          "$builder" create-pyproject --unique-id rel_cpu_darwin -f "$kernel_root"
+          .venv/bin/python "$kernel_root/scripts/prepare_wheel_project.py" \
+            "$kernel_root" \
+            --version "1.0.0"
+
+      - name: Build ABI3 CPU wheel
+        working-directory: native-kernels/orbitquant-packed-matmul
+        env:
+          CMAKE_ARGS: -DGPU_LANG=CPU
+          MAX_JOBS: "3"
+        run: |
+          python="$GITHUB_WORKSPACE/.venv/bin/python"
+          "$python" setup.py build_ext bdist_wheel --py-limited-api=cp39
+          ls -l dist/
+
+      - name: Smoke test wheel against a different torch minor
+        run: |
+          smoke="$RUNNER_TEMP/orbitquant-cpu-smoke"
+          uv venv "$smoke" --python 3.12
+          uv pip install --python "$smoke/bin/python" "torch==2.13.*" pytest numpy
+          wheel=$(find native-kernels/orbitquant-packed-matmul/dist -name '*.whl' -print -quit)
+          uv pip install --python "$smoke/bin/python" "$wheel" --no-deps
+          "$smoke/bin/python" -m pytest \
+            native-kernels/orbitquant-packed-matmul/tests/test_packed_matmul.py \
+            -m kernels_ci -ra
+
+      - name: Upload variant wheel
+        uses: actions/upload-artifact@v6.0.0
+        with:
+          name: torch-stable-abi211-cpu-aarch64-darwin
+          path: native-kernels/orbitquant-packed-matmul/dist/*.whl
+
+  manylinux-cpu:
+    name: torch-stable-abi211-cpu-${{ matrix.arch }}-linux
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-24.04
+            cibw_build: cp312-manylinux_x86_64
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+            cibw_build: cp312-manylinux_aarch64
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.0
+
+      - name: Restore pinned kernel-builder
+        id: kernel-builder-cache
+        uses: actions/cache/restore@v6.1.0
+        with:
+          path: ${{ runner.temp }}/kernel-builder
+          key: kernel-builder-linux-${{ matrix.arch }}-${{ env.KERNEL_BUILDER_REV }}
+
+      - name: Install pinned kernel-builder
+        if: steps.kernel-builder-cache.outputs.cache-hit != 'true'
+        run: |
+          cargo install \
+            --git https://github.com/huggingface/kernels \
+            --rev "$KERNEL_BUILDER_REV" \
+            --locked \
+            --debug \
+            --root "$RUNNER_TEMP/kernel-builder" \
+            hf-kernel-builder
+
+      - name: Save pinned kernel-builder
+        if: steps.kernel-builder-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6.1.0
+        with:
+          path: ${{ runner.temp }}/kernel-builder
+          key: kernel-builder-linux-${{ matrix.arch }}-${{ env.KERNEL_BUILDER_REV }}
+
+      - name: Generate native build project
+        run: |
+          kernel_root="native-kernels/orbitquant-packed-matmul"
+          builder="$RUNNER_TEMP/kernel-builder/bin/kernel-builder"
+          "$builder" check-config "$kernel_root"
+          "$builder" create-pyproject --unique-id rel_cpu_linux -f "$kernel_root"
+          uv run --no-project --with setuptools python \
+            "$kernel_root/scripts/prepare_wheel_project.py" \
+            "$kernel_root" \
+            --version "1.0.0"
+
+      - name: Build manylinux 2.28 ABI3 wheel
+        env:
+          CIBW_ARCHS_LINUX: ${{ matrix.arch }}
+          CIBW_BUILD: ${{ matrix.cibw_build }}
+          CIBW_ENVIRONMENT_LINUX: >-
+            CMAKE_ARGS=-DGPU_LANG=CPU
+            MAX_JOBS=2
+            ORBITQUANT_BUILD_TEMP=/tmp/oq-native-build
+            PIP_INDEX_URL=https://download.pytorch.org/whl/cpu
+            PIP_EXTRA_INDEX_URL=https://pypi.org/simple
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: >-
+            auditwheel repair
+            --exclude libc10.so
+            --exclude libtorch_cpu.so
+            --exclude libtorch.so
+            -w {dest_dir} {wheel}
+          CIBW_TEST_COMMAND: >-
+            python -m pytest {package}/tests/test_packed_matmul.py
+            -m kernels_ci -ra
+          CIBW_TEST_REQUIRES: numpy pytest torch==2.12.1
+        run: |
+          uv run --no-project --with cibuildwheel==4.1.0 \
+            python -m cibuildwheel \
+            native-kernels/orbitquant-packed-matmul \
+            --output-dir wheelhouse
+
+      - name: Upload variant wheel
+        uses: actions/upload-artifact@v6.0.0
+        with:
+          name: torch-stable-abi211-cpu-${{ matrix.arch }}-linux
+          path: wheelhouse/*.whl
+
+  windows-cpu:
+    name: torch-stable-abi211-cpu-x86_64-windows
+    runs-on: windows-2025
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.0
+
+      - name: Install build environment
+        shell: pwsh
+        run: |
+          uv venv .venv --python 3.12
+          uv pip install --python .venv\Scripts\python.exe `
+            --index-url https://download.pytorch.org/whl/cpu `
+            --index-strategy unsafe-best-match `
+            "torch==2.12.*" cmake ninja setuptools wheel numpy
+
+      - name: Restore pinned kernel-builder
+        id: kernel-builder-cache
+        uses: actions/cache/restore@v6.1.0
+        with:
+          path: ${{ runner.temp }}\kernel-builder
+          key: kernel-builder-windows-${{ env.KERNEL_BUILDER_REV }}
+
+      - name: Install pinned kernel-builder
+        if: steps.kernel-builder-cache.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          cargo install `
+            --git https://github.com/huggingface/kernels `
+            --rev $env:KERNEL_BUILDER_REV `
+            --locked `
+            --debug `
+            --root "$env:RUNNER_TEMP\kernel-builder" `
+            hf-kernel-builder
+
+      - name: Save pinned kernel-builder
+        if: steps.kernel-builder-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6.1.0
+        with:
+          path: ${{ runner.temp }}\kernel-builder
+          key: kernel-builder-windows-${{ env.KERNEL_BUILDER_REV }}
+
+      - name: Generate native build project
+        shell: pwsh
+        run: |
+          $kernelRoot = "native-kernels\orbitquant-packed-matmul"
+          $builder = "$env:RUNNER_TEMP\kernel-builder\bin\kernel-builder.exe"
+          & $builder check-config $kernelRoot
+          & $builder create-pyproject --unique-id rel_cpu_windows -f $kernelRoot
+          & .venv\Scripts\python.exe `
+            "$kernelRoot\scripts\prepare_wheel_project.py" `
+            $kernelRoot `
+            --version "1.0.0"
+
+      - name: Build ABI3 CPU wheel with MSVC
+        shell: pwsh
+        working-directory: native-kernels/orbitquant-packed-matmul
+        run: |
+          $vswhere = `
+            "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsRoot = & $vswhere `
+            -latest `
+            -products * `
+            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+            -property installationPath
+          if (-not $vsRoot) {
+            throw "MSVC x86_64 tools were not found"
+          }
+          $vsDevCmd = Join-Path $vsRoot "Common7\Tools\VsDevCmd.bat"
+          $envDump = cmd.exe /d /s /c `
+            "call `"$vsDevCmd`" -arch=x64 -host_arch=x64 >nul && set"
+          if ($LASTEXITCODE -ne 0) {
+            throw "failed to initialize the MSVC x86_64 environment"
+          }
+          foreach ($line in $envDump) {
+            $parts = $line -split "=", 2
+            if ($parts.Length -eq 2) {
+              Set-Item -Path "Env:$($parts[0])" -Value $parts[1]
+            }
+          }
+          $python = "$env:GITHUB_WORKSPACE\.venv\Scripts\python.exe"
+          $nmake = Get-Command nmake.exe -ErrorAction Stop
+          $env:CMAKE_GENERATOR = "NMake Makefiles"
+          $env:CMAKE_ARGS = "-DGPU_LANG=CPU"
+          $env:ORBITQUANT_CMAKE_MAKE_PROGRAM = $nmake.Source
+          $env:ORBITQUANT_BUILD_TEMP = "$env:RUNNER_TEMP\orbitquant-native-build"
+          $env:MAX_JOBS = "2"
+          & $python setup.py build_ext bdist_wheel --py-limited-api=cp39
+
+      - name: Upload variant wheel
+        uses: actions/upload-artifact@v6.0.0
+        with:
+          name: torch-stable-abi211-cpu-x86_64-windows
+          path: native-kernels/orbitquant-packed-matmul/dist/*.whl
+
+  assemble:
+    name: Assemble manifest
+    runs-on: ubuntu-24.04
+    needs:
+      - linux-cuda
+      - windows-cuda
+      - macos-metal
+      - macos-cpu
+      - manylinux-cpu
+      - windows-cpu
+    if: always() && !cancelled()
+    permissions:
+      contents: write
+    steps:
+      - name: Download all variant wheels
+        uses: actions/download-artifact@v7.0.0
+        with:
+          path: assets
+
+      - name: Build manifest
+        run: |
+          python3 - << 'PY'
+          import hashlib
+          import json
+          from pathlib import Path
+
+          variants = {}
+          for variant_dir in sorted(Path("assets").iterdir()):
+              wheels = sorted(variant_dir.glob("*.whl"))
+              if not wheels:
+                  continue
+              wheel = wheels[0]
+              variants[variant_dir.name] = {
+                  "filename": wheel.name,
+                  "sha256": hashlib.sha256(wheel.read_bytes()).hexdigest(),
+                  "size": wheel.stat().st_size,
+              }
+          manifest = {
+              "kernel_version": 1,
+              "package": "orbitquant_packed_matmul",
+              "variants": variants,
+          }
+          Path("assets/manifest.json").write_text(json.dumps(manifest, indent=2))
+          print(json.dumps(manifest, indent=2))
+          PY
+
+      - name: Upload manifest artifact
+        uses: actions/upload-artifact@v6.0.0
+        with:
+          name: kernels-manifest
+          path: assets/manifest.json
+
+      - name: Publish wheels and manifest to the kernels release
+        if: inputs.publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if ! gh release view "$KERNELS_RELEASE_TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            gh release create "$KERNELS_RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "Native kernel variants v1" \
+              --notes "Prebuilt orbitquant-packed-matmul variant wheels consumed by orbitquant.kernels.provision. Do not delete individual assets: the runtime resolves them through manifest.json." \
+              --latest=false
+          fi
+          find assets -name '*.whl' -print0 | xargs -0 gh release upload "$KERNELS_RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" --clobber
+          gh release upload "$KERNELS_RELEASE_TAG" assets/manifest.json \
+            --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/build-kernels.yml
+++ b/.github/workflows/build-kernels.yml
@@ -96,7 +96,8 @@ jobs:
           sudo dpkg -i cuda-keyring_1.1-1_all.deb
           sudo apt-get update -q
           sudo apt-get install -y -q cuda-nvcc-${{ matrix.cuda_apt }} \
-            cuda-cudart-dev-${{ matrix.cuda_apt }}
+            cuda-cudart-dev-${{ matrix.cuda_apt }} \
+            cuda-libraries-dev-${{ matrix.cuda_apt }}
           echo "/usr/local/cuda-$(echo ${{ matrix.cuda_apt }} | tr '-' '.')/bin" >> "$GITHUB_PATH"
 
       - name: Install build environment

--- a/.github/workflows/build-kernels.yml
+++ b/.github/workflows/build-kernels.yml
@@ -432,6 +432,10 @@ jobs:
         working-directory: native-kernels/orbitquant-packed-matmul
         env:
           MAX_JOBS: "3"
+          # Keep the produced metallib and dylib loadable on macOS 15 and
+          # newer (the audited contract in docs/kernel-audit.md).
+          MACOSX_DEPLOYMENT_TARGET: "15.0"
+          CMAKE_ARGS: -DCMAKE_OSX_DEPLOYMENT_TARGET=15.0
         run: |
           python="$GITHUB_WORKSPACE/.venv/bin/python"
           "$python" setup.py bdist_wheel

--- a/.github/workflows/build-kernels.yml
+++ b/.github/workflows/build-kernels.yml
@@ -215,6 +215,8 @@ jobs:
           cuda: ${{ matrix.cuda_version }}
           sub-packages: '["nvcc", "cudart", "visual_studio_integration"]'
           method: network
+          use-github-cache: false
+          use-local-cache: false
 
       - name: Install build environment
         shell: pwsh
@@ -309,7 +311,9 @@ jobs:
 
   macos-metal:
     name: ${{ matrix.variant }}
-    runs-on: macos-15
+    # Xcode 26 required: the kernel-builder metal template locates the Metal
+    # toolchain through `xcodebuild -showComponent MetalToolchain`.
+    runs-on: macos-26
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-kernels.yml
+++ b/.github/workflows/build-kernels.yml
@@ -204,6 +204,9 @@ jobs:
             torch_requirement: "torch>=2.13,<2.14"
             cuda_version: "13.0.1"
             cuda_feature_tag: "13.0"
+            # CUDA 13 repackaged the crt/ headers out of the nvcc component;
+            # install the full toolkit instead of hand-picked components.
+            cuda_full_install: true
             local_tag: cu130torch213
             unique_id: rel_win_cu130_t213
     steps:
@@ -227,21 +230,28 @@ jobs:
           $url = "https://developer.download.nvidia.com/compute/cuda/$version/network_installers/cuda_${version}_windows_network.exe"
           Write-Host "Downloading $url"
           Invoke-WebRequest -Uri $url -OutFile $installer
-          $components = @(
-            "nvcc_$feature",
-            "cudart_$feature",
-            "nvrtc_dev_$feature",
-            "cublas_dev_$feature",
-            "cusparse_dev_$feature",
-            "cusolver_dev_$feature",
-            "cufft_dev_$feature",
-            "curand_dev_$feature",
-            "thrust_$feature",
-            "visual_studio_integration_$feature"
-          )
-          Write-Host "Installing components: $components"
+          $fullInstall = "${{ matrix.cuda_full_install }}" -eq "true"
+          if ($fullInstall) {
+            $arguments = @("-s")
+            Write-Host "Installing the full CUDA toolkit"
+          } else {
+            $components = @(
+              "nvcc_$feature",
+              "cudart_$feature",
+              "nvrtc_dev_$feature",
+              "cublas_dev_$feature",
+              "cusparse_dev_$feature",
+              "cusolver_dev_$feature",
+              "cufft_dev_$feature",
+              "curand_dev_$feature",
+              "thrust_$feature",
+              "visual_studio_integration_$feature"
+            )
+            $arguments = @("-s") + $components
+            Write-Host "Installing components: $components"
+          }
           $process = Start-Process -Wait -PassThru -FilePath $installer `
-            -ArgumentList (@("-s") + $components)
+            -ArgumentList $arguments
           if ($process.ExitCode -ne 0) {
             throw "CUDA network installer failed with exit code $($process.ExitCode)"
           }

--- a/.github/workflows/build-kernels.yml
+++ b/.github/workflows/build-kernels.yml
@@ -207,6 +207,7 @@ jobs:
             # CUDA 13 repackaged the crt/ headers out of the nvcc component;
             # install the full toolkit instead of hand-picked components.
             cuda_full_install: true
+            nvcc_allow_unsupported: true
             local_tag: cu130torch213
             unique_id: rel_win_cu130_t213
     steps:
@@ -317,6 +318,11 @@ jobs:
         shell: pwsh
         working-directory: native-kernels/orbitquant-packed-matmul
         run: |
+          if ("${{ matrix.nvcc_allow_unsupported }}" -eq "true") {
+            # CUDA 13.0 nvcc rejects the MSVC 2026 toolset on windows-2025;
+            # override the version check (the cu128 build passes it natively).
+            $env:CUDAFLAGS = "-allow-unsupported-compiler"
+          }
           $vswhere = `
             "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
           $vsRoot = & $vswhere `

--- a/README.md
+++ b/README.md
@@ -45,10 +45,18 @@ pip install "orbitquant[hf,kernels]"
 ```
 
 The optimized native kernel package (`orbitquant_packed_matmul`) is provisioned
-automatically the first time a packed runtime path needs it: OrbitQuant checks
-for an installed package, then for a cached variant, then downloads the
-matching prebuilt variant wheel from this repository's `kernels-v1` GitHub
-release. Provision explicitly (or offline) with:
+automatically the first time a packed runtime path needs it. How it works: the
+kernel binary must match the runtime exactly — torch minor and CUDA version
+for CUDA builds, torch stable ABI (any torch>=2.11) for CPU builds, and the OS
+and architecture everywhere — so OrbitQuant derives that variant name from the
+running process and resolves it in order: an installed
+`orbitquant_packed_matmul` package, a locally built variant (`LOCAL_KERNELS`),
+the on-disk cache, and finally the matching prebuilt variant wheel from this
+repository's `kernels-v1` GitHub release (checksum-verified against the
+release manifest, then cached). Everything happens once per process at model
+load, never inside the forward path, and any failure falls back to the Triton
+(CUDA) or reference paths with an actionable message. Provision explicitly
+(or offline) with:
 
 ```bash
 orbitquant kernels-install          # download the matching prebuilt variant

--- a/README.md
+++ b/README.md
@@ -38,11 +38,30 @@ a machine-readable inventory before quantization.
 pip install "orbitquant[hf]"
 ```
 
-Install the CUDA/Triton and local-kernel loader dependencies with:
+Install the Triton fallback dependency for CUDA with:
 
 ```bash
 pip install "orbitquant[hf,kernels]"
 ```
+
+The optimized native kernel package (`orbitquant_packed_matmul`) is provisioned
+automatically the first time a packed runtime path needs it: OrbitQuant checks
+for an installed package, then for a cached variant, then downloads the
+matching prebuilt variant wheel from this repository's `kernels-v1` GitHub
+release. Provision explicitly (or offline) with:
+
+```bash
+orbitquant kernels-install          # download the matching prebuilt variant
+orbitquant kernels-install --build  # or compile from bundled sources (needs a toolchain)
+orbitquant kernels-status           # inspect what the resolver would do
+```
+
+Set `ORBITQUANT_KERNELS_AUTOFETCH=0` to forbid downloads,
+`ORBITQUANT_KERNELS_AUTOBUILD=1` to allow automatic source builds, and
+`ORBITQUANT_KERNELS_CACHE` to relocate the cache (default
+`~/.cache/orbitquant/kernels`). Runtimes without a matching variant fall back
+to Triton (CUDA) or the reference paths; see
+[`docs/kernel-audit.md`](docs/kernel-audit.md) for the full contract.
 
 ## Quantize A Transformers Model
 

--- a/docs/kernel-audit.md
+++ b/docs/kernel-audit.md
@@ -40,6 +40,36 @@ Other explicit modes are `native_packed_matmul`, `triton_packed_matmul`,
 | ROCm | Experimental source candidate; supported-hardware proof pending | Exact Triton activation, low-bit pack/unpack, packed matmul, weight quantization, and packed INT4 AdaLN; explicit-only |
 | XPU | Experimental source candidate; Intel hardware proof pending | Exact Triton activation, low-bit pack/unpack, packed matmul, weight quantization, and packed INT4 AdaLN on `torch.xpu`; explicit-only |
 
+## Native Package Provisioning
+
+The runtime resolves the native `orbitquant_packed_matmul` package through
+`orbitquant.kernels.provision` in this order:
+
+1. an already importable `orbitquant_packed_matmul` package (an installed
+   wheel);
+2. variant directories named by `LOCAL_KERNELS`
+   (`WaveCut/orbitquant-packed-matmul=/path/to/build/<variant>`);
+3. previously provisioned variants in the cache
+   (`~/.cache/orbitquant/kernels`, override with `ORBITQUANT_KERNELS_CACHE`);
+4. a prebuilt variant wheel downloaded from the `kernels-v1` GitHub release of
+   this repository, checksum-verified against the release `manifest.json`
+   (disable with `ORBITQUANT_KERNELS_AUTOFETCH=0`, redirect with
+   `ORBITQUANT_KERNELS_RELEASE_BASE`);
+5. an opt-in JIT build from the kernel sources bundled inside the `orbitquant`
+   wheel (enable with `ORBITQUANT_KERNELS_AUTOBUILD=1` or
+   `orbitquant kernels-install --build`; CPU builds need torch>=2.11, CUDA
+   builds need a matching `nvcc`; the Metal variant is prebuilt-only because
+   its shader library is embedded at build time).
+
+Accelerator variants are preferred over the CPU variant. The resolver runs at
+most once per process, only when a packed runtime path first needs the native
+package, and never inside the forward path. `orbitquant kernels-status` prints
+the resolution state; `orbitquant kernels-install` performs it explicitly and
+is safe to run from installer hooks. Variant wheels are built by the
+`build-kernels.yml` workflow; CUDA and Metal wheels pin the torch minor they
+were built against in `Requires-Dist`, the CPU wheel binds the torch stable
+ABI (`torch>=2.11`) and the Python stable ABI (`cp39-abi3`).
+
 ## Local Native Package
 
 Kernel Hub publication is not required. Build the native package locally from
@@ -96,9 +126,8 @@ distributing it. The Linux wheel CI builds inside `manylinux_2_28`, repairs the
 result with `auditwheel`, and runs strict `abi3audit`; an ordinary local Ubuntu
 build can still depend on a newer GLIBC.
 
-To load the local build through Hugging Face `kernels` instead of importing it
-through `PYTHONPATH`, map the kernel repository to the same generated variant
-directory containing `metadata.json`:
+To let the OrbitQuant provisioner attach the local build instead of exporting
+`PYTHONPATH`, map the kernel repository id to the generated variant directory:
 
 ```bash
 export LOCAL_KERNELS="WaveCut/orbitquant-packed-matmul=$PWD/build/<matching-variant>"

--- a/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
+++ b/native-kernels/orbitquant-packed-matmul/scripts/prepare_wheel_project.py
@@ -10,6 +10,14 @@ def main() -> None:
     )
     parser.add_argument("project", type=Path)
     parser.add_argument("--version", required=True)
+    parser.add_argument(
+        "--torch-requirement",
+        default="torch>=2.11",
+        help=(
+            "torch dependency for the wheel metadata; non-stable-ABI variants "
+            'must pin the torch minor they were built against (e.g. "torch>=2.9,<2.10")'
+        ),
+    )
     args = parser.parse_args()
 
     pyproject = args.project / "pyproject.toml"
@@ -25,7 +33,7 @@ def main() -> None:
         raise RuntimeError("generated pyproject must contain one Python requirement")
     text = text.replace(
         requires_python,
-        f'{requires_python}\ndependencies = ["torch>=2.11"]',
+        f'{requires_python}\ndependencies = ["{args.torch_requirement}"]',
         1,
     )
     pyproject.write_text(text, encoding="utf-8")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "orbitquant"
-version = "0.5.0"
+version = "0.6.0"
 description = "Calibration-free OrbitQuant for transformer linear projections"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -37,7 +37,6 @@ hf = [
   "transformers>=4.53",
 ]
 kernels = [
-  "kernels>=0.16",
   "triton>=3.5; platform_system == 'Linux'",
 ]
 eval = [
@@ -63,6 +62,16 @@ Paper = "https://arxiv.org/abs/2607.02461"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/orbitquant"]
+
+# Bundle the native kernel sources so the runtime JIT fallback can build the
+# packed matmul package outside a repository checkout.
+[tool.hatch.build.targets.wheel.force-include]
+"native-kernels/orbitquant-packed-matmul/torch-ext" = "orbitquant/_kernel_src/torch-ext"
+"native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cpu" = "orbitquant/_kernel_src/orbitquant_packed_matmul_cpu"
+"native-kernels/orbitquant-packed-matmul/orbitquant_packed_matmul_cuda" = "orbitquant/_kernel_src/orbitquant_packed_matmul_cuda"
+
+[tool.hatch.build.targets.sdist]
+include = ["src", "native-kernels", "tests", "docs", "scripts", "README.md", "LICENSE"]
 
 [tool.ruff]
 line-length = 100

--- a/src/orbitquant/__init__.py
+++ b/src/orbitquant/__init__.py
@@ -18,7 +18,7 @@ from orbitquant.pipeline import (
 from orbitquant.quantizer import register_hf_quantizers
 from orbitquant.recipes import recipe
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 
 register_hf_quantizers()
 

--- a/src/orbitquant/cli/main.py
+++ b/src/orbitquant/cli/main.py
@@ -741,6 +741,22 @@ def main(argv: list[str] | None = None) -> int:
     inspect_policy_parser.add_argument("--output")
     subparsers.add_parser("native-suites", help="list native eval suites")
     subparsers.add_parser("kernel-info", help="print activation kernel backend capabilities")
+    subparsers.add_parser(
+        "kernels-status", help="describe native kernel package provisioning state"
+    )
+    kernels_install_parser = subparsers.add_parser(
+        "kernels-install", help="provision the native kernel package for this runtime"
+    )
+    kernels_install_parser.add_argument(
+        "--build",
+        action="store_true",
+        help="allow a local JIT build from bundled sources when no prebuilt variant fits",
+    )
+    kernels_install_parser.add_argument(
+        "--no-fetch",
+        action="store_true",
+        help="do not download prebuilt variants from GitHub releases",
+    )
     kernel_bench_parser = subparsers.add_parser(
         "kernel-bench", help="benchmark OrbitQuantLinear kernel stages"
     )
@@ -1366,6 +1382,20 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "kernel-info":
         print(json.dumps(backend_capabilities(), indent=2))
         return 0
+    if args.command == "kernels-status":
+        from orbitquant.kernels import provision
+
+        print(json.dumps(provision.provision_status(), indent=2))
+        return 0
+    if args.command == "kernels-install":
+        from orbitquant.kernels import provision
+
+        report = provision.provision_native_kernel_package(
+            allow_fetch=not args.no_fetch,
+            allow_build=True if args.build else None,
+        )
+        print(json.dumps(report.to_dict(), indent=2))
+        return 0 if report.source != "unavailable" else 1
     if args.command == "kernel-bench":
         print(
             json.dumps(

--- a/src/orbitquant/kernels/_jit_support/registration.h
+++ b/src/orbitquant/kernels/_jit_support/registration.h
@@ -1,0 +1,41 @@
+// Registration macros for the orbitquant JIT kernel build. This mirrors the
+// header that kernel-builder generates for packaged builds, which is in turn
+// derived from vLLM:
+// https://github.com/vllm-project/vllm/blob/main/csrc/core/registration.h
+
+#pragma once
+
+#include <Python.h>
+
+#define _CONCAT(A, B) A##B
+#define CONCAT(A, B) _CONCAT(A, B)
+
+#define _STRINGIFY(A) #A
+#define STRINGIFY(A) _STRINGIFY(A)
+
+// A version of the TORCH_LIBRARY macro that expands the NAME, i.e. so NAME
+// could be a macro instead of a literal token.
+#define TORCH_LIBRARY_EXPAND(NAME, MODULE) TORCH_LIBRARY(NAME, MODULE)
+
+// A version of the STABLE_TORCH_LIBRARY macro that expands the NAME, i.e. so
+// NAME could be a macro instead of a literal token.
+#define STABLE_TORCH_LIBRARY_EXPAND(NAME, MODULE) STABLE_TORCH_LIBRARY(NAME, MODULE)
+
+// A version of the TORCH_LIBRARY_IMPL macro that expands the NAME, i.e. so
+// NAME could be a macro instead of a literal token.
+#define TORCH_LIBRARY_IMPL_EXPAND(NAME, DEVICE, MODULE) \
+  TORCH_LIBRARY_IMPL(NAME, DEVICE, MODULE)
+
+// A version of the STABLE_TORCH_LIBRARY_IMPL macro that expands the NAME,
+// i.e. so NAME could be a macro instead of a literal token.
+#define STABLE_TORCH_LIBRARY_IMPL_EXPAND(NAME, DEVICE, MODULE) \
+  STABLE_TORCH_LIBRARY_IMPL(NAME, DEVICE, MODULE)
+
+// REGISTER_EXTENSION allows the shared library to be loaded and initialized
+// via python's import statement.
+#define REGISTER_EXTENSION(NAME)                                               \
+  PyMODINIT_FUNC CONCAT(PyInit_, NAME)() {                                     \
+    static struct PyModuleDef module = {PyModuleDef_HEAD_INIT,                 \
+                                        STRINGIFY(NAME), nullptr, 0, nullptr}; \
+    return PyModule_Create(&module);                                           \
+  }

--- a/src/orbitquant/kernels/native_packed_matmul.py
+++ b/src/orbitquant/kernels/native_packed_matmul.py
@@ -8,9 +8,10 @@ from typing import Any
 import torch
 
 from orbitquant.codebooks import LloydMaxCodebook
+from orbitquant.kernels import provision
 
-_KERNEL_REPO_ID = "WaveCut/orbitquant-packed-matmul"
-_KERNEL_VERSION = 1
+_KERNEL_REPO_ID = provision.KERNEL_REPO_ID
+_KERNEL_VERSION = provision.KERNEL_VERSION
 _NATIVE_KERNEL: Any | None = None
 
 
@@ -50,35 +51,21 @@ def _load_native_packed_matmul_kernel() -> Any:
     if _NATIVE_KERNEL is not None:
         return _NATIVE_KERNEL
 
-    try:
-        from kernels import get_kernel
-    except Exception as exc:  # pragma: no cover - optional dependency
-        raise RuntimeError(
-            "native_packed_matmul runtime requires either an importable "
-            "orbitquant_packed_matmul kernel package or the Hugging Face kernels package. "
-            "Install `kernels` and point LOCAL_KERNELS at a compatible "
-            "built kernel variant directory containing metadata.json, make the "
-            "compatible variant directory importable through PYTHONPATH, or use "
-            f"runtime_mode='dequant_bf16'. {_runtime_variant_hint()}"
-        ) from exc
+    report = provision.provision_native_kernel_package()
+    if report.sys_path_entry is not None:
+        _NATIVE_KERNEL = _load_importable_packed_matmul_kernel()
+        if _NATIVE_KERNEL is not None:
+            return _NATIVE_KERNEL
 
-    try:
-        _NATIVE_KERNEL = get_kernel(
-            _KERNEL_REPO_ID,
-            version=_KERNEL_VERSION,
-            trust_remote_code=True,
-        )
-    except Exception as exc:  # pragma: no cover - environment and Hub dependent
-        raise RuntimeError(
-            "native_packed_matmul runtime could not load "
-            f"{_KERNEL_REPO_ID} version {_KERNEL_VERSION}. For local development, set "
-            "LOCAL_KERNELS=WaveCut/orbitquant-packed-matmul=/absolute/path/to/a/"
-            "built kernel variant directory that contains metadata.json before "
-            "importing OrbitQuant; add that same variant directory to PYTHONPATH; "
-            "or make a compatible orbitquant_packed_matmul package importable. "
-            f"{_runtime_variant_hint()}"
-        ) from exc
-    return _NATIVE_KERNEL
+    raise RuntimeError(
+        "native_packed_matmul runtime could not provision the "
+        "orbitquant_packed_matmul package. Install the prebuilt CPU wheel with "
+        "`pip install orbitquant-packed-matmul`, run `orbitquant kernels-install` "
+        "(add --build to compile locally, or set ORBITQUANT_KERNELS_AUTOBUILD=1), "
+        "point LOCAL_KERNELS=WaveCut/orbitquant-packed-matmul=/absolute/path/to/a/"
+        "built kernel variant directory, or use runtime_mode='dequant_bf16'. "
+        f"Provisioning detail: {report.detail}. {_runtime_variant_hint()}"
+    )
 
 
 def load_native_packed_matmul_kernel() -> Any:

--- a/src/orbitquant/kernels/provision.py
+++ b/src/orbitquant/kernels/provision.py
@@ -1,0 +1,598 @@
+"""Runtime provisioning of the native ``orbitquant_packed_matmul`` package.
+
+The native kernel package is resolved in this order:
+
+1. an already importable ``orbitquant_packed_matmul`` package (for example the
+   PyPI CPU wheel or a manually installed wheel),
+2. a kernel variant directory named by the ``LOCAL_KERNELS`` environment
+   variable (``<repo-id>=<variant-dir>``; the same contract the repository
+   check scripts use),
+3. a previously provisioned variant in the local cache,
+4. a prebuilt variant wheel downloaded from the OrbitQuant GitHub release
+   (checksum-verified against the release manifest),
+5. an opt-in local JIT build from the bundled kernel sources.
+
+Environment contract:
+
+- ``ORBITQUANT_KERNELS_AUTOFETCH=0`` disables the release download step.
+- ``ORBITQUANT_KERNELS_AUTOBUILD=1`` enables the local JIT build step.
+- ``ORBITQUANT_KERNELS_CACHE`` overrides the cache directory
+  (default ``~/.cache/orbitquant/kernels``).
+- ``ORBITQUANT_KERNELS_RELEASE_BASE`` overrides the release download base URL.
+- ``LOCAL_KERNELS`` points at locally built variant directories.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import platform
+import re
+import shutil
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+import zipfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+
+KERNEL_VERSION = 1
+KERNEL_PACKAGE_NAME = "orbitquant_packed_matmul"
+KERNEL_REPO_ID = "WaveCut/orbitquant-packed-matmul"
+_RELEASE_TAG = f"kernels-v{KERNEL_VERSION}"
+_DEFAULT_RELEASE_BASE = (
+    f"https://github.com/iamwavecut/OrbitQuant/releases/download/{_RELEASE_TAG}"
+)
+_MANIFEST_FILENAME = "manifest.json"
+_PROVISION_MARKER = ".orbitquant-provisioned.json"
+_MANIFEST_TIMEOUT_SECONDS = 15
+_WHEEL_TIMEOUT_SECONDS = 180
+_STABLE_ABI_TORCH_MINIMUM = (2, 11)
+
+_MEMOIZED_REPORT: KernelProvisionReport | None = None
+
+
+@dataclass(frozen=True)
+class KernelProvisionReport:
+    requested_variants: tuple[str, ...]
+    variant: str | None
+    source: str
+    sys_path_entry: str | None
+    detail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["requested_variants"] = list(self.requested_variants)
+        return payload
+
+
+def _env_flag(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() not in {"0", "false", "no", "off", ""}
+
+
+def _torch_version_tuple() -> tuple[int, int] | None:
+    match = re.match(r"^(\d+)\.(\d+)", torch.__version__)
+    if match is None:
+        return None
+    return int(match.group(1)), int(match.group(2))
+
+
+def _torch_tag() -> str | None:
+    parsed = _torch_version_tuple()
+    if parsed is None:
+        return None
+    return f"torch{parsed[0]}{parsed[1]}"
+
+
+def _normalized_machine() -> str:
+    machine = platform.machine().lower()
+    if machine in {"arm64", "aarch64"}:
+        return "aarch64"
+    if machine in {"x86_64", "amd64"}:
+        return "x86_64"
+    return machine
+
+
+def _os_name() -> str | None:
+    if sys.platform.startswith("linux"):
+        return "linux"
+    if sys.platform == "darwin":
+        return "darwin"
+    if sys.platform == "win32":
+        return "windows"
+    return None
+
+
+def cuda_variant_name() -> str | None:
+    cuda_version = torch.version.cuda
+    torch_tag = _torch_tag()
+    os_name = _os_name()
+    if cuda_version is None or torch_tag is None or os_name in {None, "darwin"}:
+        return None
+    cuda_tag = "cu" + "".join(cuda_version.split(".")[:2])
+    machine = _normalized_machine()
+    if os_name == "linux":
+        return f"{torch_tag}-cxx11-{cuda_tag}-{machine}-{os_name}"
+    return f"{torch_tag}-{cuda_tag}-{machine}-{os_name}"
+
+
+def metal_variant_name() -> str | None:
+    torch_tag = _torch_tag()
+    if torch_tag is None or _os_name() != "darwin":
+        return None
+    return f"{torch_tag}-metal-{_normalized_machine()}-darwin"
+
+
+def cpu_variant_name() -> str | None:
+    parsed = _torch_version_tuple()
+    os_name = _os_name()
+    if parsed is None or os_name is None or parsed < _STABLE_ABI_TORCH_MINIMUM:
+        return None
+    abi_tag = "".join(str(part) for part in _STABLE_ABI_TORCH_MINIMUM)
+    return f"torch-stable-abi{abi_tag}-cpu-{_normalized_machine()}-{os_name}"
+
+
+def candidate_variant_names() -> tuple[str, ...]:
+    candidates = [cuda_variant_name(), metal_variant_name(), cpu_variant_name()]
+    return tuple(name for name in candidates if name is not None)
+
+
+def kernels_cache_root() -> Path:
+    override = os.environ.get("ORBITQUANT_KERNELS_CACHE")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".cache" / "orbitquant" / "kernels"
+
+
+def _release_base_url() -> str:
+    return os.environ.get(
+        "ORBITQUANT_KERNELS_RELEASE_BASE", _DEFAULT_RELEASE_BASE
+    ).rstrip("/")
+
+
+def _variant_dir_is_valid(variant_dir: Path) -> bool:
+    package_init = variant_dir / KERNEL_PACKAGE_NAME / "__init__.py"
+    return package_init.is_file() and (variant_dir / _PROVISION_MARKER).is_file()
+
+
+def _attach_to_sys_path(variant_dir: Path) -> str:
+    entry = str(variant_dir)
+    if entry not in sys.path:
+        sys.path.insert(0, entry)
+    return entry
+
+
+def _kernel_package_importable() -> bool:
+    return importlib.util.find_spec(KERNEL_PACKAGE_NAME) is not None
+
+
+def _local_kernels_variant_dirs() -> list[Path]:
+    raw = os.environ.get("LOCAL_KERNELS", "")
+    directories: list[Path] = []
+    for item in raw.split(","):
+        item = item.strip()
+        if not item or "=" not in item:
+            continue
+        repo_id, _, path_text = item.partition("=")
+        if repo_id.strip() != KERNEL_REPO_ID:
+            continue
+        path = Path(path_text.strip()).expanduser()
+        if (path / KERNEL_PACKAGE_NAME / "__init__.py").is_file():
+            directories.append(path)
+    return directories
+
+
+def _cached_variant_dirs(variant: str) -> list[Path]:
+    root = kernels_cache_root() / f"v{KERNEL_VERSION}"
+    return [root / "prebuilt" / variant, root / "jit" / variant]
+
+
+def _write_provision_marker(variant_dir: Path, payload: dict[str, Any]) -> None:
+    marker = variant_dir / _PROVISION_MARKER
+    marker.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _http_get(url: str, timeout: float) -> bytes:
+    request = urllib.request.Request(url, headers={"User-Agent": "orbitquant-kernels"})
+    with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+        return response.read()
+
+
+def _fetch_release_manifest() -> dict[str, Any] | None:
+    url = f"{_release_base_url()}/{_MANIFEST_FILENAME}"
+    try:
+        raw = _http_get(url, timeout=_MANIFEST_TIMEOUT_SECONDS)
+    except (urllib.error.URLError, OSError, ValueError):
+        return None
+    try:
+        manifest = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(manifest, dict) or not isinstance(manifest.get("variants"), dict):
+        return None
+    return manifest
+
+
+def _extract_wheel(wheel_path: Path, destination: Path) -> None:
+    with zipfile.ZipFile(wheel_path) as wheel:
+        for info in wheel.infolist():
+            name = info.filename
+            if name.startswith(("/", "\\")) or ".." in Path(name).parts:
+                raise RuntimeError(f"refusing to extract unsafe wheel member {name!r}")
+        wheel.extractall(destination)
+
+
+def _fetch_prebuilt_variant(variant: str) -> tuple[Path | None, str]:
+    manifest = _fetch_release_manifest()
+    if manifest is None:
+        return None, f"release manifest unavailable at {_release_base_url()}"
+    entry = manifest["variants"].get(variant)
+    if not isinstance(entry, dict):
+        available = ", ".join(sorted(manifest["variants"])) or "none"
+        return None, (
+            f"variant {variant} is not published on {_release_base_url()} "
+            f"(published: {available})"
+        )
+    filename = entry.get("filename")
+    expected_sha256 = entry.get("sha256")
+    if not isinstance(filename, str) or not isinstance(expected_sha256, str):
+        return None, f"release manifest entry for {variant} is malformed"
+
+    try:
+        payload = _http_get(
+            f"{_release_base_url()}/{filename}", timeout=_WHEEL_TIMEOUT_SECONDS
+        )
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        return None, f"failed to download {filename}: {exc}"
+
+    actual_sha256 = hashlib.sha256(payload).hexdigest()
+    if actual_sha256 != expected_sha256:
+        return None, (
+            f"checksum mismatch for {filename}: expected {expected_sha256}, "
+            f"got {actual_sha256}"
+        )
+
+    final_dir = kernels_cache_root() / f"v{KERNEL_VERSION}" / "prebuilt" / variant
+    final_dir.parent.mkdir(parents=True, exist_ok=True)
+    staging_root = tempfile.mkdtemp(prefix=f"{variant}.", dir=final_dir.parent)
+    try:
+        staging_dir = Path(staging_root)
+        wheel_path = staging_dir / filename
+        wheel_path.write_bytes(payload)
+        extract_dir = staging_dir / "contents"
+        extract_dir.mkdir()
+        _extract_wheel(wheel_path, extract_dir)
+        if not (extract_dir / KERNEL_PACKAGE_NAME / "__init__.py").is_file():
+            return None, f"{filename} does not contain the {KERNEL_PACKAGE_NAME} package"
+        _write_provision_marker(
+            extract_dir,
+            {
+                "variant": variant,
+                "source": "release",
+                "filename": filename,
+                "sha256": actual_sha256,
+                "kernel_version": KERNEL_VERSION,
+            },
+        )
+        if final_dir.exists():
+            shutil.rmtree(final_dir)
+        os.replace(extract_dir, final_dir)
+    finally:
+        shutil.rmtree(staging_root, ignore_errors=True)
+    return final_dir, f"downloaded {filename}"
+
+
+def _bundled_kernel_source_root() -> Path | None:
+    repo_root = Path(__file__).resolve().parents[3]
+    checkout = repo_root / "native-kernels" / "orbitquant-packed-matmul"
+    if (checkout / "torch-ext" / "torch_binding.cpp").is_file():
+        return checkout
+    bundled = Path(__file__).resolve().parents[1] / "_kernel_src"
+    if (bundled / "torch-ext" / "torch_binding.cpp").is_file():
+        return bundled
+    return None
+
+
+def _jit_backend() -> str:
+    if torch.version.cuda is not None:
+        return "cuda"
+    # The Metal shader library is embedded at kernel-builder build time, so the
+    # JIT fallback cannot produce the metal variant; the CPU variant is still
+    # a valid build target on macOS.
+    return "cpu"
+
+
+def _jit_variant_name(backend: str) -> str | None:
+    if backend == "cuda":
+        return cuda_variant_name()
+    return cpu_variant_name()
+
+
+def _maybe_set_cuda_arch_list() -> None:
+    if os.environ.get("TORCH_CUDA_ARCH_LIST") or not torch.cuda.is_available():
+        return
+    supported = [
+        int(arch.split("_")[1])
+        for arch in torch.cuda.get_arch_list()
+        if arch.startswith("sm_")
+    ]
+    if not supported:
+        return
+    maximum = max(divmod(arch, 10) for arch in supported)
+    architectures: list[str] = []
+    for index in range(torch.cuda.device_count()):
+        capability = min(maximum, torch.cuda.get_device_capability(index))
+        text = f"{capability[0]}.{capability[1]}"
+        if text not in architectures:
+            architectures.append(text)
+    if architectures:
+        os.environ["TORCH_CUDA_ARCH_LIST"] = ";".join(sorted(architectures))
+
+
+def _jit_sources(source_root: Path, backend: str) -> list[str]:
+    sources = [source_root / "torch-ext" / "torch_binding.cpp"]
+    if backend == "cuda":
+        sources.append(
+            source_root / "orbitquant_packed_matmul_cuda" / "packed_matmul.cu"
+        )
+    else:
+        cpu_dir = source_root / "orbitquant_packed_matmul_cpu"
+        sources.extend(sorted(cpu_dir.glob("*.cpp")))
+    return [str(path) for path in sources]
+
+
+def _generated_ops_module(native_module_name: str) -> str:
+    return (
+        "import sys\n"
+        "\n"
+        "import torch\n"
+        "\n"
+        f'if "{native_module_name}" not in sys.modules:\n'
+        f"    from . import {native_module_name}  # noqa: F401\n"
+        f'ops = getattr(torch.ops, "{native_module_name}")\n'
+        "\n"
+        "\n"
+        "def add_op_namespace_prefix(op_name: str):\n"
+        f'    return f"{native_module_name}::{{op_name}}"\n'
+    )
+
+
+def build_native_kernel_package_jit() -> Path:
+    """Build the native kernel package from bundled sources into the cache."""
+
+    backend = _jit_backend()
+    parsed = _torch_version_tuple()
+    if backend == "cpu" and (parsed is None or parsed < _STABLE_ABI_TORCH_MINIMUM):
+        minimum = ".".join(str(part) for part in _STABLE_ABI_TORCH_MINIMUM)
+        raise RuntimeError(
+            f"the CPU JIT build requires torch>={minimum} "
+            "(the CPU kernel binds through the torch stable ABI headers); "
+            f"found torch {torch.__version__}."
+        )
+    variant = _jit_variant_name(backend)
+    if variant is None:
+        raise RuntimeError(
+            "could not derive a kernel variant name for this runtime "
+            f"(torch {torch.__version__}, platform {sys.platform})."
+        )
+    source_root = _bundled_kernel_source_root()
+    if source_root is None:
+        raise RuntimeError(
+            "the bundled native kernel sources are not available; reinstall "
+            "orbitquant or run from a repository checkout."
+        )
+
+    from torch.utils import cpp_extension
+
+    _maybe_set_cuda_arch_list()
+    native_module_name = f"_orbitquant_packed_matmul_jit_{backend}"
+    define = "-DCUDA_KERNEL" if backend == "cuda" else "-DCPU_KERNEL"
+    include_paths = [
+        str(Path(__file__).resolve().parent / "_jit_support"),
+        str(source_root / "torch-ext"),
+        str(source_root / f"orbitquant_packed_matmul_{backend}"),
+    ]
+    extra_cflags = [define] if sys.platform == "win32" else ["-O3", define]
+    module = cpp_extension.load(
+        name=native_module_name,
+        sources=_jit_sources(source_root, backend),
+        extra_include_paths=include_paths,
+        extra_cflags=extra_cflags,
+        extra_cuda_cflags=["-O3", "-lineinfo", define],
+        verbose=_env_flag("ORBITQUANT_KERNELS_BUILD_VERBOSE", False),
+    )
+
+    built_library = Path(module.__file__)
+    variant_dir = kernels_cache_root() / f"v{KERNEL_VERSION}" / "jit" / variant
+    package_dir = variant_dir / KERNEL_PACKAGE_NAME
+    package_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(
+        source_root / "torch-ext" / KERNEL_PACKAGE_NAME / "__init__.py",
+        package_dir / "__init__.py",
+    )
+    (package_dir / "_ops.py").write_text(
+        _generated_ops_module(native_module_name), encoding="utf-8"
+    )
+    shutil.copy2(built_library, package_dir / built_library.name)
+    (variant_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "name": "orbitquant-packed-matmul",
+                "id": native_module_name,
+                "version": KERNEL_VERSION,
+                "backend": {"type": backend},
+                "provenance": {"builder": "orbitquant-jit", "torch": torch.__version__},
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    _write_provision_marker(
+        variant_dir,
+        {
+            "variant": variant,
+            "source": "jit",
+            "backend": backend,
+            "torch": torch.__version__,
+            "kernel_version": KERNEL_VERSION,
+        },
+    )
+    return variant_dir
+
+
+def _report(
+    requested: tuple[str, ...],
+    variant: str | None,
+    source: str,
+    sys_path_entry: str | None,
+    detail: str,
+) -> KernelProvisionReport:
+    return KernelProvisionReport(
+        requested_variants=requested,
+        variant=variant,
+        source=source,
+        sys_path_entry=sys_path_entry,
+        detail=detail,
+    )
+
+
+def provision_native_kernel_package(
+    *,
+    allow_fetch: bool | None = None,
+    allow_build: bool | None = None,
+) -> KernelProvisionReport:
+    """Resolve the native kernel package, mutating ``sys.path`` when needed."""
+
+    global _MEMOIZED_REPORT
+    if _MEMOIZED_REPORT is not None:
+        return _MEMOIZED_REPORT
+
+    fetch_enabled = (
+        _env_flag("ORBITQUANT_KERNELS_AUTOFETCH", True)
+        if allow_fetch is None
+        else allow_fetch
+    )
+    build_enabled = (
+        _env_flag("ORBITQUANT_KERNELS_AUTOBUILD", False)
+        if allow_build is None
+        else allow_build
+    )
+    requested = candidate_variant_names()
+    failures: list[str] = []
+
+    if _kernel_package_importable():
+        report = _report(
+            requested,
+            None,
+            "already-importable",
+            None,
+            f"{KERNEL_PACKAGE_NAME} is already importable",
+        )
+        _MEMOIZED_REPORT = report
+        return report
+
+    for local_dir in _local_kernels_variant_dirs():
+        entry = _attach_to_sys_path(local_dir)
+        report = _report(
+            requested,
+            local_dir.name,
+            "local-kernels",
+            entry,
+            f"attached LOCAL_KERNELS directory {local_dir}",
+        )
+        _MEMOIZED_REPORT = report
+        return report
+
+    for variant in requested:
+        for cached_dir in _cached_variant_dirs(variant):
+            if _variant_dir_is_valid(cached_dir):
+                entry = _attach_to_sys_path(cached_dir)
+                report = _report(
+                    requested,
+                    variant,
+                    "cache",
+                    entry,
+                    f"attached cached variant {cached_dir}",
+                )
+                _MEMOIZED_REPORT = report
+                return report
+
+    if fetch_enabled:
+        for variant in requested:
+            fetched_dir, detail = _fetch_prebuilt_variant(variant)
+            if fetched_dir is not None:
+                entry = _attach_to_sys_path(fetched_dir)
+                report = _report(requested, variant, "release", entry, detail)
+                _MEMOIZED_REPORT = report
+                return report
+            failures.append(detail)
+    else:
+        failures.append("release download disabled (ORBITQUANT_KERNELS_AUTOFETCH=0)")
+
+    if build_enabled:
+        try:
+            built_dir = build_native_kernel_package_jit()
+        except Exception as exc:  # noqa: BLE001 - reported through the provision detail
+            failures.append(f"JIT build failed: {exc}")
+        else:
+            entry = _attach_to_sys_path(built_dir)
+            report = _report(
+                requested,
+                built_dir.name,
+                "jit",
+                entry,
+                f"built {built_dir}",
+            )
+            _MEMOIZED_REPORT = report
+            return report
+    else:
+        failures.append("JIT build disabled (set ORBITQUANT_KERNELS_AUTOBUILD=1 to enable)")
+
+    report = _report(
+        requested,
+        None,
+        "unavailable",
+        None,
+        "; ".join(failures) if failures else "no provisioning path succeeded",
+    )
+    _MEMOIZED_REPORT = report
+    return report
+
+
+def provision_status() -> dict[str, Any]:
+    """Describe provisioning state without mutating ``sys.path`` or the cache."""
+
+    requested = candidate_variant_names()
+    cached: dict[str, str] = {}
+    for variant in requested:
+        for cached_dir in _cached_variant_dirs(variant):
+            if _variant_dir_is_valid(cached_dir):
+                cached[variant] = str(cached_dir)
+                break
+    return {
+        "kernel_version": KERNEL_VERSION,
+        "package": KERNEL_PACKAGE_NAME,
+        "importable": _kernel_package_importable(),
+        "candidate_variants": list(requested),
+        "cache_root": str(kernels_cache_root()),
+        "cached_variants": cached,
+        "local_kernels": [str(path) for path in _local_kernels_variant_dirs()],
+        "release_base": _release_base_url(),
+        "autofetch": _env_flag("ORBITQUANT_KERNELS_AUTOFETCH", True),
+        "autobuild": _env_flag("ORBITQUANT_KERNELS_AUTOBUILD", False),
+        "bundled_sources": str(_bundled_kernel_source_root() or ""),
+    }
+
+
+def _reset_provision_memo_for_tests() -> None:
+    global _MEMOIZED_REPORT
+    _MEMOIZED_REPORT = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,20 @@
+import os
+import tempfile
+
 import pytest
 
 import orbitquant.kernels.dispatch as _dispatch_module
+
+# The test run must never download kernel variants from the GitHub release:
+# native probes would otherwise provision a real package mid-suite (network
+# flakiness plus an importable orbitquant_packed_matmul leaking into every
+# later test). Provision tests mock the transport explicitly. The cache is
+# also redirected so the suite neither reads nor pollutes the user-level
+# ~/.cache/orbitquant/kernels directory.
+os.environ.setdefault("ORBITQUANT_KERNELS_AUTOFETCH", "0")
+os.environ.setdefault(
+    "ORBITQUANT_KERNELS_CACHE", tempfile.mkdtemp(prefix="orbitquant-test-kernels-")
+)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_kernel_provision.py
+++ b/tests/test_kernel_provision.py
@@ -14,6 +14,10 @@ from orbitquant.kernels import provision
 @pytest.fixture(autouse=True)
 def _reset_provision_state(monkeypatch, tmp_path):
     provision._reset_provision_memo_for_tests()
+    # Earlier tests may leave a fake orbitquant_packed_matmul in sys.modules
+    # (importlib.util.find_spec consults it first), so isolate module state.
+    sys.modules.pop("orbitquant_packed_matmul", None)
+    importlib.invalidate_caches()
     monkeypatch.setenv("ORBITQUANT_KERNELS_CACHE", str(tmp_path / "kernels-cache"))
     monkeypatch.delenv("LOCAL_KERNELS", raising=False)
     monkeypatch.delenv("ORBITQUANT_KERNELS_AUTOFETCH", raising=False)
@@ -22,6 +26,8 @@ def _reset_provision_state(monkeypatch, tmp_path):
     original_sys_path = list(sys.path)
     yield
     sys.path[:] = original_sys_path
+    sys.modules.pop("orbitquant_packed_matmul", None)
+    importlib.invalidate_caches()
     provision._reset_provision_memo_for_tests()
 
 

--- a/tests/test_kernel_provision.py
+++ b/tests/test_kernel_provision.py
@@ -246,7 +246,9 @@ def test_provision_status_reports_without_side_effects(monkeypatch):
     ]
     assert status["autofetch"] is True
     assert status["autobuild"] is False
-    assert Path(status["bundled_sources"]).name == "orbitquant-packed-matmul"
+    # A repository checkout resolves to native-kernels/orbitquant-packed-matmul,
+    # an installed wheel resolves to the bundled orbitquant/_kernel_src copy.
+    assert Path(status["bundled_sources"]).name in {"orbitquant-packed-matmul", "_kernel_src"}
 
 
 def test_bundled_source_root_prefers_repo_checkout():

--- a/tests/test_kernel_provision.py
+++ b/tests/test_kernel_provision.py
@@ -1,0 +1,255 @@
+import hashlib
+import importlib
+import io
+import json
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from orbitquant.kernels import provision
+
+
+@pytest.fixture(autouse=True)
+def _reset_provision_state(monkeypatch, tmp_path):
+    provision._reset_provision_memo_for_tests()
+    monkeypatch.setenv("ORBITQUANT_KERNELS_CACHE", str(tmp_path / "kernels-cache"))
+    monkeypatch.delenv("LOCAL_KERNELS", raising=False)
+    monkeypatch.delenv("ORBITQUANT_KERNELS_AUTOFETCH", raising=False)
+    monkeypatch.delenv("ORBITQUANT_KERNELS_AUTOBUILD", raising=False)
+    monkeypatch.delenv("ORBITQUANT_KERNELS_RELEASE_BASE", raising=False)
+    original_sys_path = list(sys.path)
+    yield
+    sys.path[:] = original_sys_path
+    provision._reset_provision_memo_for_tests()
+
+
+def _patch_runtime(
+    monkeypatch,
+    *,
+    torch_version="2.12.1",
+    cuda=None,
+    platform_name="linux",
+    machine="x86_64",
+):
+    monkeypatch.setattr(provision.torch, "__version__", torch_version)
+    monkeypatch.setattr(provision.torch.version, "cuda", cuda)
+    monkeypatch.setattr(provision.sys, "platform", platform_name)
+    monkeypatch.setattr(provision.platform, "machine", lambda: machine)
+
+
+def test_cuda_variant_name_linux(monkeypatch):
+    _patch_runtime(monkeypatch, torch_version="2.9.1", cuda="12.8")
+    assert provision.cuda_variant_name() == "torch29-cxx11-cu128-x86_64-linux"
+
+
+def test_cuda_variant_name_windows_has_no_cxx11_segment(monkeypatch):
+    _patch_runtime(
+        monkeypatch, torch_version="2.13.0", cuda="13.0", platform_name="win32", machine="AMD64"
+    )
+    assert provision.cuda_variant_name() == "torch213-cu130-x86_64-windows"
+
+
+def test_metal_variant_name(monkeypatch):
+    _patch_runtime(monkeypatch, torch_version="2.12.1", platform_name="darwin", machine="arm64")
+    assert provision.metal_variant_name() == "torch212-metal-aarch64-darwin"
+
+
+def test_cpu_variant_name_uses_stable_abi_prefix(monkeypatch):
+    _patch_runtime(monkeypatch, torch_version="2.12.1")
+    assert provision.cpu_variant_name() == "torch-stable-abi211-cpu-x86_64-linux"
+
+
+def test_cpu_variant_name_requires_stable_abi_torch(monkeypatch):
+    _patch_runtime(monkeypatch, torch_version="2.9.1")
+    assert provision.cpu_variant_name() is None
+
+
+def test_candidate_order_prefers_accelerator(monkeypatch):
+    _patch_runtime(monkeypatch, torch_version="2.12.1", cuda="12.6")
+    assert provision.candidate_variant_names() == (
+        "torch212-cxx11-cu126-x86_64-linux",
+        "torch-stable-abi211-cpu-x86_64-linux",
+    )
+
+
+def _make_variant_dir(root: Path, variant: str, *, marker=True) -> Path:
+    variant_dir = root / variant
+    package_dir = variant_dir / provision.KERNEL_PACKAGE_NAME
+    package_dir.mkdir(parents=True)
+    (package_dir / "__init__.py").write_text(
+        "PROVISION_TEST_SENTINEL = True\n", encoding="utf-8"
+    )
+    if marker:
+        (variant_dir / provision._PROVISION_MARKER).write_text("{}", encoding="utf-8")
+    return variant_dir
+
+
+def test_provision_uses_cached_variant(monkeypatch):
+    _patch_runtime(monkeypatch, torch_version="2.12.1")
+    cache_root = provision.kernels_cache_root() / f"v{provision.KERNEL_VERSION}" / "prebuilt"
+    variant = provision.cpu_variant_name()
+    variant_dir = _make_variant_dir(cache_root, variant)
+
+    report = provision.provision_native_kernel_package(allow_fetch=False, allow_build=False)
+
+    assert report.source == "cache"
+    assert report.variant == variant
+    assert report.sys_path_entry == str(variant_dir)
+    assert str(variant_dir) in sys.path
+
+
+def test_provision_ignores_cache_without_marker(monkeypatch):
+    _patch_runtime(monkeypatch, torch_version="2.12.1")
+    cache_root = provision.kernels_cache_root() / f"v{provision.KERNEL_VERSION}" / "prebuilt"
+    _make_variant_dir(cache_root, provision.cpu_variant_name(), marker=False)
+
+    report = provision.provision_native_kernel_package(allow_fetch=False, allow_build=False)
+
+    assert report.source == "unavailable"
+
+
+def test_provision_uses_local_kernels_env(monkeypatch, tmp_path):
+    _patch_runtime(monkeypatch, torch_version="2.12.1")
+    local_dir = _make_variant_dir(tmp_path, "torch212-cxx11-cu126-x86_64-linux", marker=False)
+    monkeypatch.setenv("LOCAL_KERNELS", f"{provision.KERNEL_REPO_ID}={local_dir}")
+
+    report = provision.provision_native_kernel_package(allow_fetch=False, allow_build=False)
+
+    assert report.source == "local-kernels"
+    assert report.sys_path_entry == str(local_dir)
+
+
+def test_provision_memoizes_negative_result(monkeypatch):
+    _patch_runtime(monkeypatch, torch_version="2.12.1")
+    calls = []
+
+    def counting_fetch(variant):
+        calls.append(variant)
+        return None, "offline"
+
+    monkeypatch.setattr(provision, "_fetch_prebuilt_variant", counting_fetch)
+    first = provision.provision_native_kernel_package(allow_build=False)
+    second = provision.provision_native_kernel_package(allow_build=False)
+
+    assert first.source == "unavailable"
+    assert second is first
+    assert len(calls) == 1
+
+
+def _wheel_bytes() -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as wheel:
+        wheel.writestr(
+            f"{provision.KERNEL_PACKAGE_NAME}/__init__.py",
+            "PROVISION_TEST_SENTINEL = True\n",
+        )
+        wheel.writestr("orbitquant_packed_matmul-1.0.dist-info/METADATA", "stub")
+    return buffer.getvalue()
+
+
+def _serve_release(monkeypatch, variant: str, wheel_payload: bytes, *, sha256=None):
+    filename = f"{variant}.whl"
+    manifest = {
+        "kernel_version": provision.KERNEL_VERSION,
+        "variants": {
+            variant: {
+                "filename": filename,
+                "sha256": sha256 or hashlib.sha256(wheel_payload).hexdigest(),
+            }
+        },
+    }
+
+    def fake_http_get(url, timeout):
+        if url.endswith(provision._MANIFEST_FILENAME):
+            return json.dumps(manifest).encode("utf-8")
+        if url.endswith(filename):
+            return wheel_payload
+        raise AssertionError(f"unexpected URL {url}")
+
+    monkeypatch.setattr(provision, "_http_get", fake_http_get)
+
+
+def test_provision_fetches_release_wheel(monkeypatch):
+    _patch_runtime(monkeypatch, torch_version="2.12.1")
+    variant = provision.cpu_variant_name()
+    _serve_release(monkeypatch, variant, _wheel_bytes())
+
+    report = provision.provision_native_kernel_package(allow_build=False)
+
+    assert report.source == "release"
+    assert report.variant == variant
+    variant_dir = Path(report.sys_path_entry)
+    assert (variant_dir / provision.KERNEL_PACKAGE_NAME / "__init__.py").is_file()
+    assert (variant_dir / provision._PROVISION_MARKER).is_file()
+
+    provision._reset_provision_memo_for_tests()
+    sys.path.remove(str(variant_dir))
+    importlib.invalidate_caches()
+    monkeypatch.setattr(
+        provision, "_http_get", lambda url, timeout: (_ for _ in ()).throw(OSError("offline"))
+    )
+    cached = provision.provision_native_kernel_package(allow_build=False)
+    assert cached.source == "cache"
+    assert cached.variant == variant
+
+
+def test_provision_rejects_checksum_mismatch(monkeypatch):
+    _patch_runtime(monkeypatch, torch_version="2.12.1")
+    variant = provision.cpu_variant_name()
+    _serve_release(monkeypatch, variant, _wheel_bytes(), sha256="0" * 64)
+
+    report = provision.provision_native_kernel_package(allow_build=False)
+
+    assert report.source == "unavailable"
+    assert "checksum mismatch" in report.detail
+    cache_dir = (
+        provision.kernels_cache_root() / f"v{provision.KERNEL_VERSION}" / "prebuilt" / variant
+    )
+    assert not cache_dir.exists()
+
+
+def test_provision_respects_autofetch_disable(monkeypatch):
+    _patch_runtime(monkeypatch, torch_version="2.12.1")
+    monkeypatch.setenv("ORBITQUANT_KERNELS_AUTOFETCH", "0")
+
+    def unexpected_fetch(variant):
+        raise AssertionError("fetch must not run when autofetch is disabled")
+
+    monkeypatch.setattr(provision, "_fetch_prebuilt_variant", unexpected_fetch)
+    report = provision.provision_native_kernel_package(allow_build=False)
+
+    assert report.source == "unavailable"
+    assert "AUTOFETCH=0" in report.detail
+
+
+def test_extract_wheel_rejects_traversal(tmp_path):
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as wheel:
+        wheel.writestr("../escape.py", "payload")
+    wheel_path = tmp_path / "bad.whl"
+    wheel_path.write_bytes(buffer.getvalue())
+
+    with pytest.raises(RuntimeError, match="unsafe wheel member"):
+        provision._extract_wheel(wheel_path, tmp_path / "out")
+
+
+def test_provision_status_reports_without_side_effects(monkeypatch):
+    _patch_runtime(monkeypatch, torch_version="2.12.1", cuda="12.8")
+    status = provision.provision_status()
+
+    assert status["kernel_version"] == provision.KERNEL_VERSION
+    assert status["candidate_variants"] == [
+        "torch212-cxx11-cu128-x86_64-linux",
+        "torch-stable-abi211-cpu-x86_64-linux",
+    ]
+    assert status["autofetch"] is True
+    assert status["autobuild"] is False
+    assert Path(status["bundled_sources"]).name == "orbitquant-packed-matmul"
+
+
+def test_bundled_source_root_prefers_repo_checkout():
+    root = provision._bundled_kernel_source_root()
+    assert root is not None
+    assert (root / "torch-ext" / "torch_binding.cpp").is_file()

--- a/tests/test_native_kernel_package.py
+++ b/tests/test_native_kernel_package.py
@@ -70,7 +70,8 @@ def test_wheel_project_preparation_keeps_windows_ninja_executable() -> None:
         encoding="utf-8"
     )
 
-    assert 'dependencies = ["torch>=2.11"]' in script
+    assert '"--torch-requirement"' in script
+    assert 'default="torch>=2.11"' in script
     assert 'ninja_executable_path = Path(ninja.BIN_DIR)' in script
     assert 'which("ninja")' not in script
     assert '"ninja.exe" if os.name == "nt" else "ninja"' in script
@@ -158,6 +159,80 @@ setup(
     )
     assert prepared_project["project"]["version"] == "0.4.0"
     assert prepared_project["project"]["dependencies"] == ["torch>=2.11"]
+
+
+def test_wheel_project_preparation_pins_custom_torch_requirement(tmp_path) -> None:
+    project = tmp_path / "kernel"
+    project.mkdir()
+    (project / "pyproject.toml").write_text(
+        '[project]\nversion = "0.1.0"\nrequires-python = ">=3.9"\n',
+        encoding="utf-8",
+    )
+    (project / "CMakeLists.txt").write_text(
+        "find_package(Python3 COMPONENTS Development Development.SABIModule Interpreter)\n"
+        "find_package(Python3 REQUIRED COMPONENTS Development "
+        "Development.SABIModule Interpreter)\n",
+        encoding="utf-8",
+    )
+    setup_template = (
+        "import os\n"
+        "from pathlib import Path\n"
+        "from shutil import which, move\n"
+        "\n"
+        "def is_sccache_available() -> bool:\n"
+        '    return which("sccache") is not None\n'
+        "\n"
+        "def is_ccache_available() -> bool:\n"
+        '    return which("ccache") is not None\n'
+        "\n"
+        "def make_args():\n"
+        "    cmake_args = []\n"
+        '    if "CMAKE_ARGS" in os.environ:\n'
+        '        cmake_args += [item for item in os.environ["CMAKE_ARGS"].split(" ") '
+        "if item]\n"
+        '    ninja_executable_path = Path(ninja.BIN_DIR) / "ninja"\n'
+        "    return cmake_args, ninja_executable_path\n"
+        "\n"
+        "class Build:\n"
+        "    def build_extension(self, ext):\n"
+        "        build_temp = Path(self.build_temp) / ext.name\n"
+        '        extdir = Path("output")\n'
+        '        cfg = "Release"\n'
+        "        build_args = []\n"
+        "        subprocess.run(\n"
+        '            ["cmake", "--build", str(build_temp), *build_args], '
+        "cwd=build_temp, check=True\n"
+        "        )\n"
+        '        if sys.platform == "win32":\n'
+        "            # Move the dylib one folder up for discovery.\n"
+        "            for filename in os.listdir(extdir / cfg):\n"
+        "                move(extdir / cfg / filename, extdir / filename)\n"
+        "        return build_temp\n"
+        "\n"
+        "setup(\n"
+        "    zip_safe=False,\n"
+        ")\n"
+    )
+    (project / "setup.py").write_text(setup_template, encoding="utf-8")
+
+    subprocess.run(
+        [
+            sys.executable,
+            KERNEL_ROOT / "scripts/prepare_wheel_project.py",
+            project,
+            "--version",
+            "1.0.0+cu128torch29",
+            "--torch-requirement",
+            "torch>=2.9,<2.10",
+        ],
+        check=True,
+    )
+
+    prepared_project = tomllib.loads(
+        (project / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    assert prepared_project["project"]["version"] == "1.0.0+cu128torch29"
+    assert prepared_project["project"]["dependencies"] == ["torch>=2.9,<2.10"]
     prepared_cmake = (project / "CMakeLists.txt").read_text(encoding="utf-8")
     assert "COMPONENTS Development.SABIModule Interpreter" in prepared_cmake
     assert "COMPONENTS Development Development.SABIModule" not in prepared_cmake

--- a/tests/test_native_packed_matmul.py
+++ b/tests/test_native_packed_matmul.py
@@ -173,86 +173,75 @@ def test_native_packed_matmul_loader_accepts_kernel_builder_variant_layout(
             sys.modules["orbitquant_packed_matmul_variant_test"] = previous_variant
 
 
-def test_native_packed_matmul_loader_uses_versioned_hf_kernel_when_import_missing(
-    monkeypatch,
-):
-    calls = []
+def test_native_packed_matmul_loader_provisions_when_import_missing(monkeypatch):
     fake_kernel = SimpleNamespace(matmul_packed_weight=lambda *args, **kwargs: None)
     real_import = builtins.__import__
+    provisioned = []
 
-    def fake_get_kernel(repo_id, *, version, trust_remote_code):
-        calls.append((repo_id, version, trust_remote_code))
-        return fake_kernel
+    def fake_import(name, *args, **kwargs):
+        if name == "orbitquant_packed_matmul" and not provisioned:
+            raise ImportError("missing importable native package")
+        return real_import(name, *args, **kwargs)
+
+    def fake_provision():
+        provisioned.append(True)
+        monkeypatch.setitem(sys.modules, "orbitquant_packed_matmul", fake_kernel)
+        return SimpleNamespace(sys_path_entry="/tmp/orbitquant-variant", detail="test")
+
+    monkeypatch.setattr(native_module, "_NATIVE_KERNEL", None)
+    monkeypatch.delitem(sys.modules, "orbitquant_packed_matmul", raising=False)
+    monkeypatch.setattr(
+        native_module.provision, "provision_native_kernel_package", fake_provision
+    )
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    assert native_module._load_native_packed_matmul_kernel() is fake_kernel
+    assert provisioned == [True]
+
+
+def test_native_packed_matmul_loader_uses_importable_package_without_provisioning(
+    monkeypatch,
+):
+    fake_kernel = SimpleNamespace(matmul_packed_weight=lambda *args, **kwargs: None)
+
+    def fail_provision(*args, **kwargs):
+        raise AssertionError("provisioning must not run when the package is importable")
+
+    monkeypatch.setattr(native_module, "_NATIVE_KERNEL", None)
+    monkeypatch.setitem(sys.modules, "orbitquant_packed_matmul", fake_kernel)
+    monkeypatch.setattr(
+        native_module.provision, "provision_native_kernel_package", fail_provision
+    )
+
+    assert native_module._load_native_packed_matmul_kernel() is fake_kernel
+
+
+def test_native_packed_matmul_loader_reports_provisioning_failure(monkeypatch):
+    real_import = builtins.__import__
 
     def fake_import(name, *args, **kwargs):
         if name == "orbitquant_packed_matmul":
             raise ImportError("missing importable native package")
         return real_import(name, *args, **kwargs)
 
-    monkeypatch.setattr(native_module, "_NATIVE_KERNEL", None)
-    monkeypatch.delitem(sys.modules, "orbitquant_packed_matmul", raising=False)
-    monkeypatch.setitem(sys.modules, "kernels", SimpleNamespace(get_kernel=fake_get_kernel))
-    monkeypatch.setattr(builtins, "__import__", fake_import)
-
-    assert native_module._load_native_packed_matmul_kernel() is fake_kernel
-    assert calls == [("WaveCut/orbitquant-packed-matmul", 1, True)]
-
-
-def test_native_packed_matmul_loader_falls_back_to_importable_package_without_hf_kernels(
-    monkeypatch,
-):
-    fake_kernel = SimpleNamespace(matmul_packed_weight=lambda *args, **kwargs: None)
-
-    real_import = builtins.__import__
-
-    def fake_import(name, *args, **kwargs):
-        if name == "kernels":
-            raise ImportError("missing Hugging Face kernels package")
-        return real_import(name, *args, **kwargs)
-
-    monkeypatch.setattr(native_module, "_NATIVE_KERNEL", None)
-    monkeypatch.setitem(sys.modules, "orbitquant_packed_matmul", fake_kernel)
-    monkeypatch.delitem(sys.modules, "kernels", raising=False)
-    monkeypatch.setattr(builtins, "__import__", fake_import)
-
-    assert native_module._load_native_packed_matmul_kernel() is fake_kernel
-
-
-def test_native_packed_matmul_loader_does_not_probe_hf_when_importable_package_exists(
-    monkeypatch,
-):
-    fake_kernel = SimpleNamespace(matmul_packed_weight=lambda *args, **kwargs: None)
-
-    def fail_get_kernel(*args, **kwargs):
-        raise AssertionError("Hub kernel should not be probed")
-
-    monkeypatch.setattr(native_module, "_NATIVE_KERNEL", None)
-    monkeypatch.setitem(sys.modules, "orbitquant_packed_matmul", fake_kernel)
-    monkeypatch.setitem(sys.modules, "kernels", SimpleNamespace(get_kernel=fail_get_kernel))
-
-    assert native_module._load_native_packed_matmul_kernel() is fake_kernel
-
-
-def test_native_packed_matmul_loader_reports_missing_optional_dependency(monkeypatch):
-    real_import = builtins.__import__
-
-    def fake_import(name, *args, **kwargs):
-        if name in {"orbitquant_packed_matmul", "kernels"}:
-            raise ImportError("missing kernels package")
-        return real_import(name, *args, **kwargs)
+    def unavailable_provision():
+        return SimpleNamespace(sys_path_entry=None, detail="offline for the test")
 
     monkeypatch.setattr(native_module, "_NATIVE_KERNEL", None)
     monkeypatch.delitem(sys.modules, "orbitquant_packed_matmul", raising=False)
-    monkeypatch.delitem(sys.modules, "kernels", raising=False)
+    monkeypatch.setattr(
+        native_module.provision, "provision_native_kernel_package", unavailable_provision
+    )
     monkeypatch.setattr(builtins, "__import__", fake_import)
 
     with pytest.raises(RuntimeError, match="orbitquant_packed_matmul") as exc_info:
         native_module._load_native_packed_matmul_kernel()
 
     message = str(exc_info.value)
+    assert "pip install orbitquant-packed-matmul" in message
+    assert "kernels-install" in message
     assert "built kernel variant directory" in message
-    assert "metadata.json" in message
-    assert "PYTHONPATH" in message
+    assert "offline for the test" in message
     assert "Current runtime is torch" in message
     assert "The built kernel variant must match this runtime." in message
     if torch.version.cuda is not None and sys.platform == "linux":

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -10,9 +10,9 @@ def test_kernels_extra_keeps_triton_linux_only_for_mps_installs():
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
     kernels_extra = pyproject["project"]["optional-dependencies"]["kernels"]
 
-    assert "kernels>=0.16" in kernels_extra
     assert "triton>=3.5; platform_system == 'Linux'" in kernels_extra
     assert "triton>=3.5" not in kernels_extra
+    assert not any(item.startswith("kernels") for item in kernels_extra)
 
 
 def test_core_import_does_not_require_pillow():

--- a/uv.lock
+++ b/uv.lock
@@ -35,15 +35,6 @@ wheels = [
 ]
 
 [[package]]
-name = "annotated-types"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
-]
-
-[[package]]
 name = "anyio"
 version = "4.14.1"
 source = { registry = "https://pypi.org/simple" }
@@ -63,104 +54,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
-]
-
-[[package]]
-name = "cffi"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/67/85c89a59ba36a671e79638f44d466749f08179266a57e4f2ffdf92174072/cffi-2.1.0-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:02cb7ff33ded4f1532476731f89ede53e2e488a8e6205515a82144246ffa7dcc", size = 183845, upload-time = "2026-07-06T21:32:26.32Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/dd/e3b0baa2d3d6a857ac72b7efbf18e32e487c9cdafcc13049ad765495b15e/cffi-2.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f5bce581e6b8c235e566a14768a943b172ada3ed73537bb0c0be1edee312d4e7", size = 184186, upload-time = "2026-07-06T21:32:28.025Z" },
-    { url = "https://files.pythonhosted.org/packages/65/68/9f3ef890cf3c6ab97bd531c5677f67613d302165d16f8142b2811782a614/cffi-2.1.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:30b65779d598c370374fefabf138d456fd6f3216bfa7bedfab1ba82025b0cd93", size = 211892, upload-time = "2026-07-06T21:32:29.565Z" },
-    { url = "https://files.pythonhosted.org/packages/22/d7/1a74539db16d8bfd839ff1515948948efbb162e574650fd3d846896eea95/cffi-2.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88023dfe18799507b73f1dbb0d14326a17465de1bc9c9c7655c22845e9ddc3a2", size = 218793, upload-time = "2026-07-06T21:32:30.951Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/d1/9a5b7169499e8e8d8e636de70b97ac7c9447104d2ff1a2cd94790cea5162/cffi-2.1.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:0a96b74cda968eebbad56d973efe5098974f0a9fb323865bf99ea1fd24e3e64c", size = 205737, upload-time = "2026-07-06T21:32:32.216Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/b0/e131a9c41f10607926278453d9596163594fe1c4ebc46efe3b5e5b34eb84/cffi-2.1.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a5781494d4d400a3f47f8f1da94b324f6e6b440a53387774002890a2a2f4b50f", size = 204909, upload-time = "2026-07-06T21:32:33.655Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/d2/4398416cd699b35167947c6e22aca52c47e69ad5695073c9f1f2c52e04aa/cffi-2.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aa7a1b53a2a4452ada2d1b5dade9960b2522f1e61293a811a077439e39029565", size = 217883, upload-time = "2026-07-06T21:32:35.173Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/a5/d4fe77b589e5e82d43ebc809bf2e6474afe8e48e32ea050b9357645b6471/cffi-2.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9d8272c0e483b024e1b9ad029821470ed8ec65631dbd90217469da0e7cd89f1c", size = 221251, upload-time = "2026-07-06T21:32:36.527Z" },
-    { url = "https://files.pythonhosted.org/packages/22/f0/a2fc43084c0433caf7f461bccc013e28f848d04ee1c5ed7fce71423cf4d9/cffi-2.1.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7762faa47e8ff7eb80bd261d9a7d8eea2d8baa69de5e95b70c1f338bbe712f02", size = 214250, upload-time = "2026-07-06T21:32:37.852Z" },
-    { url = "https://files.pythonhosted.org/packages/04/8c/b925975448cf20634a9fbd5efceb807219db452653648d2897c0989cab2d/cffi-2.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:89095c1968b4ba8285840e131bf2891b09ae137fe2146905acae0354fbce1b5e", size = 219441, upload-time = "2026-07-06T21:32:39.146Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/da/5c4918a2d61d86fa927d716cb3d8e4626ef8dc8f605a599d32f33897f59a/cffi-2.1.0-cp311-cp311-win32.whl", hash = "sha256:64c753a0f87a256020004f37a1c8c02c480e725f910f0b2a0f3f07debd1b2479", size = 174496, upload-time = "2026-07-06T21:32:40.467Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/c8/6c2de1d55cf35ef8b92885d5ef280790f0fb9634d87ea1cc315176aecd61/cffi-2.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:4f26194e3d95e06501b942642855aed4f953d55e95d7d01b7c4483db3ecff458", size = 185113, upload-time = "2026-07-06T21:32:41.761Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/4e/e8d7cb5783f1841a3c8fb3a7735838d7484d08ec08c9f984b14cac1ac0e9/cffi-2.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:35aaea0c7ee0e58a5cd8c2fd1a48fdf7ece0d2699b7ecdda08194e9ce5dd9b3d", size = 179927, upload-time = "2026-07-06T21:32:42.961Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/85/990925db5df586ec90beb97529c853497e7f85ba0234830447faf41c3057/cffi-2.1.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:df2b82571a1b30f58a87bf4e5a9e78d2b1eff6c6ce8fd3aa3757221f93f0863f", size = 184829, upload-time = "2026-07-06T21:32:44.324Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/92/e7bb136ad6b5352603732cf907ef862ca103f20f2031c1735a46300c20c9/cffi-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:78474632761faa0fb96f30b1c928c84ebcf68713cbb80d15bab09dfe61640fde", size = 184728, upload-time = "2026-07-06T21:32:45.683Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/c0/d1ec30ffb370f748f2fb54425972bfef9871e0132e82fb589c46b6676049/cffi-2.1.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:5972433ad71a9e46516584ef60a0fda12d9dc459938d1539c3ddecf9bdc1368d", size = 214815, upload-time = "2026-07-06T21:32:48.557Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/dc/5620cf930688be01f2d673804291de757a934c90b946dbdc3d84130c2ea4/cffi-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b6422532152adf4e59b110cb2808cee7a033800952f5c036b4af047ee43199e7", size = 222429, upload-time = "2026-07-06T21:32:49.848Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/a4/77b53abbf7a1e0beb9637edbef2a94d15f9c822f591e85d439ffd91519a6/cffi-2.1.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:46b1c8db8f6122420f32d02fffb924c2fe9bc772d228c7c711748fff56aabb2b", size = 210315, upload-time = "2026-07-06T21:32:51.221Z" },
-    { url = "https://files.pythonhosted.org/packages/58/0c/f528df19cc94b675087324d4760d9e6d5bfae97d6217aa4fac43de4f5fcc/cffi-2.1.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9fafc5aa2e2a39aaf7f8cc0c1f044a9b07fca12e558dca53a3cc5c654ad67a7", size = 208859, upload-time = "2026-07-06T21:32:52.512Z" },
-    { url = "https://files.pythonhosted.org/packages/62/f2/c9522a81c32132799a1972c39f5c5f8b4c8b9f00488a23feaa6c06f07741/cffi-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1e9f50d192a3e525b15a75ab5114e442d83d657b7ec29182a991bc9a88fd3a66", size = 221844, upload-time = "2026-07-06T21:32:53.704Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/28/bd53988b9833e8f8ad539d26f4c07a6b3f6bcb1e9e02e7ca038250b3428d/cffi-2.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:98fff996e983a36d3aa2eca83af40c5821202e7e6f32d13ae94e3d2286f10cfe", size = 225287, upload-time = "2026-07-06T21:32:54.907Z" },
-    { url = "https://files.pythonhosted.org/packages/79/99/0d0fd37f055224085f42bbb2c022d002e17dde4a97972822327b07d84101/cffi-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:379de10ce1ba048b1448599d1b37b24caee16309d1ac98d3982fc997f768700b", size = 223681, upload-time = "2026-07-06T21:32:56.329Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/80/c138990aa2a70b1a269f6e06348729836d733d6f970867943f61d367f8cc/cffi-2.1.0-cp312-cp312-win32.whl", hash = "sha256:9b8f0f26ca4e7513c534d351eca551947d053fac438f2a04ac96d882909b0d3a", size = 175269, upload-time = "2026-07-06T21:32:57.777Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/eb/f636456ff21a83fc13c032b58cc5dde061691546ac79efa284b2989b7982/cffi-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:c97f080ea627e2863524c5af3836e2270b5f5dfff1f104392b959f8df0c5d384", size = 185881, upload-time = "2026-07-06T21:32:59.253Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/2c/400ea43e721727dca8a65c4521390e9196757caba4a45643acb2b63271b8/cffi-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:6d194185eabd279f1c05ebe3504265ddfc5ad2b58d0714f7db9f01da592e9eb6", size = 180088, upload-time = "2026-07-06T21:33:02.278Z" },
-    { url = "https://files.pythonhosted.org/packages/96/88/a996879e2eeccb815f6e3a5967b12a308257412acec882039d386bd2aa7b/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:10537b1df4967ca26d21e5072d7d54188354483b91dc75058968d3f0cf13fbda", size = 194331, upload-time = "2026-07-06T21:33:03.697Z" },
-    { url = "https://files.pythonhosted.org/packages/58/85/7ae00d5c8dd6266f4e944c3db630f3c5c9a98b61d469c714d848b1d8138a/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a95b05f9baf29b91171b3a8bd2020b028835243e7b0ff6bb23e2a3c228518b1b", size = 196966, upload-time = "2026-07-06T21:33:05.353Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/e9/45c3a76ad8d43ad9261f4c95436da61128d3ca545d72b9612c0ab5be0b1c/cffi-2.1.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:15faec4adfff450819f3aee0e2e02c812de6edb88203aa58807955db2003472a", size = 184795, upload-time = "2026-07-06T21:33:06.699Z" },
-    { url = "https://files.pythonhosted.org/packages/84/4c/82f132cb4418ee6d953d982b19191e87e2a6372c8a4ce36e50b69d6ade4a/cffi-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:716ff8ec22f20b4d988b12884086bcef0fc99737043e503f7a3935a6be99b1ea", size = 184746, upload-time = "2026-07-06T21:33:08.071Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/1c/4ed5a0e5bdca6cbc275556de3328dd1b76fd0c11cc13c88fe66d1d8715f2/cffi-2.1.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:63960549e4f8dc41e31accb97b975abaecfc44c03e396c093a6436763c2ea7db", size = 214747, upload-time = "2026-07-06T21:33:09.671Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/a6/e879bb68cc23a2bc9ba8f4b7d8019f0c2694bad2ab6c4a3701d429439f58/cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f", size = 222392, upload-time = "2026-07-06T21:33:10.896Z" },
-    { url = "https://files.pythonhosted.org/packages/88/f6/01890cfd63c08f8eb96a8319b0443690197d240a8bd6346048cf7bde9190/cffi-2.1.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3b926723c13eba9f81d2ef3820d63aeceec3b2d4639906047bf675cb8a7a500d", size = 210285, upload-time = "2026-07-06T21:33:12.251Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/cf/2b684132056f438567b61e19d690dd31cd0921ace051e0a458be6074369e/cffi-2.1.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:47ff3a8bfd8cb9da1af7524b965127095055654c177fcfc7578debcb015eecd0", size = 208801, upload-time = "2026-07-06T21:33:13.617Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/08/f2e7d62c460faae0926f2d6e423694aa409ced3bc1fe2927a0a6e5f05416/cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224", size = 221808, upload-time = "2026-07-06T21:33:15.466Z" },
-    { url = "https://files.pythonhosted.org/packages/38/37/04f54b8e63a02f3d908332c9effbf8c366167c6f733ed8a3d4f79b7e2a1e/cffi-2.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:961be50688f7fba2fa65f63712d3b9b341a22311f5253460ce933f52f0de1c8c", size = 225241, upload-time = "2026-07-06T21:33:16.869Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/d6/c72eecca433cd3e681c65ed313ab4835d9d4a379704d0f628a6a05f51c2e/cffi-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bf5c6cf48238b0eb4c086978c492ad1cbc22373fc5b2d7353b3a598ce6db887a", size = 223588, upload-time = "2026-07-06T21:33:18.239Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/4b/e706f67279140f92939da3475ad610df18bfd52d50f14953a8e5fede71d5/cffi-2.1.0-cp313-cp313-win32.whl", hash = "sha256:db3eb7d46527159a878ec3460e9d40615bc25ba337d477db681aea6e4f05c5d2", size = 175248, upload-time = "2026-07-06T21:33:19.799Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/47/59eb7975cb0e4ef0afa764ea945b29a5bb4537a9f771cb7d6c8a5dd74c95/cffi-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:8e74a6135550c4748af665b1b1118b6aab33b1fc6a16f9aff630af107c3b4512", size = 185717, upload-time = "2026-07-06T21:33:21.47Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/af/34fee85c48f8d94efc8597bc09470c9dd274c145f1c12e0fbc6ab6d38d74/cffi-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:2282cd5e38aa8accd03e99d1256af8411c84cdbee6a89d841b563fdbd1f3e50f", size = 180114, upload-time = "2026-07-06T21:33:22.515Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/f0/81478e482afa03f6d18dc8f2afb5edc45b3080853b634b5ed91961be0998/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d2117334c3af3bdcb9a88522b844a2bdb5efdc4f71c6c822df55486ae1c3347a", size = 194142, upload-time = "2026-07-06T21:33:23.657Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/95/8de304305cd9204974b0ca051b86d307cafca13aa575a0ef1b44d92c0d8c/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:702c436735fbe99d59ada02a1f65cfc0d31c0ee8b7290912f8fbc5cd1e4b16c3", size = 196819, upload-time = "2026-07-06T21:33:25.007Z" },
-    { url = "https://files.pythonhosted.org/packages/20/71/7c8372d30e42415602ed9f268f7cfd66f1b855fed881ecd168bcb45dbc0b/cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1ff3456eab0d889592d1936d6125bbfbc7ae4d3354a700f8bd80450a66445d4d", size = 184965, upload-time = "2026-07-06T21:33:26.605Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/5c/584e626835f0375c928176c04137c96927165cb8733cdb3150ec04e5ee5e/cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c4165821e131d6d4ca444347c2b694e2311bcfa3fe5a861cc72968f28867beac", size = 184952, upload-time = "2026-07-06T21:33:27.823Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/d2/065fcae1c73979fac8e054462478d0ff8a29c40cdc2ed7ea5676a061df53/cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:276f20fffd7b396e12516ba8edf9509210ac248cbbc5acbc39cd512f9f59ebe6", size = 222353, upload-time = "2026-07-06T21:33:29.178Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/a5/e8bbb1ce5b3ac2f53ad6a10bde44318a5a8d99d4f4a000d44a6e39aeb3e4/cffi-2.1.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7d5980a3433d4b71a5e120f9dd551403d7824e31e2e67124fe2769c404c06913", size = 210051, upload-time = "2026-07-06T21:33:30.534Z" },
-    { url = "https://files.pythonhosted.org/packages/28/ed/c127d3ac36e899c965e3361357c3befacd6578c03f40125183e41c3b219e/cffi-2.1.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6ca4919c6e4f89aa99c42510b42cf54596892c00b3f9077f6bdd1505e24b9c8d", size = 208630, upload-time = "2026-07-06T21:33:31.753Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/d7/97d3136f81db489ec8d1d67748c110d6c994268fd7528014aa9f2b085e4e/cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d53d10f7da99ae46f7373b9150393e9c5eab9b224909982b43832668de4779f5", size = 221593, upload-time = "2026-07-06T21:33:33.044Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/27/93195977168ee63aed233a1a0993a2178798654d1f4bddcdd321d6fd3b21/cffi-2.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c351efb95e832a853a29361675f33a7ce53de1a109cd73fd47af0712213aa4ce", size = 225146, upload-time = "2026-07-06T21:33:34.224Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/c1/6dbd291ee2ae5a50a034aa057207081f545923bbf15dad4511e985aafff5/cffi-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7c7a88e2bac086f06d14577332760bdeecc42bdec8ac4077f6260557d9326", size = 223240, upload-time = "2026-07-06T21:33:35.57Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/6f/ade5ce9863a57992a6ea3d0d10d7e29b8749fc127204b3d493d667b2815f/cffi-2.1.0-cp314-cp314-win32.whl", hash = "sha256:1854b724d00f6654c742097d5387569021be12d3a0f770eae1df8f8acfcc6acd", size = 177723, upload-time = "2026-07-06T21:33:51.626Z" },
-    { url = "https://files.pythonhosted.org/packages/41/de/92b9eeed4ae4a21d6fd9b2a2c8505cbed573299902ea73981cc13f7ff62c/cffi-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:1b96bfe2c4bd825681b7d311ad6d9b7280a091f43e8f63da5729638083cd3bfb", size = 187937, upload-time = "2026-07-06T21:33:53.403Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/1a/cc6ae6c2913a03aab8898eee57963cf1035b8df5872ed8b9115fcc7e2be8/cffi-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:7d28dff1db6764108bc30788d85d61c876beff416d9a49cb9dd7c5a9f34f5804", size = 183001, upload-time = "2026-07-06T21:33:54.74Z" },
-    { url = "https://files.pythonhosted.org/packages/14/f0/134c00ce0779ec86dea2aa1aac69339c2741a8045072676763512363a2ea/cffi-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7ea6b3e2c4250ff1de21c630fe72d0f63eb95c2c32ffbf64a358cf4a8836d714", size = 188538, upload-time = "2026-07-06T21:33:36.792Z" },
-    { url = "https://files.pythonhosted.org/packages/50/d8/3b86aba791cb610d24e8a3e1b2cd529e71fa15096b04e4d4e360049d4a4c/cffi-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6af371f3767faeffc6ac1ef57cdfd25844403e9d3f476c5537caee499de96376", size = 188230, upload-time = "2026-07-06T21:33:38.011Z" },
-    { url = "https://files.pythonhosted.org/packages/14/d0/117dcd9209255ad8571fbc8c92ef32593a1d294dcec91ddc4e4db50606f2/cffi-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb4e8997a49aa2c08a3e43c9045d224448b8941d88e7ac163c7d383e560cbf98", size = 223899, upload-time = "2026-07-06T21:33:39.514Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/3d/f20f8b886b254e3ad10e15cd4186d3aed49f3e6a35ab37aab9f8f25f7c03/cffi-2.1.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf01d8c84cbea96b944c73b22182e6c7c432b3475632b8111dbfdc95ddad6e13", size = 211652, upload-time = "2026-07-06T21:33:40.851Z" },
-    { url = "https://files.pythonhosted.org/packages/28/3b/fad54de07260b93ddeef4b96d0131d57ea900675df1d410ae1deee52d7a6/cffi-2.1.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:33eb1ad83ebe8f313e0df035c406227d55a79456704a863fad9842136af5ad7d", size = 210755, upload-time = "2026-07-06T21:33:42.183Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/82/3d5c705acb7abbba9bbd7d79b8e62e0f25b6120eb7ae6ac49f1b721722fe/cffi-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac0f1a2d0cfa7eea3f2aaf006ab6e70e8feeb16b75d65b7e5939982ca2f11056", size = 223933, upload-time = "2026-07-06T21:33:43.603Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/d0/47e338384ab6b1004241002fa616301020cea4fc95f283506565d252f276/cffi-2.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c16914df9fb7f500e440e6875fa23ff5e0b31db01fa9c06af98d59a91f0dc2e4", size = 226749, upload-time = "2026-07-06T21:33:45.046Z" },
-    { url = "https://files.pythonhosted.org/packages/70/25/65bd5b58ea4bfdfc15cde02cb5365f89ef8ab8b2adfb8fe5c4bd4233382f/cffi-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5ecbd0499275d57506d397eebe1981cee87b47fcd9ef5c22cab7ed7644a39a94", size = 225703, upload-time = "2026-07-06T21:33:46.374Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/78/aa01ac599a8a4322533d45a1f9bc93b338276d2d59dabbe7c6d92a775c81/cffi-2.1.0-cp314-cp314t-win32.whl", hash = "sha256:7d034dcffa09e9a46c93fa3a3be402096cb5354ac6e41ab8e5cc9cd8b642ad76", size = 182857, upload-time = "2026-07-06T21:33:47.696Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/26/d00496b22de4d4228f32dde94ad996f350c8aad676d63bcca0743c8dea4d/cffi-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0582a58f3051372229ca8e7f5f589f9e5632678208d8636fea3676711fdf7fe5", size = 194065, upload-time = "2026-07-06T21:33:48.953Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/dd/0c7dbf815a579ff005008a2d815a55d6bb047c349eef536d9dc53d3f0a8d/cffi-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:510aeeeac94811b138077451da1fb18b308a5feab47dd2b603af55804155e1c8", size = 186404, upload-time = "2026-07-06T21:33:50.309Z" },
-    { url = "https://files.pythonhosted.org/packages/55/c7/8c8c50cb11c6750051daf12164098a9a6f027ac4356967fd4d800a07f242/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:2e9dabb9abcb7ad15938c7196ad5c1718a4e6d33cc79b4c0209bdb64c4a54a5c", size = 194121, upload-time = "2026-07-06T21:33:56.109Z" },
-    { url = "https://files.pythonhosted.org/packages/99/e2/67680bf19a6b60d2bb7ff83baefa2a4c3d2d7dc0f3277034b802e1fc504c/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:37f525a7e7e50c017fdebe58b787be310ad59357ae43a053943a6e1a6c526001", size = 196820, upload-time = "2026-07-06T21:33:57.288Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/da/4bbe583a3b3a5c8c60892124fe17f3fa3656523faf0d3484eae90f091853/cffi-2.1.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:95f2954c2c9473d892eca6e0409f3568b37ab62a8eedb122461f73cc273476e3", size = 184936, upload-time = "2026-07-06T21:33:58.765Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/4b/1f4c36ab273980d7aa75bb126ea4f8971f24a96108acad3a0a084028c57b/cffi-2.1.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:cdf2448aab5f661c9315308ec8b93f4e8a1a67a3c733f8631067a2b67d5913dc", size = 185045, upload-time = "2026-07-06T21:34:00.085Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/c3/ad299dc38f3583f8d916b299f028af418a9ec98bc695fcbebeae7420691c/cffi-2.1.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:90bec57cf82089383bd06a605b3eb8daebf7e5a668520beaf6e327a83a947699", size = 222342, upload-time = "2026-07-06T21:34:01.814Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/d8/df4543cc087245044ed02ef3ad8e0a26619d0075ac7a77a12dc81177851b/cffi-2.1.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6274dcb2d15cef48daa73ed1be5a40d501d74dccd0cd6db364776d12cb6ba022", size = 210073, upload-time = "2026-07-06T21:34:03.255Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/0e/fac738d73728c6cea2a88a2883dca54892496cbba88a1dc1f2909cb8a6f5/cffi-2.1.0-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b71d409cccee78310ab5dec549aed052aaea483346e282c7b02362596e01bb0", size = 208551, upload-time = "2026-07-06T21:34:04.433Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/3f/0b04a700dd64f465c93020253a793a82c9b4dff9961f48facd0df945d9b8/cffi-2.1.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7d3538f9c0e50670f4deb93dbb696576e60590369cae2faf7de681e597a8a1f1", size = 221649, upload-time = "2026-07-06T21:34:06.157Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/7c/b7379a5704c79eda57ce075869ba70a0368d1c850f803b3c0d078d39dcaf/cffi-2.1.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8f9ec95b8a043d3dfbc74d9abc6f7baf524dd27a8dc160b0a32ff9cdab650c28", size = 225203, upload-time = "2026-07-06T21:34:07.489Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/02/d5e6c43ea85c41bda2a184a3418f195fe7cf602967a8d2b94e085b83deef/cffi-2.1.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:af5e2915d41fe6c961694d7bfdc8562942638200f3ce2765dfb8b745cf997629", size = 223263, upload-time = "2026-07-06T21:34:08.712Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/d8/772b8259bf75749adffb1c546828978381fb516f60cf701f6c83daf60c85/cffi-2.1.0-cp315-cp315-win32.whl", hash = "sha256:0a42c688d19fca6e095a53c6a6e2295a5b050a8b289f109adab02a9e61a25de6", size = 177696, upload-time = "2026-07-06T21:34:26.355Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/dd/afa2191fc6d57fedd26e5844a2fe2fcc0bbfa00961bbaa5a41e4921e7cca/cffi-2.1.0-cp315-cp315-win_amd64.whl", hash = "sha256:bccbbb5ee76a61f9d99b5bf3846a51d7fca4b6a732fe46f89295610edaf41853", size = 187914, upload-time = "2026-07-06T21:34:27.58Z" },
-    { url = "https://files.pythonhosted.org/packages/05/ef/6cd4f8c671517162379dc79cfae5aea9106bc38abb89628d5c16adf6a838/cffi-2.1.0-cp315-cp315-win_arm64.whl", hash = "sha256:8d35c139744adb3e727cd51b1a18324bbe44b8bd41bf8322bca4d41289f48eda", size = 183004, upload-time = "2026-07-06T21:34:28.905Z" },
-    { url = "https://files.pythonhosted.org/packages/11/b6/12fc55092817a5faa26fb8c40c7f9d662e11a46ee248c137aafc42517d92/cffi-2.1.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:f9912624a0c0b834b7520d7769b3644453aabc0a7e1c839da7359f050750e9bc", size = 188378, upload-time = "2026-07-06T21:34:09.926Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/2e/cdac88979f295fde5daa69622c7d2111e56e7ceb94f211357fbe452339e4/cffi-2.1.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:df92f2aba50eb4d96718b68ef76f2e57a57b54f2fa62333496d16c6d585a85ca", size = 188319, upload-time = "2026-07-06T21:34:11.101Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/27/1d0b408497e41a74795af122d7b603c418c5fed0171450f899afd04e594f/cffi-2.1.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0520e1f4c35f44e209cbbb421b67eec42e6a157f59444dfb6058874ff3610e5d", size = 223904, upload-time = "2026-07-06T21:34:12.606Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/31/e115c985105dd7ffb32444505f18ceb874bb42d992af05d5dced7ecf1980/cffi-2.1.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3681e031db29958a7502f5c0c9d6bbc4c36cb20f7b104086fa642d1799631ff8", size = 211554, upload-time = "2026-07-06T21:34:13.987Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/67/9e6e09409336d9e515c58367e7cfcf4f89df06ad25252675595a58eb59d5/cffi-2.1.0-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:762f99479dcb369f60ab9017ad4ab97a36a1dd7c1ee5a3b15db0f4b8659120cd", size = 210795, upload-time = "2026-07-06T21:34:15.972Z" },
-    { url = "https://files.pythonhosted.org/packages/19/e5/d3cc82a4a0be7902af279c04181ad038449c096734464a5ae1de3e1401bd/cffi-2.1.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0611e7ebf90573a535ebdc33ae9da222d037853983e13359f580fab781ca017f", size = 223843, upload-time = "2026-07-06T21:34:17.509Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/65/b434abc97ce7cecc2c640fde160507c0ecc7e21544b483ba3325d2e2ea17/cffi-2.1.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:86cf8755a791f72c85dc287128cc62d4f24d392e3f1e15837245623f4a33cccc", size = 226773, upload-time = "2026-07-06T21:34:19.05Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/9f/d4dc66ca651eb1145a133314cda721abf13cfac3d28c4a0402263ae6ad75/cffi-2.1.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:ba00f661f8ba35d075c937174e27c2c421cec3942fd2e0ea3e66996757c0fdd9", size = 225719, upload-time = "2026-07-06T21:34:20.576Z" },
-    { url = "https://files.pythonhosted.org/packages/68/5a/e536c528bc8057496c360c0978559a2dc45653f89dd6151078aa7d8fca1a/cffi-2.1.0-cp315-cp315t-win32.whl", hash = "sha256:cb96698e3c7413d906ce83f8ffd245ec1bd94707541f299d0ce4d6b0193e982b", size = 182760, upload-time = "2026-07-06T21:34:22.059Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/0b/0ffe8b82d3875bced5fa1e7986a7a46b748262a40ab7f60b475eb9fb1bb3/cffi-2.1.0-cp315-cp315t-win_amd64.whl", hash = "sha256:f146d154428a2523f9cc7936c02353c2459b8f6cf07d3cd1ee1c0a611109c5d5", size = 193769, upload-time = "2026-07-06T21:34:23.589Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/17/1073b53b68c9b5ca6914adf5f8bf55aacc2d3be102418c90700160ea8605/cffi-2.1.0-cp315-cp315t-win_arm64.whl", hash = "sha256:cbb7640ce37159548d2147b5b8c241f962143d4c71231431820783f4dc78f210", size = 186405, upload-time = "2026-07-06T21:34:24.857Z" },
 ]
 
 [[package]]
@@ -274,62 +167,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cryptography"
-version = "49.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
-    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
-    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
-    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
-    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
-    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
-    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
-    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
-    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
-    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
-    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
-    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
-    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
-    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
-    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
-    { url = "https://files.pythonhosted.org/packages/63/d3/4a83af35d65e3fad632c926fad684c193ea4398569ccb0bbbc7fe8f5dc9a/cryptography-49.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc1e275c2f1d97b1a6450b8b0ea3ebfa6e087a611c2b26cb2404d48588abab7b", size = 3993685, upload-time = "2026-06-12T20:02:14.883Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/a7/f9dac0ab7f80368c56993a7bf638ef9935f825c91902798481fac0898138/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c83782480a4a9da4d0feb51950131ba32e12e70813848b3343f6e18c28a66838", size = 4676239, upload-time = "2026-06-12T20:02:28.793Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/70/2ba3769dd0ae167e2f33dfa9592d45db6ff9a61d62ca1a5b3d1bdd09068f/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b39efa323140595abd3ecca8529d321ae50f55f3aa3ba9cc81ea56a6011953d5", size = 4715584, upload-time = "2026-06-12T20:01:27.495Z" },
-    { url = "https://files.pythonhosted.org/packages/94/64/2923570ac1c0bd3a737aa366ac3abbbbde273042308b8cde95e2364a6e6a/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:b47db11c2c3525083296069b98ac5221907455e989ae0c2e3008bde851921615", size = 4675885, upload-time = "2026-06-12T20:01:55.49Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/f8/614dc7e051418cfe53d55173c1e24c6b0085e89996fe90508c2fdf769aef/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:084ef1af862eb07ec46d25f68689f2102a9fc0e05ce7b80f14f5fe51e4eef0f6", size = 4715449, upload-time = "2026-06-12T20:02:05.469Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/50/a9caea39ad19c431c1a3f8a31114df65b260cdfe67786b6c7e7c040c4c44/cryptography-49.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be9fcb48a55f023493482827d4f459bd263cc20efde64f204b97c123201850c6", size = 3783731, upload-time = "2026-06-12T20:02:43.319Z" },
-]
-
-[[package]]
 name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -416,28 +253,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1a/81/6095237b86a3116c4789f28c4435d5296c00c0fc74ffde99008fd6b3a36c/diffusers-0.39.0.tar.gz", hash = "sha256:14bb1d98c85a0e463d734c99aaa73b480a7bc9bad22af30fbf730ef8f09c1d67", size = 4651240, upload-time = "2026-07-03T08:48:47.904Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/3f/7469c46e9d22307ea686bab687d70e6bf328722952f9d10339f5e913e608/diffusers-0.39.0-py3-none-any.whl", hash = "sha256:912aca51b5787365110806e984d5555735bf8a461073bb8459029d0bca7870ef", size = 5631176, upload-time = "2026-07-03T08:48:45.337Z" },
-]
-
-[[package]]
-name = "dnspython"
-version = "2.8.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
-]
-
-[[package]]
-name = "email-validator"
-version = "2.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "dnspython" },
-    { name = "idna" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
 ]
 
 [[package]]
@@ -557,18 +372,6 @@ wheels = [
 ]
 
 [[package]]
-name = "id"
-version = "1.6.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/04/c2156091427636080787aac190019dc64096e56a23b7364d3c1764ee3a06/id-1.6.1.tar.gz", hash = "sha256:d0732d624fb46fd4e7bc4e5152f00214450953b9e772c182c1c22964def1a069", size = 18088, upload-time = "2026-02-04T16:19:41.26Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/77/de194443bf38daed9452139e960c632b0ef9f9a5dd9ce605fdf18ca9f1b1/id-1.6.1-py3-none-any.whl", hash = "sha256:f5ec41ed2629a508f5d0988eda142e190c9c6da971100612c4de9ad9f9b237ca", size = 14689, upload-time = "2026-02-04T16:19:40.051Z" },
-]
-
-[[package]]
 name = "idna"
 version = "3.18"
 source = { registry = "https://pypi.org/simple" }
@@ -636,60 +439,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
-]
-
-[[package]]
-name = "kernels"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "huggingface-hub" },
-    { name = "kernels-data" },
-    { name = "packaging" },
-    { name = "pyyaml" },
-    { name = "sigstore" },
-    { name = "tomlkit" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/11/e2/2a6cc28c75c85725fa1b4025cc6544fe2a0aaa01624411664b29fc697537/kernels-0.16.0.tar.gz", hash = "sha256:5a4118396b9866209e767973d697d3f2ee76f6ed1b2f72269b72f8cd4dc90a7f", size = 70898, upload-time = "2026-06-26T07:27:42.769Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/f5/ec0e49e5a6f28a346f94a7c5a8a90bc192da4d456e9b06ca5ed57c4e028d/kernels-0.16.0-py3-none-any.whl", hash = "sha256:794af6a10fd888bb4f46ad1b9b2f4f61b5b0b104475a6415c5322b58a7bf02ed", size = 63577, upload-time = "2026-06-26T07:27:41.486Z" },
-]
-
-[[package]]
-name = "kernels-data"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/07/a0af3ee1e703c956dd54845dac30eda939c47c7aea70c053b3bf05eb9c4b/kernels_data-0.16.0.tar.gz", hash = "sha256:a4dae006305a572122ae8550a224b678d747ffaba431dff8a3f21817271e7148", size = 49742, upload-time = "2026-06-26T07:21:45.858Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/69/06e104234b3c0123acdfa1bfa00aab0ee51256a5be14cd8cd777c0b883b1/kernels_data-0.16.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:a9edbb9a1cc7c98e5fdd34b374c75a8e35d2f557dcf339609515e963c1f3e42d", size = 1182369, upload-time = "2026-06-26T07:21:33.099Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/2c/4e648755a2148702a11535e4f5cc05a6240c55cb149a496aa7d2b2bce62b/kernels_data-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:39c9886a44efd178b60b9c6fdf1d693b9280b6b80e52f608be5e66b598d56428", size = 1123948, upload-time = "2026-06-26T07:21:30.25Z" },
-    { url = "https://files.pythonhosted.org/packages/52/99/36bf142bb65df7f84895236ee9c2a1f94dd61f6482b4c9a887e96d3efca5/kernels_data-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76e8dd2586e076869571ba6e0ebe7261bb8c7f2d4c7dd60976a52c7a99e1b592", size = 1288781, upload-time = "2026-06-26T07:21:15.386Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/7f/e9d0404b6914c7e8d3b95dac28bf899a0ba504588cf8c4a26168a8730615/kernels_data-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:84fa77048a109b95aff569a690b5eed2c0ef3d76b13fed2a5e35481183ac5327", size = 1240676, upload-time = "2026-06-26T07:21:18.083Z" },
-    { url = "https://files.pythonhosted.org/packages/44/f6/f8782e6c5f9f968a46ed7295c81a044a6bbed50383fc9dbc123648e74655/kernels_data-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c3bc803777d99ee14481dbf67e018bd56f9d11d5b0ed0de6f4b0d219e803e4c4", size = 1507779, upload-time = "2026-06-26T07:21:20.74Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/f8/698db74246e66a6efc8929c998fca16694ce8d1907b2d4a8b556d3cfad5a/kernels_data-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e97507a0e5d6fba4b49c26eda48713d4fe6fcf561c9ef4b30271294b7881fd02", size = 1350803, upload-time = "2026-06-26T07:21:23.189Z" },
-    { url = "https://files.pythonhosted.org/packages/13/3f/3276f45160bc4c57cedae7bd8dd8be26f728fb837b0e5d2b1bb699d3ccbf/kernels_data-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:368c61ac93fb98fbb2fac2160ffdf58324ad569b284e07fe7cf63cc5d858e5ca", size = 1299057, upload-time = "2026-06-26T07:21:27.878Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/1c/15c1a041f95f133a7658b9539870df1d1f1dc5ed518cd033d5814cfe73cd/kernels_data-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8e10b625a1a189caa0b356a25ce78a329446eabaeb4e706fb77acbfb527ca12f", size = 1353097, upload-time = "2026-06-26T07:21:25.454Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/8a/b9b396e7c7913d1de3f8082e6345db74c00ab79a314042bc212f6d285c25/kernels_data-0.16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9998ded5cab1b01f6e47f57b19916f5cff0a072524ed68997e91b6f9187ec5c6", size = 1465896, upload-time = "2026-06-26T07:21:35.469Z" },
-    { url = "https://files.pythonhosted.org/packages/82/8e/85cf7d521986c390874919fc3b0a48134a8ef50684dedbc9a872e755e1c5/kernels_data-0.16.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:001468edc4713b51932ce422de0ed2199f73d405ec7d8adf83d79fef887be035", size = 1515951, upload-time = "2026-06-26T07:21:38.307Z" },
-    { url = "https://files.pythonhosted.org/packages/14/63/cbaec264c7d50d1b3a2f5a818e41a87f2ad875a5ba1be6623414123f9f73/kernels_data-0.16.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d806a02546c3f47e69f1947d35429867c461edcee3081d54d26239cc6abac0f5", size = 1525660, upload-time = "2026-06-26T07:21:40.863Z" },
-    { url = "https://files.pythonhosted.org/packages/29/a4/57a5d39bf301d5211a7d59fda9b907bc87708f41594848365c4506fc4a8b/kernels_data-0.16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5702459e5b2c510a1022a24c7513294d517094b4739e0ae1bfa9e3caa721df7b", size = 1544397, upload-time = "2026-06-26T07:21:43.434Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/48/ddf2e80dc13236a77fddaad3af3ff5bfbbc1eadf0fce625541492dfe4a84/kernels_data-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:4ad6eb43cbe1f35884ca03044812a3080b232130e6532c168a384712031d35ca", size = 942690, upload-time = "2026-06-26T07:21:50.425Z" },
-    { url = "https://files.pythonhosted.org/packages/88/3f/40fc81f11eda3fbd299a44c2161bb729155e096f63e38a64762227d56f23/kernels_data-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1335e05238d83e44c42ab5f1b790058a4a6b96e21e2e84c0ca1cabfa0230947b", size = 1031244, upload-time = "2026-06-26T07:21:48.059Z" },
-    { url = "https://files.pythonhosted.org/packages/37/01/ed9328c4cbd86c5065b478013f5a52c2afd457a68d7615ee84dfc69d89da/kernels_data-0.16.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d39cf7b780724133c3f8b8ed2c82a47d6064c2b821f8ec743dbcc01e3286663b", size = 1192966, upload-time = "2026-06-26T07:21:34.2Z" },
-    { url = "https://files.pythonhosted.org/packages/49/8b/7eb0c2eec2cc3cf3e76d69c929ec27419e4fb4b1560038daca29b6a26fde/kernels_data-0.16.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:d36401d623eebb260c744871d424c26463e0f617af7ec6e128e113a4590d34e3", size = 1132370, upload-time = "2026-06-26T07:21:31.377Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/cb/303fcb2b3ee6268c87c19ec78c571ec84518be8b999e27a509e7f5b5f77c/kernels_data-0.16.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8494e4d7716de272a2a16048b19d076e2708a9c3953225e50906cc7c4849dbe6", size = 1294322, upload-time = "2026-06-26T07:21:16.744Z" },
-    { url = "https://files.pythonhosted.org/packages/82/3c/6703938ea6ddc483a88c7f8f16341a86815eea2076b453eb05c1a5e62ed2/kernels_data-0.16.0-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2b1f61d49ab6a91fad75d4303ce351980e6ce614d22e3dea814cf756fb2a3394", size = 1247905, upload-time = "2026-06-26T07:21:19.376Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/24/24a3f821cfd2210de3c61cc11ddb872a1a4b496037b51d1d0e70445fdba8/kernels_data-0.16.0-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:73759c6e84bd712c0b06ff9b88d98905d3510c60de7e6b3286419025570587b6", size = 1512006, upload-time = "2026-06-26T07:21:21.959Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/48/b171ef8800b34f685205cf50bf9846c38b8bdbd1b9340f4e82766976caee/kernels_data-0.16.0-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:425e33a4f5171eb25b4395a50acf702c7abe4fc998dc801191abdabe88cab2d4", size = 1357734, upload-time = "2026-06-26T07:21:24.266Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/f8/03732c30403e2ee1f622fc4d6510185d4aa603d47a990b62fbcc42b00e06/kernels_data-0.16.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:30efa0e6ee0261c6c5b581fed372321a79db923a3e1934d00b7675565baaffc3", size = 1306343, upload-time = "2026-06-26T07:21:28.911Z" },
-    { url = "https://files.pythonhosted.org/packages/94/ae/05a390d39d6ec1697e412f6ab419bbd8909d790e492e1a112d669eacc4f2/kernels_data-0.16.0-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:34cc623f5495e8984881cc53635fb274485db8f00fb9f43a61966ec5bd2f4887", size = 1360097, upload-time = "2026-06-26T07:21:26.718Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/6e/3763708d096abd206ab0770da1702898e8bb0dee15b4d79a1190fa19382e/kernels_data-0.16.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:d01a87f9904abf64215ca4831ccc89944f447897e4e5ab7dd565fa951966ddb2", size = 1472289, upload-time = "2026-06-26T07:21:37.051Z" },
-    { url = "https://files.pythonhosted.org/packages/64/45/ae65191673a92f639631b33c8a89ecb1cd3314a8422996f601c07c6282e7/kernels_data-0.16.0-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:aec0daf3d5b24e66f25e7ede838810389ddd0100c261dc2842ec769ddab20a0f", size = 1522275, upload-time = "2026-06-26T07:21:39.548Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/0a/b6ecd4579e864631dba6f2b40c187338c85ce71c53398dbcdc55b628b82a/kernels_data-0.16.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:24091f6704b2123553bdfd7fbf538279391da9d9475f2315627a35da232880d0", size = 1533174, upload-time = "2026-06-26T07:21:42.158Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/53/6a39c3f8d7388608f7e2c346e1da0f702f1cdcfd1b4f0d889ed036ec686a/kernels_data-0.16.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:47f9f774fa541ffc93cbfa3677ffeef8a7f32b4fc2251e76b020d09f993efdbf", size = 1553117, upload-time = "2026-06-26T07:21:44.711Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/58/63c5879440780fea17703566d523638c4fcbc858b7a381a11880519841a9/kernels_data-0.16.0-cp38-abi3-win32.whl", hash = "sha256:7de71ce965e7c085fd1198ffaa664103433cefadd729c0705536e3fdd82c0ea7", size = 949428, upload-time = "2026-06-26T07:21:51.519Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/f2/e54f9a2c1e494f6dd48962910d145b075225f580cedec644fb0452c069d0/kernels_data-0.16.0-cp38-abi3-win_amd64.whl", hash = "sha256:bf9653ea0576cdd22c01e18168504be2d64b9d900dfeb165d020b99abbea38a6", size = 1037871, upload-time = "2026-06-26T07:21:49.256Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/bb/760d0529180c3a18429ebb6b4b6de54f2dacfe11cdf952d06436dd46c2f0/kernels_data-0.16.0-cp38-abi3-win_arm64.whl", hash = "sha256:09d5c122bdc9094e94b7d53c0ac732947fd24d218e42751638cfccce99ded8bb", size = 971321, upload-time = "2026-06-26T07:21:46.709Z" },
 ]
 
 [[package]]
@@ -1095,7 +844,7 @@ wheels = [
 
 [[package]]
 name = "orbitquant"
-version = "0.4.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "huggingface-hub" },
@@ -1125,7 +874,6 @@ hf = [
     { name = "transformers" },
 ]
 kernels = [
-    { name = "kernels" },
     { name = "triton", marker = "sys_platform == 'linux'" },
 ]
 
@@ -1136,7 +884,6 @@ requires-dist = [
     { name = "huggingface-hub", specifier = ">=0.33" },
     { name = "imageio", marker = "extra == 'eval'", specifier = ">=2.37" },
     { name = "imageio-ffmpeg", marker = "extra == 'eval'", specifier = ">=0.6" },
-    { name = "kernels", marker = "extra == 'kernels'", specifier = ">=0.16" },
     { name = "numpy", specifier = ">=2.0" },
     { name = "packaging", specifier = ">=24.0" },
     { name = "pillow", marker = "extra == 'eval'", specifier = ">=11.0" },
@@ -1247,15 +994,6 @@ wheels = [
 ]
 
 [[package]]
-name = "platformdirs"
-version = "4.10.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
-]
-
-[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1293,174 +1031,12 @@ wheels = [
 ]
 
 [[package]]
-name = "pyasn1"
-version = "0.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
-]
-
-[[package]]
-name = "pycparser"
-version = "3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
-]
-
-[[package]]
-name = "pydantic"
-version = "2.13.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "annotated-types" },
-    { name = "pydantic-core" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
-]
-
-[package.optional-dependencies]
-email = [
-    { name = "email-validator" },
-]
-
-[[package]]
-name = "pydantic-core"
-version = "2.46.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
-    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
-    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
-    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
-    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
-    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
-    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
-    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
-    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
-    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
-    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
-    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
-    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
-    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
-    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
-    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
-    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
-    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
-    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
-    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
-    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
-    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
-    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
-    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
-    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
-    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
-    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
-    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
-    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
-    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
-    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
-    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
-    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
-    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
-    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
-    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
-    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
-    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
-    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
-]
-
-[[package]]
-name = "pyjwt"
-version = "2.13.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
-]
-
-[[package]]
-name = "pyopenssl"
-version = "26.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/74/b7/da07bae88f5a9506b4def6f2f4903cf4c3b8831e560dba8fa18ca08f758f/pyopenssl-26.3.0.tar.gz", hash = "sha256:589de7fae1c9ea670d18422ed00fc04da787bbde8e1454aea872aa57b49ad341", size = 182024, upload-time = "2026-06-12T20:28:07.458Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/18/1dd71c9b43192ab83f1d531ad6002dc81108ac36c475f79fb7a295abe2f4/pyopenssl-26.3.0-py3-none-any.whl", hash = "sha256:46367f8f66b92271e6d218da9c87607e1ef5a0bc5c8dea5bb3db82f395c385a3", size = 56008, upload-time = "2026-06-12T20:28:05.999Z" },
 ]
 
 [[package]]
@@ -1667,38 +1243,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rfc3161-client"
-version = "1.0.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/35/0d/b9e726d45557d756d2e162bd3ca23f641119c4fd0717b9e4b7519080be10/rfc3161_client-1.0.7.tar.gz", hash = "sha256:8c02330b8b09cbf88f2f5f1ecdb6e6b76c0c9bd7c4199a5068ab43b95d7ab8e5", size = 107286, upload-time = "2026-07-07T19:10:46.322Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/dd/27f5a2b7a452bfa6ac65f70240707bd45259db67eab0460aef2a6baace02/rfc3161_client-1.0.7-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:351cb9149ea4f0db6206711d795f29ab23be2f28d4ac615d2ac6e47aed96d5fa", size = 2110106, upload-time = "2026-07-07T19:10:26.57Z" },
-    { url = "https://files.pythonhosted.org/packages/08/b8/6296398bfeaf900a3d5bfac638c654c7b88c97d3fad5aa52f45ad18847fe/rfc3161_client-1.0.7-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:966ab2b49b1dd157527818985512099c44fa8d3510eb4288e7bb986cd215b860", size = 2438380, upload-time = "2026-07-07T19:10:28.16Z" },
-    { url = "https://files.pythonhosted.org/packages/92/73/44e1acdcc2d9c8dbf1faa11151a0e93cfa309aae25a9acf44228818d391a/rfc3161_client-1.0.7-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83cd871823fa998e2d6a91e1a09881c798b016a87b71bad8e29b9135e4b6c036", size = 2652183, upload-time = "2026-07-07T19:10:29.766Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/ef/91229ff3c659f09bbed9f956e2dc16baec7077280e20834538a4fc96ee38/rfc3161_client-1.0.7-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3cf66df2e31674206699a5d4d31ca81f57e84c4892de3c676341ec2c3f764ae1", size = 2049522, upload-time = "2026-07-07T19:10:31.243Z" },
-    { url = "https://files.pythonhosted.org/packages/93/61/8228f3c5d603a8797d942a1a387b8fae4672a456ebf57777c369fd85a30d/rfc3161_client-1.0.7-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8db252741022bc27e1150c066b163130dc9fcded5822dc079217d5df3e5689a1", size = 2419948, upload-time = "2026-07-07T19:10:32.856Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/72/b403d38c83e7d667a72eb1495d11dbcfeeb3bda9703301a0d2adf5af0ee7/rfc3161_client-1.0.7-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ee940d6c65648732fa02606d6277356382347e34e89be54403ed4825cc9d391", size = 2419693, upload-time = "2026-07-07T19:10:34.397Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/20/5e0ef07211a5b3c2a87ece05e540a1b962294695eb9158e9042cd4a99c2e/rfc3161_client-1.0.7-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ec52ada36981e74f8926290f5cf9e8e81b4779b907dab17cf2e7d000d0e5a230", size = 2997400, upload-time = "2026-07-07T19:10:36.06Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/a6/25e7e030f75bf1a10573e7ab31468d852f82cd68c08eb087b92ae985c883/rfc3161_client-1.0.7-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c5b29bf5e4c01350654e80db8761466bbdf41efd2794c819493da63effa8a226", size = 2354890, upload-time = "2026-07-07T19:10:38.253Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/39/37d80f9bb14f6cc5e86b8b10b30b81938f68e85cd1f32f65a5e7d5e805e8/rfc3161_client-1.0.7-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:ad799a0500e4a7c56172e247fe29c6029903b5c43eb2c5ff5b35d5641e37a325", size = 2567223, upload-time = "2026-07-07T19:10:40.043Z" },
-    { url = "https://files.pythonhosted.org/packages/05/44/acc2aa9aa119c0db865275b90658dcc92d0cd6a8be2d96c2b0099bdc2888/rfc3161_client-1.0.7-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:563d2a87d21fa184782afd0cf57f06e3713580810c0dd62f7271ec2ae83b7219", size = 2641115, upload-time = "2026-07-07T19:10:41.632Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/13/a3f0cdd7eb2110b59dcd73e70a5a822f2aa1bffdb24f784653ae5eeb96f3/rfc3161_client-1.0.7-cp39-abi3-win32.whl", hash = "sha256:f5ba8607a6d44dd194e0e0ba68f9b6e8501d69a79b5b7b34a2228040050b59a4", size = 1994189, upload-time = "2026-07-07T19:10:43.222Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/1a/3bf139b58746d80f5e6eca2573e796ecb2b17e3726b091f0606ee5c06218/rfc3161_client-1.0.7-cp39-abi3-win_amd64.whl", hash = "sha256:5ea1340fa199c529af7b432c06689c865db8f395f4d6756b0a7663ffdbc04840", size = 2425247, upload-time = "2026-07-07T19:10:44.604Z" },
-]
-
-[[package]]
-name = "rfc8785"
-version = "0.1.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ef/2f/fa1d2e740c490191b572d33dbca5daa180cb423c24396b856f5886371d8b/rfc8785-0.1.4.tar.gz", hash = "sha256:e545841329fe0eee4f6a3b44e7034343100c12b4ec566dc06ca9735681deb4da", size = 14321, upload-time = "2024-09-27T16:33:31.206Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/78/119878110660b2ad709888c8a1614fce7e2fab39080ab960656dc8605bf6/rfc8785-0.1.4-py3-none-any.whl", hash = "sha256:520d690b448ecf0703691c76e1a34a24ddcd4fc5bc41d589cb7c58ec651bcd48", size = 9240, upload-time = "2024-09-27T16:33:29.683Z" },
-]
-
-[[package]]
 name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1761,15 +1305,6 @@ wheels = [
 ]
 
 [[package]]
-name = "securesystemslib"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b8/11/9623c61604f9b8955248d43fc6a75658bb687c0d3ab65b032b2e43613bd5/securesystemslib-1.4.0.tar.gz", hash = "sha256:faea87be0f9c4b4277a5fa1b54bf9bfd807be9a94ab11be6c557dc8b75c43285", size = 934332, upload-time = "2026-05-27T08:01:53.21Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/29/3ff76b9d90ce4482dc8e8d216dc3a6b6d0c934c52f68b0738e2c99ca685f/securesystemslib-1.4.0-py3-none-any.whl", hash = "sha256:a0743a3d978cf26e98a70a57e3fbd5a18e0a74c20cabe615f6a55b02ef0272b3", size = 871457, upload-time = "2026-05-27T08:01:51.093Z" },
-]
-
-[[package]]
 name = "setuptools"
 version = "81.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1785,56 +1320,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
-]
-
-[[package]]
-name = "sigstore"
-version = "4.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-    { name = "id" },
-    { name = "platformdirs" },
-    { name = "pyasn1" },
-    { name = "pydantic" },
-    { name = "pyjwt" },
-    { name = "pyopenssl" },
-    { name = "requests" },
-    { name = "rfc3161-client" },
-    { name = "rfc8785" },
-    { name = "rich" },
-    { name = "sigstore-models" },
-    { name = "sigstore-rekor-types" },
-    { name = "tuf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/04/a9/7f7625225c6e7041ab4460bfc5b30a6ebc40bcf6487ee28d5864149124c4/sigstore-4.4.0.tar.gz", hash = "sha256:20ffe791c1fa33ce62148c0291b46280d29c1910964d9afac419e9b1a8afc56b", size = 90986, upload-time = "2026-07-06T13:07:49.36Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/37/7922b125ede9cbee53569adb992f6f86aefab009105f3b0e77bc5225636d/sigstore-4.4.0-py3-none-any.whl", hash = "sha256:80c36d08b02479e2a282d0bea93de68fe0d43a93b0d58e4d9ac6bb9f8425957c", size = 111705, upload-time = "2026-07-06T13:07:47.946Z" },
-]
-
-[[package]]
-name = "sigstore-models"
-version = "0.0.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/ed/5c0ff809f90b19f4e971e17c1ed11f4df60082c6010b32a82054087e91e0/sigstore_models-0.0.6.tar.gz", hash = "sha256:c766c09470c2a7e8a4a333c893f07e2001c56a3ff1757b1a246119f53169a849", size = 7037, upload-time = "2025-11-26T19:18:12.61Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/dc/7a19864a7bc9f43121ab459e12768ab0080590e3e1b60a29b2f2eb01fb85/sigstore_models-0.0.6-py3-none-any.whl", hash = "sha256:5201a68f4d7d0f8bec1e2f4378eb646b084c52609a4e31db8c385095fff68b2e", size = 13213, upload-time = "2025-11-26T19:18:11.365Z" },
-]
-
-[[package]]
-name = "sigstore-rekor-types"
-version = "0.0.18"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic", extra = ["email"] },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b4/54/102e772445c5e849b826fbdcd44eb9ad7b3d10fda17b08964658ec7027dc/sigstore_rekor_types-0.0.18.tar.gz", hash = "sha256:19aef25433218ebf9975a1e8b523cc84aaf3cd395ad39a30523b083ea7917ec5", size = 15687, upload-time = "2024-11-22T13:59:54.009Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/7c/f0b4e19fd424df4cc964f5d454e1d814fd2dc3b386342e6040441024318f/sigstore_rekor_types-0.0.18-py3-none-any.whl", hash = "sha256:b62bf38c5b1a62bc0d7fe0ee51a0709e49311d137c7880c329882a8f4b2d1d78", size = 20610, upload-time = "2024-11-22T13:59:52.684Z" },
 ]
 
 [[package]]
@@ -1873,15 +1358,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
     { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
     { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
-]
-
-[[package]]
-name = "tomlkit"
-version = "0.15.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz", hash = "sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3", size = 161875, upload-time = "2026-05-10T07:38:22.245Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl", hash = "sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738", size = 41328, upload-time = "2026-05-10T07:38:23.517Z" },
 ]
 
 [[package]]
@@ -1979,19 +1455,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tuf"
-version = "7.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "securesystemslib" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/40/25ceaf7f02e18b0d99150d94e200929351a542479c54abb7b92e1fd74b10/tuf-7.0.0.tar.gz", hash = "sha256:9d2e6723538e0d5a3e482b6de805fcfe64481448d5853039ba6b06ba541efd7f", size = 272032, upload-time = "2026-05-18T08:28:57.408Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/c7/301f699ad9427bb0e06935ed56850dd26eecb2b3e8e07b80311875eae676/tuf-7.0.0-py3-none-any.whl", hash = "sha256:572bdbdc9ff4a82278a0d4773e6100863b9b33023f27575e84ca65b486dd0d79", size = 55277, upload-time = "2026-05-18T08:28:56.123Z" },
-]
-
-[[package]]
 name = "typer"
 version = "0.26.8"
 source = { registry = "https://pypi.org/simple" }
@@ -2013,18 +1476,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
-]
-
-[[package]]
-name = "typing-inspection"
-version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The native `orbitquant_packed_matmul` package is now provisioned automatically at runtime, replacing the dead Hugging Face `kernels.get_kernel` path (Kernel Hub publication is out of scope for this project, so that loader branch could never succeed for users).

Resolution order (`orbitquant.kernels.provision`):
1. an already importable `orbitquant_packed_matmul` (installed wheel);
2. `LOCAL_KERNELS=<repo-id>=<variant-dir>` (same contract the check scripts use, now parsed natively — the `kernels` dependency is removed from the `[kernels]` extra);
3. cached variants under `~/.cache/orbitquant/kernels` (`ORBITQUANT_KERNELS_CACHE`);
4. checksum-verified prebuilt variant wheels downloaded from the `kernels-v1` GitHub release of this repository (`ORBITQUANT_KERNELS_AUTOFETCH=0` disables, `ORBITQUANT_KERNELS_RELEASE_BASE` redirects);
5. opt-in JIT build via `torch.utils.cpp_extension.load` from kernel sources bundled into the orbitquant wheel (`ORBITQUANT_KERNELS_AUTOBUILD=1`; CPU needs torch>=2.11 stable-ABI headers, CUDA needs a matching nvcc, Metal stays prebuilt-only because its shader library is embedded at build time).

New CLI: `orbitquant kernels-install [--build] [--no-fetch]`, `orbitquant kernels-status`. The resolver runs at most once per process and never inside the forward path; every failure degrades to the existing Triton/dequant fallbacks with an actionable message.

## Asset pipeline

`build-kernels.yml` (workflow_dispatch, `publish=true` uploads to the `kernels-v1` release together with `manifest.json`):
- linux CUDA wheels: torch 2.9/2.12/2.13 x cu126/cu128/cu130 (official pairs), `cp39-abi3`, torch minor pinned in `Requires-Dist`;
- **windows CUDA wheels (experimental)**: torch 2.12+cu128, 2.13+cu130 via MSVC+NMake, same path the existing windows CPU job proved out;
- macOS metal wheels: torch 2.12/2.13, aarch64;
- CPU stable-ABI wheels (`cp39-abi3`, `torch>=2.11`): manylinux x86_64 + aarch64, macOS arm64, windows x64 — these are torch-version-independent and are also PyPI-eligible as `orbitquant-packed-matmul`.

`prepare_wheel_project.py` gains `--torch-requirement` so non-stable-ABI wheels pin the torch minor they were built against (the `undefined symbol` failure mode becomes a pip resolution error instead).

## Validated

- 552 passed / 80 skipped, ruff clean, paper-methodology and hf-compat (`--mode all`) gates green.
- Real CPU JIT build exercised end-to-end on macOS arm64 (torch 2.12): build ~5s, cache hit in a fresh process, capability probes true, packed matmul finite, native test suite green against the JIT-built package.
- Release fetch path covered by tests (manifest match, sha256 verify, unsafe-member rejection, offline behavior, negative-result memoization).

## Remaining before merge

- [x] `build-kernels.yml` matrix run on this branch: **14/15 variants build** — 6 linux CUDA wheels (nvcc on CPU runners), CPU stable-ABI on all 4 platforms, 2 Metal wheels (needs the Xcode 26 runner), **Windows CUDA cu128 confirmed working** (direct NVIDIA network installer; the Jimver action failed 3 different ways). Windows cu130 needs the full-toolkit install (crt headers repackaged in CUDA 13) — fix in the final run.
- [ ] publish wheels + manifest to `kernels-v1` release, then e2e fetch verification on a RunPod CUDA pod and macOS
- [ ] ComfyUI-OrbitQuant follow-up PR: requirements.txt + install.py hook calling `orbitquant kernels-install`