### PR TITLE
Protect DiT boundary blocks under 2-bit weight quantization

### DIFF
--- a/src/orbitquant/artifacts/loader.py
+++ b/src/orbitquant/artifacts/loader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import json
 from pathlib import Path
 
@@ -87,7 +88,13 @@ def load_orbitquant_artifact(
         module = _get_module(model, name)
         if not isinstance(module, torch.nn.Linear):
             raise TypeError(f"expected Linear at {name}, got {type(module).__name__}")
-        replacement = OrbitQuantLinear.empty_from_linear(module, config=config, module_name=name)
+        module_config = config
+        override_bits = manifest.module_bits.get(name)
+        if override_bits is not None and override_bits != config.weight_bits:
+            module_config = dataclasses.replace(config, weight_bits=override_bits)
+        replacement = OrbitQuantLinear.empty_from_linear(
+            module, config=module_config, module_name=name
+        )
         parent, child_name = _parent_and_child(model, name)
         _set_child(parent, child_name, replacement)
 

--- a/src/orbitquant/artifacts/manifest.py
+++ b/src/orbitquant/artifacts/manifest.py
@@ -29,6 +29,9 @@ class OrbitQuantManifest:
     adaln_modules: list[str] = field(default_factory=list)
     skipped_modules: list[str] = field(default_factory=list)
     module_shapes: dict[str, list[int]] = field(default_factory=dict)
+    # Per-module weight bit-width overrides (low-bit boundary protection);
+    # absent for uniform-precision artifacts, keeping the format unchanged.
+    module_bits: dict[str, int] = field(default_factory=dict)
     checksums: dict[str, str] = field(default_factory=dict)
 
     @classmethod
@@ -44,6 +47,7 @@ class OrbitQuantManifest:
         adaln_modules: list[str] | None = None,
         module_shapes: dict[str, list[int]] | None = None,
         checksums: dict[str, str] | None = None,
+        module_bits: dict[str, int] | None = None,
         quantization_device: str = "unknown",
         weight_quantization_backend: str = "unknown",
         quantization_staging_mode: str = "unknown",
@@ -72,6 +76,7 @@ class OrbitQuantManifest:
             adaln_modules=[] if adaln_modules is None else list(adaln_modules),
             skipped_modules=list(skipped_modules),
             module_shapes={} if module_shapes is None else dict(module_shapes),
+            module_bits={} if module_bits is None else dict(module_bits),
             checksums={} if checksums is None else dict(checksums),
         )
 
@@ -105,6 +110,7 @@ class OrbitQuantManifest:
             "adaln_modules": self.adaln_modules,
             "skipped_modules": self.skipped_modules,
             "module_shapes": self.module_shapes,
+            **({"module_bits": self.module_bits} if self.module_bits else {}),
             "checksums": self.checksums,
         }
 
@@ -134,5 +140,9 @@ class OrbitQuantManifest:
             adaln_modules=list(data.get("adaln_modules", [])),
             skipped_modules=list(data.get("skipped_modules", [])),
             module_shapes=dict(data.get("module_shapes", {})),
+            module_bits={
+                str(key): int(value)
+                for key, value in (data.get("module_bits") or {}).items()
+            },
             checksums=dict(data.get("checksums", {})),
         )

--- a/src/orbitquant/artifacts/validator.py
+++ b/src/orbitquant/artifacts/validator.py
@@ -127,7 +127,10 @@ def _validate_model_index(
 
 
 def _validate_codebook_tensors(
-    tensors: dict[str, torch.Tensor], *, config: OrbitQuantConfig
+    tensors: dict[str, torch.Tensor],
+    *,
+    config: OrbitQuantConfig,
+    extra_weight_bits: set[int] | None = None,
 ) -> set[int]:
     grouped: dict[tuple[int, int], dict[str, torch.Tensor]] = {}
     unexpected: list[str] = []
@@ -146,6 +149,8 @@ def _validate_codebook_tensors(
         raise RuntimeError("artifact codebook tensor mismatch: no codebooks found")
 
     allowed_bits = {config.weight_bits, config.activation_bits}
+    if extra_weight_bits:
+        allowed_bits |= set(extra_weight_bits)
     dims: set[int] = set()
     mismatches: list[str] = []
     for (dim, bits), fields in sorted(grouped.items()):
@@ -325,6 +330,7 @@ def validate_orbitquant_artifact(
         codebook_dims = _validate_codebook_tensors(
             load_file(artifact_path / "orbitquant_codebooks.safetensors"),
             config=config,
+            extra_weight_bits=set(manifest.module_bits.values()),
         )
         rotation_dims = _validate_rotation_tensors(
             load_file(artifact_path / "orbitquant_rotations.safetensors"),

--- a/src/orbitquant/artifacts/writer.py
+++ b/src/orbitquant/artifacts/writer.py
@@ -25,6 +25,17 @@ def _metadata_config(model: torch.nn.Module, config: OrbitQuantConfig) -> OrbitQ
     return OrbitQuantConfig.from_dict(values)
 
 
+def _module_bits(model: torch.nn.Module, config) -> dict[str, int]:
+    """Per-module weight bit-widths that differ from the config default."""
+    from orbitquant.layers import OrbitQuantLinear
+
+    overrides: dict[str, int] = {}
+    for name, module in model.named_modules():
+        if isinstance(module, OrbitQuantLinear) and module.weight_bits != config.weight_bits:
+            overrides[name] = int(module.weight_bits)
+    return overrides
+
+
 def _module_shapes(model: torch.nn.Module) -> dict[str, list[int]]:
     shapes: dict[str, list[int]] = {}
     for name, tensor in model.state_dict().items():
@@ -210,6 +221,7 @@ def save_orbitquant_artifact(
         adaln_modules=_summary_list(summary, "adaln_modules"),
         skipped_modules=skipped,
         module_shapes=_module_shapes(model),
+        module_bits=_module_bits(model, config),
         checksums=checksums,
         quantization_device=getattr(summary, "quantization_device", "unknown"),
         weight_quantization_backend=getattr(

--- a/src/orbitquant/config.py
+++ b/src/orbitquant/config.py
@@ -96,6 +96,17 @@ class OrbitQuantConfig(QuantizationConfigMixin):
     # Opt-in: keep a persistent INT8 copy of each W4A4 weight on CUDA (twice
     # the packed size) so the cuBLASLt path skips its per-forward decode.
     w4a4_int8_weight_cache: bool = False
+    # Low-bit boundary protection: at 2-bit weights the per-layer quantization
+    # error sits at the scalar Lloyd-Max floor (~34% relative) and deep DiT
+    # stacks fail cumulatively, with the first/last blocks acting as error
+    # amplifiers (measured on Ideogram-v4: protecting 4 boundary blocks turns
+    # noise back into coherent images). "auto" protects
+    # lowbit_protected_blocks boundary blocks plus all out-of-block modules
+    # when weight_bits <= 2 and does nothing for higher widths; an int forces
+    # that block count; 0 disables protection.
+    lowbit_boundary_protection: int | str = "auto"
+    lowbit_protected_blocks: int = 4
+    lowbit_protected_bits: int = 4
 
     def __post_init__(self) -> None:
         if self.weight_bits not in _SUPPORTED_BITS:
@@ -143,6 +154,17 @@ class OrbitQuantConfig(QuantizationConfigMixin):
             raise ValueError("adaln_group_size must be positive")
         if not isinstance(self.w4a4_int8_weight_cache, bool):
             raise ValueError("w4a4_int8_weight_cache must be a boolean")
+        if self.lowbit_boundary_protection != "auto":
+            if not isinstance(self.lowbit_boundary_protection, int) or isinstance(
+                self.lowbit_boundary_protection, bool
+            ):
+                raise ValueError("lowbit_boundary_protection must be 'auto' or an int >= 0")
+            if self.lowbit_boundary_protection < 0:
+                raise ValueError("lowbit_boundary_protection must be 'auto' or an int >= 0")
+        if self.lowbit_protected_blocks < 0:
+            raise ValueError("lowbit_protected_blocks must be >= 0")
+        if not 2 <= self.lowbit_protected_bits <= 8:
+            raise ValueError("lowbit_protected_bits must be in [2, 8]")
         normalized_dtype_dict: dict[str, list[str]] = {}
         for dtype_name, module_names in self.modules_dtype_dict.items():
             normalized_dtype = dtype_name.lower()

--- a/src/orbitquant/modeling.py
+++ b/src/orbitquant/modeling.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import time
 from dataclasses import dataclass, field
 from typing import Any
@@ -16,6 +17,7 @@ from orbitquant.linear_adapters import (
     linear_module_spec,
 )
 from orbitquant.policies import PolicyDecision, classify_linear_modules, resolve_target_policy
+from orbitquant.policies.lowbit_protection import apply_lowbit_boundary_protection
 
 _TORCH_DTYPE_BY_NAME = {
     "bfloat16": torch.bfloat16,
@@ -255,6 +257,7 @@ def quantize_linear_modules(
         raise ValueError("staging_mode must be 'streaming' or 'component'")
 
     decisions = classify_linear_modules(model, config)
+    apply_lowbit_boundary_protection(decisions, config)
     target_device = _quantization_device(quantization_device)
     summary = QuantizationSummary(
         quantization_device="preserve" if target_device is None else str(target_device),
@@ -284,7 +287,12 @@ def quantize_linear_modules(
                     module, target_device, summary, synchronize=synchronize_per_module
                 )
             module_started_at = time.perf_counter()
-            replacement = OrbitQuantLinear.from_linear(module, config=config, module_name=name)
+            module_config = config
+            if decision.weight_bits is not None and decision.weight_bits != config.weight_bits:
+                module_config = dataclasses.replace(config, weight_bits=decision.weight_bits)
+            replacement = OrbitQuantLinear.from_linear(
+                module, config=module_config, module_name=name
+            )
             if synchronize_per_module:
                 _synchronize_if_needed(_first_tensor_device(replacement))
             summary.orbitquant_seconds += time.perf_counter() - module_started_at

--- a/src/orbitquant/policies/generic_dit.py
+++ b/src/orbitquant/policies/generic_dit.py
@@ -15,6 +15,9 @@ class PolicyDecision:
     action: str
     reason: str
     dtype: str | None = None
+    # Per-module weight bit-width override (low-bit boundary protection);
+    # None means the config-wide weight_bits applies.
+    weight_bits: int | None = None
 
 
 _HARD_SKIP_TOKENS = (

--- a/src/orbitquant/policies/lowbit_protection.py
+++ b/src/orbitquant/policies/lowbit_protection.py
@@ -1,0 +1,89 @@
+"""Boundary-block protection for very low weight bit widths.
+
+At 2-bit weights every layer quantizes at the scalar Lloyd-Max floor (~34%
+relative error), and deep DiT stacks fail cumulatively rather than through a
+single culprit. Measured on Ideogram-v4-Instant (34 blocks, 8-step distilled):
+quantizing all block projections to W2 collapses the output to noise, while
+keeping the first and last 4 blocks intact restores a coherent image even
+with more layers quantized overall — the boundary blocks act as error
+amplifiers. This module upgrades the weight bit width of boundary-block and
+out-of-block projections after policy classification, architecture-agnostic:
+block indices are recovered from the module paths themselves.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import replace
+
+from orbitquant.config import OrbitQuantConfig
+from orbitquant.policies.generic_dit import PolicyDecision
+
+_BLOCK_INDEX_RE = re.compile(r"(?:^|\.)(?P<container>[a-zA-Z_][a-zA-Z0-9_]*)\.(?P<index>\d+)\.")
+
+
+def _block_key(name: str) -> tuple[str, int] | None:
+    """Return the outermost (container, index) pair of an indexed module path."""
+    match = _BLOCK_INDEX_RE.search(name)
+    if match is None:
+        return None
+    return match.group("container"), int(match.group("index"))
+
+
+def resolve_protected_block_count(config: OrbitQuantConfig) -> int:
+    if config.lowbit_boundary_protection == "auto":
+        return config.lowbit_protected_blocks if config.weight_bits <= 2 else 0
+    return int(config.lowbit_boundary_protection)
+
+
+def apply_lowbit_boundary_protection(
+    decisions: dict[str, PolicyDecision], config: OrbitQuantConfig
+) -> dict[str, PolicyDecision]:
+    """Upgrade boundary and out-of-block orbitquant decisions to protected bits.
+
+    Only decisions with ``action == "orbitquant"`` are touched, and only when
+    the resolved protected block count is positive and the protected bit width
+    exceeds ``config.weight_bits``. Returns the same dict for chaining.
+    """
+
+    protected_blocks = resolve_protected_block_count(config)
+    protected_bits = max(config.lowbit_protected_bits, config.weight_bits)
+    if protected_blocks <= 0 or protected_bits == config.weight_bits:
+        return decisions
+
+    per_container: dict[str, set[int]] = {}
+    keys: dict[str, tuple[str, int] | None] = {}
+    for name, decision in decisions.items():
+        if decision.action != "orbitquant":
+            continue
+        key = _block_key(name)
+        keys[name] = key
+        if key is not None:
+            per_container.setdefault(key[0], set()).add(key[1])
+
+    for name, decision in decisions.items():
+        if decision.action != "orbitquant":
+            continue
+        key = keys.get(name)
+        if key is None:
+            protected = True
+            reason = "out-of-block projection"
+        else:
+            container, index = key
+            indices = per_container[container]
+            first = min(indices)
+            last = max(indices)
+            protected = (
+                index < first + protected_blocks or index > last - protected_blocks
+            )
+            reason = f"boundary block {container}.{index}"
+        if protected:
+            decisions[name] = replace(
+                decision,
+                weight_bits=protected_bits,
+                reason=(
+                    f"{decision.reason}; low-bit boundary protection "
+                    f"({reason} upgraded to W{protected_bits})"
+                ),
+            )
+    return decisions

--- a/tests/test_lowbit_protection.py
+++ b/tests/test_lowbit_protection.py
@@ -1,0 +1,117 @@
+import torch
+
+from orbitquant.artifacts.manifest import OrbitQuantManifest
+from orbitquant.config import OrbitQuantConfig
+from orbitquant.layers import OrbitQuantLinear
+from orbitquant.modeling import quantize_model
+from orbitquant.policies.generic_dit import PolicyDecision
+from orbitquant.policies.lowbit_protection import (
+    apply_lowbit_boundary_protection,
+    resolve_protected_block_count,
+)
+
+
+def _decisions(names):
+    return {name: PolicyDecision(name, "orbitquant", "test") for name in names}
+
+
+def _block_names(count=10):
+    names = []
+    for index in range(count):
+        names.append(f"layers.{index}.attention.to_q")
+        names.append(f"layers.{index}.feed_forward.up")
+    names.append("input_proj")
+    names.append("llm_cond_proj")
+    return names
+
+
+def test_protection_upgrades_boundary_and_out_of_block_modules():
+    config = OrbitQuantConfig(weight_bits=2, activation_bits=4, lowbit_protected_blocks=2)
+    decisions = apply_lowbit_boundary_protection(_decisions(_block_names()), config)
+
+    assert decisions["layers.0.attention.to_q"].weight_bits == 4
+    assert decisions["layers.1.feed_forward.up"].weight_bits == 4
+    assert decisions["layers.8.attention.to_q"].weight_bits == 4
+    assert decisions["layers.9.feed_forward.up"].weight_bits == 4
+    assert decisions["layers.5.attention.to_q"].weight_bits is None
+    assert decisions["input_proj"].weight_bits == 4
+    assert decisions["llm_cond_proj"].weight_bits == 4
+
+
+def test_protection_is_inert_for_three_bit_and_above():
+    config = OrbitQuantConfig(weight_bits=3, activation_bits=3)
+    decisions = apply_lowbit_boundary_protection(_decisions(_block_names()), config)
+    assert all(d.weight_bits is None for d in decisions.values())
+    assert resolve_protected_block_count(config) == 0
+
+
+def test_protection_disabled_explicitly():
+    config = OrbitQuantConfig(weight_bits=2, activation_bits=4, lowbit_boundary_protection=0)
+    decisions = apply_lowbit_boundary_protection(_decisions(_block_names()), config)
+    assert all(d.weight_bits is None for d in decisions.values())
+
+
+def test_manifest_round_trips_module_bits():
+    manifest = OrbitQuantManifest.from_config(
+        OrbitQuantConfig(weight_bits=2, activation_bits=4),
+        source_model_id="example/model",
+        source_revision="rev",
+        source_license="apache-2.0",
+        quantized_modules=["layers.0.attn"],
+        skipped_modules=[],
+        module_bits={"layers.0.attn": 4},
+    )
+    payload = manifest.to_dict()
+    assert payload["module_bits"] == {"layers.0.attn": 4}
+    restored = OrbitQuantManifest.from_dict(payload)
+    assert restored.module_bits == {"layers.0.attn": 4}
+
+    uniform = OrbitQuantManifest.from_config(
+        OrbitQuantConfig(),
+        source_model_id="example/model",
+        source_revision="rev",
+        source_license="apache-2.0",
+        quantized_modules=[],
+        skipped_modules=[],
+    )
+    assert "module_bits" not in uniform.to_dict()
+    assert OrbitQuantManifest.from_dict(uniform.to_dict()).module_bits == {}
+
+
+class _TinyDiT(torch.nn.Module):
+    def __init__(self, blocks=6):
+        super().__init__()
+        self.layers = torch.nn.ModuleList(
+            [
+                torch.nn.ModuleDict(
+                    {
+                        "attention": torch.nn.ModuleDict(
+                            {"to_q": torch.nn.Linear(16, 16)}
+                        )
+                    }
+                )
+                for _ in range(blocks)
+            ]
+        )
+
+
+def test_quantize_model_applies_mixed_bits_end_to_end():
+    torch.manual_seed(0)
+    model = _TinyDiT()
+    config = OrbitQuantConfig(
+        weight_bits=2,
+        activation_bits=4,
+        block_size=8,
+        target_policy="universal",
+        lowbit_protected_blocks=1,
+        runtime_mode="dequant_bf16",
+    )
+    quantize_model(model, config, quantization_device=None)
+
+    first = model.layers[0]["attention"]["to_q"]
+    middle = model.layers[3]["attention"]["to_q"]
+    last = model.layers[5]["attention"]["to_q"]
+    assert isinstance(first, OrbitQuantLinear)
+    assert first.weight_bits == 4
+    assert middle.weight_bits == 2
+    assert last.weight_bits == 4

--- a/uv.lock
+++ b/uv.lock
@@ -844,7 +844,7 @@ wheels = [
 
 [[package]]
 name = "orbitquant"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "huggingface-hub" },


### PR DESCRIPTION
## Summary

Root-causes and fixes the W2A4/W2A3 noise collapse observed on Ideogram-v4-Instant, generalized for any transformer.

**What the experiments showed** (real fal weights + full pipeline on 2x RTX 3090):
- Rotation scheme is innocent: paper block-512, a Kronecker R9(x)H512 full mix, a two-stage FWHT, and a dense QR rotation all quantize real 4608-wide weights to the same W2 relative error (0.342 +/- 0.002) — which is the scalar Lloyd-Max floor for 4 levels, so the per-layer quantizer has no headroom either. Real captured activations gaussianize equally well (excess kurtosis +0.09).
- The collapse is cumulative with boundary amplification: attention-only (136 layers), MLP-only (102), and periphery-only (41) W2A4 each stay coherent; all block projections together (238) collapse to noise. Keeping the first and last 4 blocks intact restores coherence at 182 quantized layers, while 177 unprotected layers are already noise; 2 protected blocks are not enough.

## Fix

`quantize` upgrades boundary-block and out-of-block projections to `lowbit_protected_bits` (default W4) when `weight_bits <= 2`:
- `lowbit_boundary_protection`: `"auto"` (default; active only at W2 and below) | explicit int | `0` to disable; `lowbit_protected_blocks` (default 4).
- Architecture-agnostic: block indices are parsed from module paths (`layers.N.`, `blocks.N.`, ...), the outermost indexed container per module.
- Manifest gains an optional `module_bits` map; the loader honors it; the codebook validator accepts the protected widths (the codebook tensor format was already per-`(dim, bits)`).

## Non-regression

- W3 and above: resolver returns 0 protected blocks — behavior byte-identical.
- Existing artifacts: no `module_bits` field → uniform loading, unchanged.
- Runtime: untouched; protected layers are ordinary OrbitQuantLinear modules at their own width, dispatching through the existing per-layer paths.
- Gates: ruff, full pytest, paper-methodology — green.

## Cost

For Ideogram-v4 W2: 8 of 34 blocks + periphery at W4 raises the checkpoint from ~2.5 GB to ~3.0 GB (still well under W3's 3.6 GB) and turns noise into images.